### PR TITLE
Fix JSON RPC missing body

### DIFF
--- a/make.paws/DESCRIPTION
+++ b/make.paws/DESCRIPTION
@@ -66,4 +66,5 @@ Collate:
     'request.R'
     'signer_v4.R'
     'time.R'
+    'util.R'
     'xmlutil.R'

--- a/make.paws/R/handlers_jsonrpc.R
+++ b/make.paws/R/handlers_jsonrpc.R
@@ -8,19 +8,15 @@ jsonrpc_build <- function(request) {
     body <- EMPTY_JSON
   }
 
-  if (!is.null(request$client_info$target_prefix) && (
-      request$client_info$target_prefix != "" ||
-      (!is.null(body) && body != "{}"))) {
+  if (not_empty(request$client_info$target_prefix) || (!is.null(body) && body != "{}")) {
      request <- set_body(request, body)
   }
-  if (!is.null(request$client_info$target_prefix) &&
-      request$client_info$target_prefix != "")  {
+  if (not_empty(request$client_info$target_prefix))  {
     target <- paste0(request$client_info$target_prefix, ".", request$operation$name)
     request$http_request$header["X-Amz-Target"] <- target
   }
 
-  if (!is.null(request$client_info$json_version) &&
-      request$client_info$json_version != "") {
+  if (not_empty(request$client_info$json_version)) {
     json_version <- request$client_info$json_version
     request$http_request$header["Content-Type"] <- paste0("application/x-amz-json-", json_version)
   }

--- a/make.paws/R/make_service.R
+++ b/make.paws/R/make_service.R
@@ -41,8 +41,8 @@ make_service_init <- function(api) {
       .SERVICE_ID = service_id(api),
       .API_VERSION = api$metadata$apiVersion,
       .SIGNING_NAME = signing_name(api),
-      .JSON_VERSION = api$metadata$jsonVersion,
-      .TARGET_PREFIX = api$metadata$targetPrefix,
+      .JSON_VERSION = json_version(api),
+      .TARGET_PREFIX = target_prefix(api),
       .HANDLERS = make_handlers(api)
     ),
     params = c()
@@ -96,4 +96,18 @@ signing_name <- function(api) {
   name <- api$metadata$signingName
   if (!is.null(name)) return(name)
   return(quote(cfg$signing_name))
+}
+
+# Returns the JSON version for the API, or "" if none.
+json_version <- function(api) {
+  version <- api$metadata$jsonVersion
+  if (is.null(version)) return("")
+  return(version)
+}
+
+# Returns the target prefix for the API, or "" if none.
+target_prefix <- function(api) {
+  prefix <- api$metadata$targetPrefix
+  if (is.null(prefix)) return("")
+  return(prefix)
 }

--- a/make.paws/R/util.R
+++ b/make.paws/R/util.R
@@ -1,0 +1,9 @@
+# Return whether x is non-empty, i.e. not null and has a non-default value.
+not_empty <- function(x) {
+  if (is.null(x)) return(FALSE)
+  UseMethod("not_empty")
+}
+
+not_empty.character <- function(x) {
+  return(x != "")
+}

--- a/make.paws/R/util.R
+++ b/make.paws/R/util.R
@@ -1,6 +1,6 @@
 # Return whether x is non-empty, i.e. not null and has a non-default value.
 not_empty <- function(x) {
-  if (is.null(x)) return(FALSE)
+  if (is.null(x) || is.na(x)) return(FALSE)
   UseMethod("not_empty")
 }
 

--- a/make.paws/tests/testthat/test_handlers_jsonrpc.R
+++ b/make.paws/tests/testthat/test_handlers_jsonrpc.R
@@ -334,6 +334,37 @@ test_that("build enums", {
 
 #-------------------------------------------------------------------------------
 
+# Build with no target prefix
+
+op <- Operation(name = "OperationName")
+svc <- Client(
+  client_info = ClientInfo(
+    json_version = "1.1",
+    target_prefix = NULL
+  )
+)
+svc$handlers$build <- HandlerList(jsonrpc_build)
+
+op_input1 <- function(Name) {
+  args <- list(Name = Name)
+  interface <- Structure(
+    Name = Scalar()
+  )
+  return(populate(args, interface))
+}
+
+test_that("build scalar members", {
+  input <- op_input1(
+    Name = "myname"
+  )
+  req <- new_request(svc, op, input, NULL)
+  req <- build(req)
+  r <- req$http_request
+  expect_equal(r$body, '{"Name":"myname"}')
+})
+
+#-------------------------------------------------------------------------------
+
 # Unmarshal tests
 
 op <- Operation(name = "OperationName")

--- a/make.paws/tests/testthat/test_util.R
+++ b/make.paws/tests/testthat/test_util.R
@@ -1,0 +1,6 @@
+test_that("not_empty", {
+  expect_equal(not_empty(NULL), FALSE)
+  expect_equal(not_empty(""), FALSE)
+  expect_equal(not_empty(NA_character_), FALSE)
+  expect_equal(not_empty("foo"), TRUE)
+})


### PR DESCRIPTION
This bug is triggered by a `NULL` in the target prefix. The target prefix is set in each API's `service` function. If the API metadata has no target prefix, it gets a `NULL` rather than the expected empty string `""`. The request body is set by conditions on both target prefix and the body itself.

This bug is dealt with by fixing both possible sources of error:
* Fix if condition that leads to the request body not being set when target prefix is `NULL` by adding a new `not_empty` function.
* Fix the `make_service` function which generates each API's `service` function so that the target prefix is `""` rather than `NULL` when there is no target prefix.