### PR TITLE
Add docs directory, add more examples

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -9,7 +9,7 @@ output:
 knitr::opts_chunk$set(echo = TRUE)
 ```
 
-# Paws
+# Paws, an AWS SDK for R
 
 [![Build Status](https://travis-ci.com/paws-r/paws.svg?branch=master)](https://travis-ci.com/paws-r/paws)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/2ma1spb2f55129qc/branch/master?svg=true)](https://ci.appveyor.com/project/paws-r/paws/branch/master)
@@ -22,8 +22,7 @@ access to the full suite of AWS services from within R.
 Each AWS service has its own R package within Paws. For example, to use EC2, use
 the `paws.ec2` package.
 
-Disclaimer: We are not affiliated with Amazon Web Services, and Paws is not a 
-product of or supported by Amazon Web Services.
+**Disclaimer**: Paws is not a product of or supported by Amazon Web Services.
 
 Paws is based on the design and implementation of the 
 [AWS SDK for Go](https://github.com/aws/aws-sdk-go) and it uses AWS's API 
@@ -35,7 +34,8 @@ definition files and API documentation from the
 
 ### Installation
 
-Paws is currently only available from GitHub. Install a package using:
+Paws is currently available on GitHub. See [the list of available packages
+here](service). Install a package (e.g. `paws.ec2`) using:
 
 ```{r, eval = FALSE}
 devtools::install_github("paws-r/paws/service/paws.ec2")
@@ -43,8 +43,9 @@ devtools::install_github("paws-r/paws/service/paws.ec2")
 
 ### Credentials
 
-First, set up your credentials and region. See the section below for more on the
-different ways you can do this. Here we set them within R.
+First, set up your credentials and region. See 
+[credentials.md](docs/credentials.md) for the different ways you can do this.
+Here we set them within R.
 
 ```{r, eval = FALSE}
 Sys.setenv(
@@ -97,145 +98,3 @@ the package documentation.
 ```{r, eval = FALSE}
 help(package = "paws.ec2")
 ```
-
-
-## Setting Up Credentials and Region
-
-### Credentials
-
-In order to use a Paws package, you must provide it with your credentials.
-
-Credentials can be set in the following four ways, and Paws will look for them
-in this order.
-
-1. R environment variables.
-2. System environment variables (Mac and Linux Only).
-3. AWS credentials file.
-4. IAM role.
-
-If you are running the package on an instance with an appropriate IAM role,
-Paws will use it automatically and you don't need to do anything extra.
-
-
-#### Setting Credentials with R Environment Variables
-Use R to set the credentials with the following command:
-```{r, eval = FALSE}
-Sys.setenv(AWS_ACCESS_KEY_ID = "accessKeyID")
-Sys.setenv(AWS_SECRET_ACCESS_KEY = "secretAccessKey")
-```
-
-#### Setting Credentials with System Environment Variables
-On Mac or Linux you can use the command line to set the credentials with the
-following command:
-```{bash, eval = FALSE}
-export AWS_ACCESS_KEY_ID="accessKeyID"
-export AWS_SECRET_ACCESS_KEY="secretAccessKey"
-```
-
-Paws currently does not support setting the credentials using a system
-variable on Windows.
-
-#### Setting Credentials with AWS Credentials File
-You can set the credentials using a credentials file in `~/.aws/credentials`.
-You can generate a credentials file using the AWS CLI's `aws configure` command.
-
-The credentials file should be in INI format and should look like:
-```
-[default]
-aws_access_key_id=awsAccessKeyID
-aws_secret_access_key=awsSecretAccessKey
-```
-
-By default, Paws will use the `default` profile. If you would
-rather use the credentials from a different profile, you can set the preferred
-profile by following the instructions in the "Profile" section of this
-document.
-
-Profiles are added to the credentials file by appending them to the file below
-the default:
-```
-[default]
-aws_access_key_id=awsAccessKeyID
-aws_secret_access_key=awsSecretAccessKey
-
-[other_profile]
-aws_access_key_id=awsOtherAccessKeyID
-aws_secret_access_key=awsOtherSecretAccessKey
-```
-
-### Region
-In order to use a Paws package, you must also set your AWS region.
-
-Paws will look for the region in the following three places, in order:
-
-1. `AWS_REGION` R environment variable.
-2. `AWS_REGION` system environment variable (Mac and Linux Only).
-3. AWS config file.
-
-#### Setting Region with R Environment Variable
-Use R to set the region with the following command:
-
-```{r, eval = FALSE}
-Sys.setenv(AWS_REGION = "us-east-1")
-```
-
-#### Setting Region with System Environment Variable
-On Mac or Linux you can use the command line to set the region with the
-following command:
-
-```{bash, eval = FALSE}
-export AWS_REGION="us-east-1"
-```
-
-Paws currently does not support setting the region using a system
-variable on Windows.
-
-#### Setting Region with Config file
-You can set the region using a config file in `~/.aws/config`. You can generate
-a config file using the AWS CLI's `aws configure` command.
-
-The config file should be in INI format and should look like:
-
-```
-[default]
-region=us-east-1
-```
-
-By default, Paws will use the `default` profile. If you would rather use a 
-different profile, you can set the preferred profile by following the 
-instructions in the "Profile" section of this document.
-
-Profiles are added to the config file by appending them to the file below the
-default:
-```
-[default]
-region=region-1
-
-[other_profile]
-region=region-2
-```
-
-### AWS Profile
-If you do not set your AWS profile, the package will use the `default` profile.
-
-However, you may want to use another profile, which you can choose in the 
-following ways:
-
-1. `AWS_PROFILE` R environment variable.
-2. `AWS_PROFILE` system environment variable - (Mac and Linux Only)
-
-#### Setting Profile with R Environment Variable
-Use R to set the profile with the following command:
-```{r, eval = FALSE}
-Sys.setenv(AWS_PROFILE = "nameOfProfile")
-```
-
-#### Setting Region with System Environment Variable
-On Mac or Linux you can use the command line to set the profile with the
-following command:
-```{bash, eval = FALSE}
-export AWS_PROFILE="nameOfProfile"
-```
-
-Paws currently does not support setting the profile using a system
-variable on Windows.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Paws
+# Paws, an AWS SDK for R
 
 [![Build
 Status](https://travis-ci.com/paws-r/paws.svg?branch=master)](https://travis-ci.com/paws-r/paws)
@@ -13,8 +13,8 @@ access to the full suite of AWS services from within R.
 Each AWS service has its own R package within Paws. For example, to use
 EC2, use the `paws.ec2` package.
 
-Disclaimer: We are not affiliated with Amazon Web Services, and Paws is
-not a product of or supported by Amazon Web Services.
+**Disclaimer**: Paws is not a product of or supported by Amazon Web
+Services.
 
 Paws is based on the design and implementation of the [AWS SDK for
 Go](https://github.com/aws/aws-sdk-go) and it uses AWS’s API definition
@@ -25,7 +25,8 @@ JavaScript](https://github.com/aws/aws-sdk-js).
 
 ### Installation
 
-Paws is currently only available from GitHub. Install a package using:
+Paws is currently available on GitHub. See [the list of available
+packages here](service). Install a package (e.g. `paws.ec2`) using:
 
 ``` r
 devtools::install_github("paws-r/paws/service/paws.ec2")
@@ -33,8 +34,9 @@ devtools::install_github("paws-r/paws/service/paws.ec2")
 
 ### Credentials
 
-First, set up your credentials and region. See the section below for
-more on the different ways you can do this. Here we set them within R.
+First, set up your credentials and region. See
+[credentials.md](docs/credentials.md) for the different ways you can do
+this. Here we set them within R.
 
 ``` r
 Sys.setenv(
@@ -88,156 +90,3 @@ through the package documentation.
 ``` r
 help(package = "paws.ec2")
 ```
-
-## Setting Up Credentials and Region
-
-### Credentials
-
-In order to use a Paws package, you must provide it with your
-credentials.
-
-Credentials can be set in the following four ways, and Paws will look
-for them in this order.
-
-1.  R environment variables.
-2.  System environment variables (Mac and Linux Only).
-3.  AWS credentials file.
-4.  IAM role.
-
-If you are running the package on an instance with an appropriate IAM
-role, Paws will use it automatically and you don’t need to do anything
-extra.
-
-#### Setting Credentials with R Environment Variables
-
-Use R to set the credentials with the following command:
-
-``` r
-Sys.setenv(AWS_ACCESS_KEY_ID = "accessKeyID")
-Sys.setenv(AWS_SECRET_ACCESS_KEY = "secretAccessKey")
-```
-
-#### Setting Credentials with System Environment Variables
-
-On Mac or Linux you can use the command line to set the credentials with
-the following command:
-
-``` bash
-export AWS_ACCESS_KEY_ID="accessKeyID"
-export AWS_SECRET_ACCESS_KEY="secretAccessKey"
-```
-
-Paws currently does not support setting the credentials using a system
-variable on Windows.
-
-#### Setting Credentials with AWS Credentials File
-
-You can set the credentials using a credentials file in
-`~/.aws/credentials`. You can generate a credentials file using the AWS
-CLI’s `aws configure` command.
-
-The credentials file should be in INI format and should look like:
-
-    [default]
-    aws_access_key_id=awsAccessKeyID
-    aws_secret_access_key=awsSecretAccessKey
-
-By default, Paws will use the `default` profile. If you would rather use
-the credentials from a different profile, you can set the preferred
-profile by following the instructions in the “Profile” section of this
-document.
-
-Profiles are added to the credentials file by appending them to the file
-below the default:
-
-    [default]
-    aws_access_key_id=awsAccessKeyID
-    aws_secret_access_key=awsSecretAccessKey
-    
-    [other_profile]
-    aws_access_key_id=awsOtherAccessKeyID
-    aws_secret_access_key=awsOtherSecretAccessKey
-
-### Region
-
-In order to use a Paws package, you must also set your AWS region.
-
-Paws will look for the region in the following three places, in order:
-
-1.  `AWS_REGION` R environment variable.
-2.  `AWS_REGION` system environment variable (Mac and Linux Only).
-3.  AWS config file.
-
-#### Setting Region with R Environment Variable
-
-Use R to set the region with the following command:
-
-``` r
-Sys.setenv(AWS_REGION = "us-east-1")
-```
-
-#### Setting Region with System Environment Variable
-
-On Mac or Linux you can use the command line to set the region with the
-following command:
-
-``` bash
-export AWS_REGION="us-east-1"
-```
-
-Paws currently does not support setting the region using a system
-variable on Windows.
-
-#### Setting Region with Config file
-
-You can set the region using a config file in `~/.aws/config`. You can
-generate a config file using the AWS CLI’s `aws configure` command.
-
-The config file should be in INI format and should look like:
-
-    [default]
-    region=us-east-1
-
-By default, Paws will use the `default` profile. If you would rather use
-a different profile, you can set the preferred profile by following the
-instructions in the “Profile” section of this document.
-
-Profiles are added to the config file by appending them to the file
-below the default:
-
-    [default]
-    region=region-1
-    
-    [other_profile]
-    region=region-2
-
-### AWS Profile
-
-If you do not set your AWS profile, the package will use the `default`
-profile.
-
-However, you may want to use another profile, which you can choose in
-the following ways:
-
-1.  `AWS_PROFILE` R environment variable.
-2.  `AWS_PROFILE` system environment variable - (Mac and Linux Only)
-
-#### Setting Profile with R Environment Variable
-
-Use R to set the profile with the following command:
-
-``` r
-Sys.setenv(AWS_PROFILE = "nameOfProfile")
-```
-
-#### Setting Region with System Environment Variable
-
-On Mac or Linux you can use the command line to set the profile with the
-following command:
-
-``` bash
-export AWS_PROFILE="nameOfProfile"
-```
-
-Paws currently does not support setting the profile using a system
-variable on Windows.

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -1,0 +1,152 @@
+# Setting Up Credentials and Region
+
+## Credentials
+
+In order to use a Paws package, you must provide it with your
+credentials.
+
+Credentials can be set in the following four ways, and Paws will look
+for them in this order.
+
+1.  R environment variables.
+2.  System environment variables (Mac and Linux Only).
+3.  AWS credentials file.
+4.  IAM role.
+
+If you are running the package on an instance with an appropriate IAM
+role, Paws will use it automatically and you don’t need to do anything
+extra.
+
+## Setting Credentials with R Environment Variables
+
+Use R to set the credentials with the following command:
+
+``` r
+Sys.setenv(AWS_ACCESS_KEY_ID = "accessKeyID")
+Sys.setenv(AWS_SECRET_ACCESS_KEY = "secretAccessKey")
+```
+
+## Setting Credentials with System Environment Variables
+
+On Mac or Linux you can use the command line to set the credentials with
+the following command:
+
+``` bash
+export AWS_ACCESS_KEY_ID="accessKeyID"
+export AWS_SECRET_ACCESS_KEY="secretAccessKey"
+```
+
+Paws currently does not support setting the credentials using a system
+variable on Windows.
+
+## Setting Credentials with AWS Credentials File
+
+You can set the credentials using a credentials file in
+`~/.aws/credentials`. You can generate a credentials file using the AWS
+CLI’s `aws configure` command.
+
+The credentials file should be in INI format and should look like:
+
+    [default]
+    aws_access_key_id=awsAccessKeyID
+    aws_secret_access_key=awsSecretAccessKey
+
+By default, Paws will use the `default` profile. If you would rather use
+the credentials from a different profile, you can set the preferred
+profile by following the instructions in the “Profile” section of this
+document.
+
+Profiles are added to the credentials file by appending them to the file
+below the default:
+
+    [default]
+    aws_access_key_id=awsAccessKeyID
+    aws_secret_access_key=awsSecretAccessKey
+    
+    [other_profile]
+    aws_access_key_id=awsOtherAccessKeyID
+    aws_secret_access_key=awsOtherSecretAccessKey
+
+## Region
+
+In order to use a Paws package, you must also set your AWS region.
+
+Paws will look for the region in the following three places, in order:
+
+1.  `AWS_REGION` R environment variable.
+2.  `AWS_REGION` system environment variable (Mac and Linux Only).
+3.  AWS config file.
+
+## Setting Region with R Environment Variable
+
+Use R to set the region with the following command:
+
+``` r
+Sys.setenv(AWS_REGION = "us-east-1")
+```
+
+## Setting Region with System Environment Variable
+
+On Mac or Linux you can use the command line to set the region with the
+following command:
+
+``` bash
+export AWS_REGION="us-east-1"
+```
+
+Paws currently does not support setting the region using a system
+variable on Windows.
+
+## Setting Region with Config file
+
+You can set the region using a config file in `~/.aws/config`. You can
+generate a config file using the AWS CLI’s `aws configure` command.
+
+The config file should be in INI format and should look like:
+
+    [default]
+    region=us-east-1
+
+By default, Paws will use the `default` profile. If you would rather use
+a different profile, you can set the preferred profile by following the
+instructions in the “Profile” section of this document.
+
+Profiles are added to the config file by appending them to the file
+below the default:
+
+    [default]
+    region=region-1
+    
+    [other_profile]
+    region=region-2
+
+## AWS Profile
+
+If you do not set your AWS profile, the package will use the `default`
+profile.
+
+However, you may want to use another profile, which you can choose in
+the following ways:
+
+1.  `AWS_PROFILE` R environment variable.
+2.  `AWS_PROFILE` system environment variable - (Mac and Linux Only)
+
+## Setting Profile with R Environment Variable
+
+Use R to set the profile with the following command:
+
+``` r
+Sys.setenv(AWS_PROFILE = "nameOfProfile")
+```
+
+## Setting Region with System Environment Variable
+
+On Mac or Linux you can use the command line to set the profile with the
+following command:
+
+``` bash
+export AWS_PROFILE="nameOfProfile"
+```
+
+Paws currently does not support setting the profile using a system
+variable on Windows.

--- a/examples/batch.R
+++ b/examples/batch.R
@@ -1,7 +1,7 @@
 # Batch examples
 
 # Note: In some cases, you'll need to wait for a step to complete in your AWS
-# account before you can successfully run the next.
+# account before you can successfully run the next step.
 
 # To set up the Batch compute environment, get security group and subnet info
 # for the default VPC.
@@ -21,7 +21,7 @@ subnets <- paws.ec2::describe_subnets(
 
 #-------------------------------------------------------------------------------
 
-# Set up an IAM role for the Lambda function.
+# Set up an IAM role for Batch.
 
 role_name <- "TestBatchServiceRole"
 policy_arn <- "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"

--- a/examples/batch.R
+++ b/examples/batch.R
@@ -15,7 +15,8 @@ subnets <- paws.ec2::describe_subnets(
   Filters = sprintf("vpc-id=%s", default_vpc$VpcId)
 )$Subnets
 
-# You will need to set up the Batch service role and provide its ARN here.
+# You will need to set up the Batch service role and provide your AWS account
+# account number here.
 service_role <- sprintf(
   "arn:aws:iam::%s:role/service-role/AWSBatchServiceRole",
   account_id = "1234567890123"

--- a/examples/batch.R
+++ b/examples/batch.R
@@ -1,0 +1,82 @@
+# Batch examples
+
+# To set up the Batch compute environment, get security group and subnet info
+# for the default VPC.
+default_vpc <- paws.ec2::describe_vpcs(
+  Filters = "isDefault=true"
+)$Vpcs[[1]]
+
+security_group <- paws.ec2::describe_security_groups(
+  Filters = sprintf("vpc-id=%s", default_vpc$VpcId),
+  GroupNames = "default"
+)$SecurityGroups[[1]]
+
+subnets <- paws.ec2::describe_subnets(
+  Filters = sprintf("vpc-id=%s", default_vpc$VpcId)
+)$Subnets
+
+# Set up a compute environment: the resources on which Batch jobs will run.
+# You will need to set up the Batch service role and provide its ARN here.
+paws.batch::create_compute_environment(
+  type = "MANAGED",
+  computeEnvironmentName = "TestComputeEnvironment",
+  computeResources = list(
+    type = "EC2",
+    desiredvCpus = 1L,
+    ec2KeyPair = "default",
+    instanceRole = "ecsInstanceRole",
+    instanceTypes = "optimal",
+    maxvCpus = 128L,
+    minvCpus = 0L,
+    securityGroupIds = security_group$GroupId,
+    subnets = sapply(subnets, function(x) x$SubnetId)
+  ),
+  serviceRole = "arn:aws:iam::123456790123:role/service-role/AWSBatchServiceRole",
+  state = "ENABLED"
+)
+
+# Set up a job queue for the compute environment.
+queue <- paws.batch::create_job_queue(
+  computeEnvironmentOrder = list(
+    list(
+      computeEnvironment = "TestComputeEnvironment",
+      order = 1L
+    )
+  ),
+  jobQueueName = "TestJobQueue",
+  priority = 1L,
+  state = "ENABLED"
+)
+
+# Add an example job definition -- sleep 10 seconds.
+job_def <- paws.batch::register_job_definition(
+  type = "container",
+  containerProperties = list(
+    command = list(
+      "sleep",
+      "10"
+    ),
+    image = "busybox",
+    memory = 128L,
+    vcpus = 1L
+  ),
+  jobDefinitionName = "sleep10"
+)
+
+# Submit a job.
+paws.batch::submit_job(
+  jobDefinition = "sleep10",
+  jobName = "Example",
+  jobQueue = "TestJobQueue"
+)
+
+# List the submitted job(s).
+paws.batch::list_jobs(
+  jobQueue = "TestJobQueue",
+  jobStatus = "SUBMITTED"
+)
+
+# Clean up.
+paws.batch::deregister_job_definition(jobDefinition = job_def$jobDefinitionArn)
+paws.batch::delete_job_queue(jobQueue = "TestJobQueue")
+paws.batch::delete_compute_environment(computeEnvironment = "TestComputeEnvironment")

--- a/examples/batch.R
+++ b/examples/batch.R
@@ -26,7 +26,7 @@ subnets <- paws.ec2::describe_subnets(
 role_name <- "TestBatchServiceRole"
 policy_arn <- "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
 
-role_policy <- list(
+trust_policy <- list(
   Version = "2012-10-17",
   Statement = list(
     list(
@@ -41,7 +41,7 @@ role_policy <- list(
 
 iam <- paws.iam::create_role(
   RoleName = role_name,
-  AssumeRolePolicyDocument = jsonlite::toJSON(role_policy, auto_unbox = TRUE)
+  AssumeRolePolicyDocument = jsonlite::toJSON(trust_policy, auto_unbox = TRUE)
 )
 
 paws.iam::attach_role_policy(

--- a/examples/batch.R
+++ b/examples/batch.R
@@ -15,8 +15,13 @@ subnets <- paws.ec2::describe_subnets(
   Filters = sprintf("vpc-id=%s", default_vpc$VpcId)
 )$Subnets
 
-# Set up a compute environment: the resources on which Batch jobs will run.
 # You will need to set up the Batch service role and provide its ARN here.
+service_role <- sprintf(
+  "arn:aws:iam::%s:role/service-role/AWSBatchServiceRole",
+  account_id = "1234567890123"
+)
+
+# Set up a compute environment: the resources on which Batch jobs will run.
 paws.batch::create_compute_environment(
   type = "MANAGED",
   computeEnvironmentName = "TestComputeEnvironment",
@@ -31,12 +36,12 @@ paws.batch::create_compute_environment(
     securityGroupIds = security_group$GroupId,
     subnets = sapply(subnets, function(x) x$SubnetId)
   ),
-  serviceRole = "arn:aws:iam::123456790123:role/service-role/AWSBatchServiceRole",
+  serviceRole = service_role,
   state = "ENABLED"
 )
 
 # Set up a job queue for the compute environment.
-queue <- paws.batch::create_job_queue(
+paws.batch::create_job_queue(
   computeEnvironmentOrder = list(
     list(
       computeEnvironment = "TestComputeEnvironment",
@@ -78,5 +83,8 @@ paws.batch::list_jobs(
 
 # Clean up.
 paws.batch::deregister_job_definition(jobDefinition = job_def$jobDefinitionArn)
-paws.batch::delete_job_queue(jobQueue = "TestJobQueue")
+paws.batch::update_job_queue("TestJobQueue", state = "DISABLED")
+paws.batch::delete_job_queue("TestJobQueue")
+Sys.sleep(30)
+paws.batch::update_compute_environment("TestComputeEnvironment", state = "DISABLED")
 paws.batch::delete_compute_environment(computeEnvironment = "TestComputeEnvironment")

--- a/examples/batch.R
+++ b/examples/batch.R
@@ -1,7 +1,11 @@
 # Batch examples
 
+# Note: In some cases, you'll need to wait for a step to complete in your AWS
+# account before you can successfully run the next.
+
 # To set up the Batch compute environment, get security group and subnet info
 # for the default VPC.
+
 default_vpc <- paws.ec2::describe_vpcs(
   Filters = "isDefault=true"
 )$Vpcs[[1]]
@@ -15,12 +19,37 @@ subnets <- paws.ec2::describe_subnets(
   Filters = sprintf("vpc-id=%s", default_vpc$VpcId)
 )$Subnets
 
-# You will need to set up the Batch service role and provide your AWS account
-# account number here.
-service_role <- sprintf(
-  "arn:aws:iam::%s:role/service-role/AWSBatchServiceRole",
-  account_id = "1234567890123"
+#-------------------------------------------------------------------------------
+
+# Set up an IAM role for the Lambda function.
+
+role_name <- "TestBatchServiceRole"
+policy_arn <- "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
+
+role_policy <- list(
+  Version = "2012-10-17",
+  Statement = list(
+    list(
+      Effect = "Allow",
+      Principal = list(
+        Service = "batch.amazonaws.com"
+      ),
+      Action = "sts:AssumeRole"
+    )
+  )
 )
+
+iam <- paws.iam::create_role(
+  RoleName = role_name,
+  AssumeRolePolicyDocument = jsonlite::toJSON(role_policy, auto_unbox = TRUE)
+)
+
+paws.iam::attach_role_policy(
+  RoleName = role_name,
+  PolicyArn = policy_arn
+)
+
+#-------------------------------------------------------------------------------
 
 # Set up a compute environment: the resources on which Batch jobs will run.
 paws.batch::create_compute_environment(
@@ -37,7 +66,7 @@ paws.batch::create_compute_environment(
     securityGroupIds = security_group$GroupId,
     subnets = sapply(subnets, function(x) x$SubnetId)
   ),
-  serviceRole = service_role,
+  serviceRole = iam$Role$Arn,
   state = "ENABLED"
 )
 
@@ -82,10 +111,11 @@ paws.batch::list_jobs(
   jobStatus = "SUBMITTED"
 )
 
-# Clean up.
+# Clean up. You may have to wait for some steps to complete.
 paws.batch::deregister_job_definition(jobDefinition = job_def$jobDefinitionArn)
 paws.batch::update_job_queue("TestJobQueue", state = "DISABLED")
 paws.batch::delete_job_queue("TestJobQueue")
-Sys.sleep(30)
 paws.batch::update_compute_environment("TestComputeEnvironment", state = "DISABLED")
 paws.batch::delete_compute_environment(computeEnvironment = "TestComputeEnvironment")
+paws.iam::detach_role_policy(role_name, policy_arn)
+paws.iam::delete_role(role_name)

--- a/examples/comprehend.R
+++ b/examples/comprehend.R
@@ -1,0 +1,30 @@
+# Comprehend natural language processing examples
+
+# Determine the dominant language(s) in a document.
+paws.comprehend::detect_dominant_language(
+  Text = "Hello world!"
+)
+
+# Determine the prevailing sentiment in a batch of documents.
+paws.comprehend::batch_detect_sentiment(
+  TextList = list(
+    "Awesome!",
+    "OK",
+    "Meh",
+    "Terrible!"
+  ),
+  LanguageCode = "en"
+)
+
+text <-
+  "Gatsby believed in the green light, the orgiastic future that year by
+   year recedes before us. It eluded us then, but that's no matter--
+   tomorrow we will run faster, stretch out our arms farther.... And one
+   fine morning-- So we beat on, boats against the current, borne back
+   ceaselessly into the past."
+
+# Find named entities in a document.
+paws.comprehend::detect_entities(
+  Text = text,
+  LanguageCode = "en"
+)

--- a/examples/lambda.R
+++ b/examples/lambda.R
@@ -31,7 +31,7 @@ role_policy <- list(
 )
 
 iam <- paws.iam::create_role(
-  RoleName = "MyTestRole",
+  RoleName = "MyRole",
   AssumeRolePolicyDocument = jsonlite::toJSON(role_policy, auto_unbox = TRUE),
   PermissionsBoundary = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 )
@@ -48,10 +48,14 @@ paws.lambda::create_function(
 )
 
 # Run the function.
-paws.lambda::invoke("MyFunction")
+response <- paws.lambda::invoke("MyFunction")
+
+# Print the function's output.
+rawToChar(response$Payload)
 
 # List available functions.
 paws.lambda::list_functions()
 
-# Delete the function.
+# Clean up.
 paws.lambda::delete_function("MyFunction")
+paws.iam::delete_role("MyRole")

--- a/examples/lambda.R
+++ b/examples/lambda.R
@@ -17,7 +17,10 @@ zip_contents <- readBin(zip_file, "raw", n = 1e5)
 
 # Set up an IAM role for the Lambda function.
 
-role_policy <- list(
+role_name <- "MyRole"
+policy_arn <- "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+
+trust_policy <- list(
   Version = "2012-10-17",
   Statement = list(
     list(
@@ -31,9 +34,13 @@ role_policy <- list(
 )
 
 iam <- paws.iam::create_role(
-  RoleName = "MyRole",
-  AssumeRolePolicyDocument = jsonlite::toJSON(role_policy, auto_unbox = TRUE),
-  PermissionsBoundary = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  RoleName = role_name,
+  AssumeRolePolicyDocument = jsonlite::toJSON(trust_policy, auto_unbox = TRUE)
+)
+
+paws.iam::attach_role_policy(
+  RoleName = role_name,
+  PolicyArn = policy_arn
 )
 
 #-------------------------------------------------------------------------------
@@ -58,4 +65,5 @@ paws.lambda::list_functions()
 
 # Clean up.
 paws.lambda::delete_function("MyFunction")
-paws.iam::delete_role("MyRole")
+paws.iam::detach_role_policy(role_name, policy_arn)
+paws.iam::delete_role(role_name)

--- a/examples/lambda.R
+++ b/examples/lambda.R
@@ -1,21 +1,40 @@
 # Lambda examples
 
-path <- tempdir()
+#-------------------------------------------------------------------------------
 
-# Write a file containing a JavaScript function.
+# Create a Lambda function package to upload.
+
 code <- 'exports.handler = async (event, context) => { return "Hello!"; };'
+path <- tempdir()
 js_file <- file.path(path, "lambda.js")
 writeLines(code, js_file)
 
-# Write the zip file to upload.
 zip_file <- file.path(path, "lambda.zip")
 utils::zip(zip_file, js_file, flags = "-j")
-
 zip_contents <- readBin(zip_file, "raw", n = 1e5)
 
 #-------------------------------------------------------------------------------
 
 # Set up an IAM role for the Lambda function.
+
+role_policy <- list(
+  Version = "2012-10-17",
+  Statement = list(
+    list(
+      Effect = "Allow",
+      Principal = list(
+        Service = "lambda.amazonaws.com"
+      ),
+      Action = "sts:AssumeRole"
+    )
+  )
+)
+
+iam <- paws.iam::create_role(
+  RoleName = "MyTestRole",
+  AssumeRolePolicyDocument = jsonlite::toJSON(role_policy, auto_unbox = TRUE),
+  PermissionsBoundary = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+)
 
 #-------------------------------------------------------------------------------
 
@@ -24,12 +43,15 @@ paws.lambda::create_function(
   Code = list(ZipFile = zip_contents),
   FunctionName = "MyFunction",
   Handler = "lambda.handler",
-  Role = "arn:aws:iam::185682296754:role/service-role/myLambdaRole",
+  Role = iam$Role$Arn,
   Runtime = "nodejs8.10"
 )
 
 # Run the function.
 paws.lambda::invoke("MyFunction")
+
+# List available functions.
+paws.lambda::list_functions()
 
 # Delete the function.
 paws.lambda::delete_function("MyFunction")

--- a/examples/lambda.R
+++ b/examples/lambda.R
@@ -1,0 +1,35 @@
+# Lambda examples
+
+path <- tempdir()
+
+# Write a file containing a JavaScript function.
+code <- 'exports.handler = async (event, context) => { return "Hello!"; };'
+js_file <- file.path(path, "lambda.js")
+writeLines(code, js_file)
+
+# Write the zip file to upload.
+zip_file <- file.path(path, "lambda.zip")
+utils::zip(zip_file, js_file, flags = "-j")
+
+zip_contents <- readBin(zip_file, "raw", n = 1e5)
+
+#-------------------------------------------------------------------------------
+
+# Set up an IAM role for the Lambda function.
+
+#-------------------------------------------------------------------------------
+
+# Create the Lambda function.
+paws.lambda::create_function(
+  Code = list(ZipFile = zip_contents),
+  FunctionName = "MyFunction",
+  Handler = "lambda.handler",
+  Role = "arn:aws:iam::185682296754:role/service-role/myLambdaRole",
+  Runtime = "nodejs8.10"
+)
+
+# Run the function.
+paws.lambda::invoke("MyFunction")
+
+# Delete the function.
+paws.lambda::delete_function("MyFunction")

--- a/examples/sns.R
+++ b/examples/sns.R
@@ -3,6 +3,9 @@
 # Create a topic to which we can send notifications.
 topic <- paws.sns::create_topic("ExampleTopic")
 
+# List our topics.
+paws.sns::list_topics()
+
 # Subscribe an email address to the topic.
 # You'll have to confirm the subscription to receive emails.
 paws.sns::subscribe(

--- a/examples/sns.R
+++ b/examples/sns.R
@@ -1,0 +1,21 @@
+# Simple Notification Service examples
+
+# Create a topic to which we can send notifications.
+topic <- paws.sns::create_topic("ExampleTopic")
+
+# Subscribe an email address to the topic.
+# You'll have to confirm the subscription to receive emails.
+paws.sns::subscribe(
+  TopicArn = topic$TopicArn,
+  Protocol = "email",
+  Endpoint = "user@example.com"
+)
+
+# Publish a message to the topic.
+paws.sns::publish(
+  Message = "Hello world!",
+  TopicArn = topic$TopicArn
+)
+
+# Delete the example topic.
+paws.sns::delete_topic(topic$TopicArn)

--- a/examples/sqs.R
+++ b/examples/sqs.R
@@ -1,0 +1,34 @@
+# Simple Queue Service examples
+
+# Create a queue.
+sqs <- paws.sqs::create_queue(
+  QueueName = "ExampleQueue"
+)
+
+# Add a message to the queue.
+paws.sqs::send_message(
+  QueueUrl = sqs$QueueUrl,
+  MessageBody = "foo"
+)
+
+# Get the queue's attributes.
+paws.sqs::get_queue_attributes(
+  QueueUrl = sqs$QueueUrl,
+  AttributeNames = "All"
+)
+
+# Get the next message from the queue.
+msg <- paws.sqs::receive_message(
+  QueueUrl = sqs$QueueUrl
+)
+
+# Delete the message.
+paws.sqs::delete_message(
+  QueueUrl = sqs$QueueUrl,
+  ReceiptHandle = msg$Messages[1]$ReceiptHandle
+)
+
+# Delete the queue.
+paws.sqs::delete_queue(
+  QueueUrl = sqs$QueueUrl
+)

--- a/examples/sqs.R
+++ b/examples/sqs.R
@@ -25,7 +25,7 @@ msg <- paws.sqs::receive_message(
 # Delete the message.
 paws.sqs::delete_message(
   QueueUrl = sqs$QueueUrl,
-  ReceiptHandle = msg$Messages[1]$ReceiptHandle
+  ReceiptHandle = msg$Messages[[1]]$ReceiptHandle
 )
 
 # Delete the queue.

--- a/make.paws/R/make_docs.R
+++ b/make.paws/R/make_docs.R
@@ -253,30 +253,14 @@ make_doc_desc <- function(operation) {
   return(as.character(description))
 }
 
-# Get the inputs to the function.
-make_inputs <- function(shape) {
-  members <- shape$members
-  required <- members[unlist(shape$required)]
-  optional <- members[setdiff(names(members), names(required))]
-  members <- c(required, optional)
-  members[] <- lapply(seq_along(members), function(i) {
-    x <- members[[i]]
-    x$member_name <- names(members)[i]
-    x$param_name <- x$member_name
-    x$required <- x$member_name %in% names(required)
-    x
-  })
-  return(members)
-}
-
 # Make the parameter documentation.
 make_doc_params <- function(operation, api) {
   if (!is.null(operation$input$shape)) {
     shapes <- api$shapes
     shape <- shapes[[operation$input$shape]]
-    inputs <- make_inputs(shape)
+    inputs <- get_inputs(shape)
     params <- sapply(inputs, function(input) {
-      param <- input$param_name
+      param <- input$member_name
       required <- input$required
       documentation <- convert(input$documentation, wrap = FALSE)
       documentation <- glue::glue_collapse(documentation, sep = "\n")

--- a/make.paws/R/make_docs.R
+++ b/make.paws/R/make_docs.R
@@ -180,13 +180,6 @@ preprocess <- function(text) {
   if (length(code) > 0) {
     code_text <- xml2::xml_text(code)
     xml2::xml_text(code) <- fix_unmatched_chars(code_text)
-
-    # if (!grepl("^<body>", text)) {
-    #   result <- xml2::xml_find_first(html, ".//body")
-    # } else {
-    #   result <- html
-    # }
-
     result <- as.character(xml2::xml_children(html))
   } else {
     result <- text
@@ -284,8 +277,12 @@ make_doc_params <- function(operation, api) {
     inputs <- make_inputs(shape)
     params <- sapply(inputs, function(input) {
       param <- input$param_name
+      required <- input$required
       documentation <- convert(input$documentation, wrap = FALSE)
       documentation <- glue::glue_collapse(documentation, sep = "\n")
+      if (required) {
+        documentation <- glue::glue("&#91;required&#93; {documentation}")
+      }
       documentation <- glue::glue("@param {param} {documentation}")
       lines <- strsplit(documentation, "\n")[[1]]
       lines <- glue::glue("#' {lines}")

--- a/make.paws/R/make_operation.R
+++ b/make.paws/R/make_operation.R
@@ -81,17 +81,15 @@ make_operations <- function(api) {
 
 #-------------------------------------------------------------------------------
 
-# Get the inputs for an API operation, putting required arguments first.
+# Get the inputs for an API operation.
 get_inputs <- function(input) {
   if (!is.null(input)) {
     members <- input$members
-    required <- members[unlist(input$required)]
-    optional <- members[setdiff(names(members), unlist(input$required))]
-    members <- c(required, optional)
+    required <- unlist(input$required)
     members[] <- lapply(seq_along(members), function(i) {
       x <- members[[i]]
       x$member_name <- names(members)[i]
-      x$required <- x$member_name %in% names(required)
+      x$required <- x$member_name %in% required
       x
     })
   } else {

--- a/make.paws/tests/testthat/test_make_docs.R
+++ b/make.paws/tests/testthat/test_make_docs.R
@@ -147,6 +147,9 @@ test_that("make_doc_params", {
   api <- list(
     shapes = list(
       Foo = list(
+        required = list(
+          "Member2"
+        ),
         members = list(
           Member1 = list(
             documentation = "Documentation1"
@@ -156,13 +159,11 @@ test_that("make_doc_params", {
           )
         )
       )
-    ),
-    required = list(
     )
   )
   expected <- paste(
     "#' @param Member1 Documentation1",
-    "#' @param Member2 Documentation2",
+    "#' @param Member2 &#91;required&#93; Documentation2",
     sep = "\n"
   )
   expect_equal(make_doc_params(operation, api), expected)


### PR DESCRIPTION
* Add a `docs` folder and move the credentials/region setup documentation into it.
* Add more examples to the `examples` folder.
* Use each API operation's original parameter order, rather than required parameters first. This keeps Paws consistent with the behavior of the official SDKs. In addition, add "[required]" to the descriptions of required parameters in the documentation.