### PR TITLE
Fix JSON string value encoding, missing location name attributes

### DIFF
--- a/make.paws/R/handlers_rest.R
+++ b/make.paws/R/handlers_rest.R
@@ -183,7 +183,7 @@ rest_unmarshal_header <- function(value, type) {
     integer = as.integer,
     float = as.numeric,
     jsonvalue = json_to_list, # TODO
-    long = as.integer,
+    long = as.numeric,
     string = as.character,
     timestamp = function(x) as_timestamp(x, format = "rfc1123"),
     as.character

--- a/make.paws/R/jsonutil.R
+++ b/make.paws/R/jsonutil.R
@@ -218,7 +218,7 @@ json_parse_scalar <- function(node, interface) {
     double = as.numeric,
     float = as.numeric,
     integer = as.integer,
-    long = as.integer,
+    long = as.numeric,
     string = as.character,
     timestamp = unix_time,
     as.character

--- a/make.paws/R/jsonutil.R
+++ b/make.paws/R/jsonutil.R
@@ -117,11 +117,46 @@ json_build_scalar <- function(values) {
     float = as.character(values),
     integer = as.character(values),
     long = as.character(values),
-    string = sprintf('"%s"', values),
+    string = json_convert_string(values),
     timestamp = as.character(as.numeric(values)),
     sprintf('"%s"', values)
   )
   return(s)
+}
+
+#-------------------------------------------------------------------------------
+
+# Escape control characters by replacing them with their Unicode representation.
+json_escape_unicode <- function(string) {
+  result <- string
+  for (i in 1:31) {
+    from <- intToUtf8(i)
+    to <- paste0("\\u00", format(as.hexmode(i), width = 2))
+    result <- gsub(from, to, result, fixed = TRUE)
+  }
+  return(result)
+}
+
+# Return a string for a JSON value, with special characters escaped.
+json_convert_string <- function(string) {
+  replace <- list(
+    c("\\", "\\\\"),
+    c('"', '\\"'),
+    c("\b", "\\b"),
+    c("\f", "\\f"),
+    c("\r", "\\r"),
+    c("\t", "\\t"),
+    c("\n", "\\n")
+  )
+  result <- string
+  for (elem in replace) {
+    from <- elem[1]
+    to <- elem[2]
+    result <- gsub(from, to, result, fixed = TRUE)
+  }
+  result <- json_escape_unicode(result)
+  result <- sprintf('"%s"', result)
+  return(result)
 }
 
 #-------------------------------------------------------------------------------

--- a/make.paws/R/make_interface.R
+++ b/make.paws/R/make_interface.R
@@ -102,6 +102,11 @@ make_shape_structure <- function(shape, api, path) {
 make_shape_list <- function(shape, api, path) {
   member <- shape$member
   proto <- list(make_shape(member, api, path))
+
+  if (not_empty(member$locationName)) {
+    proto <- add_tags(list(locationNameList = member$locationName), proto)
+  }
+
   return(proto)
 }
 
@@ -109,6 +114,12 @@ make_shape_map <- function(shape, api, path) {
   key <- shape$key
   value <- shape$value
   proto <- list(make_shape(value, api, path))
+  if (not_empty(key$locationName)) {
+    proto <- add_tags(list(locationNameKey = key$locationName), proto)
+  }
+  if (not_empty(value$locationName)) {
+    proto <- add_tags(list(locationNameValue = value$locationName), proto)
+  }
   return(proto)
 }
 

--- a/make.paws/R/make_interface.R
+++ b/make.paws/R/make_interface.R
@@ -89,12 +89,8 @@ make_shape_structure <- function(shape, api, path) {
   members <- shape$members
   for (member_name in names(members)) {
     member <- members[[member_name]]
-    export_name <- make_export_name(member_name)
     interface <- make_shape(member, api, path)
-    if (export_name != member_name) {
-      attr(interface, "locationName") <- member_name
-    }
-    proto[[export_name]] <- interface
+    proto[[member_name]] <- interface
   }
   return(proto)
 }

--- a/make.paws/R/xmlutil.R
+++ b/make.paws/R/xmlutil.R
@@ -57,11 +57,16 @@ xml_parse_structure <- function(node, interface) {
       node_name <- get_tag(field, "locationName")
     }
 
-    children <- get_children(node, node_name)
-    if (length(children) == 0) {
+    elem <- node[[node_name]]
+    if (flattened) {
+      elem <- node[names(node) == node_name]
+    }
+
+    if (length(elem) == 0) {
       # TODO: Implement.
     }
-    parsed <- xml_parse(children, field)
+
+    parsed <- xml_parse(elem, field)
     result[[name]] <- parsed
   }
   return(result)
@@ -132,14 +137,4 @@ xml_parse_scalar <- function(node, interface) {
 xml_to_list <- function(value) {
   result <- xml2::as_list(xml2::read_xml(value))
   return(result)
-}
-
-# Return the child node or nodes with a given name.
-# Multiple nodes with the same name arise with flattened lists,
-# e.g. <foo>"a"</foo><foo>"b"</foo>.
-get_children <- function(node, name) {
-  if (sum(names(node) == name) == 1) {
-    return(node[[name]])
-  }
-  return(node[names(node) == name])
 }

--- a/make.paws/R/xmlutil.R
+++ b/make.paws/R/xmlutil.R
@@ -123,7 +123,7 @@ xml_parse_scalar <- function(node, interface) {
     double = as.numeric,
     float = as.numeric,
     integer = as.integer,
-    long = as.integer,
+    long = as.numeric,
     timestamp = function(x) as_timestamp(x, format = "iso8601"),
     as.character
   )

--- a/make.paws/tests/testthat/test_handlers_ec2query.R
+++ b/make.paws/tests/testthat/test_handlers_ec2query.R
@@ -301,7 +301,7 @@ test_that("unmarshal list", {
 })
 
 op_output5 <- Structure(
-  ListMember = List(Scalar(type = "string", .attrs = list(flattened = TRUE)))
+  ListMember = List(Scalar(type = "string"), .attrs = list(flattened = TRUE))
 )
 
 test_that("unmarshal flattened list", {

--- a/make.paws/tests/testthat/test_handlers_query.R
+++ b/make.paws/tests/testthat/test_handlers_query.R
@@ -664,7 +664,7 @@ test_that("unmarshal flattened map", {
 })
 
 op_output12 <- Structure(
-  Map = Map(Scalar(type = "string"), .attrs = list(locationNameKey = "foo", locationNameValue = "bar"))
+  Map = Map(Scalar(type = "string"), .attrs = list(locationNameKey = "foo", locationNameValue = "bar", flattened = TRUE))
 )
 
 test_that("unmarshal named map", {

--- a/make.paws/tests/testthat/test_jsonutil.R
+++ b/make.paws/tests/testthat/test_jsonutil.R
@@ -12,35 +12,26 @@ test_that("JSON tests", {
     )
     return(populate(args, interface))
   }
-  tests <- list(
-    list(
-      input = J(),
-      expected = "{}",
-      err = ""
-    ),
-    list(
-      input = J(
-        S = "str",
-        SS = list("A", "B", "C"),
-        D = 123,
-        `F` = 4.56,
-        `T` = unix_time(987)
-      ),
-      expected = '{"S":"str","SS":["A","B","C"],"D":123,"F":4.56,"T":987}',
-      err = ""
-    ),
-    list(
-      input = J(S = "\"''\""),
-      expected = '{"S":""\'\'""}',
-      err = ""
-    ),
-    list(
-      input = J(S = "føø\u00FF\n\\\"\r\t\b\f"),
-      expected = '{"S":"føø\u00FF\n\\\"\r\t\b\f"}',
-      err = ""
-    )
+
+  input <- J()
+  expected <- "{}"
+  expect_equal(json_build(input), expected)
+
+  input <- J(
+    S = "str",
+    SS = list("A", "B", "C"),
+    D = 123,
+    `F` = 4.56,
+    `T` = unix_time(987)
   )
-  for (test in tests) {
-    expect_equal(json_build(test$input), test$expected)
-  }
+  expected <- '{"S":"str","SS":["A","B","C"],"D":123,"F":4.56,"T":987}'
+  expect_equal(json_build(input), expected)
+
+  input <- J(S = "\"''\"")
+  expected <- '{"S":"\\"\'\'\\""}'
+  expect_equal(json_build(input), expected)
+
+  input <- J(S = "foo\u00F8\u00F8\u00FF\n\\\"\r\t\b\f")
+  expected <- '{"S":"fooøøÿ\\n\\\\\\"\\r\\t\\b\\f"}'
+  expect_equal(json_build(input), expected)
 })

--- a/make.paws/tests/testthat/test_make_interface.R
+++ b/make.paws/tests/testthat/test_make_interface.R
@@ -195,6 +195,71 @@ test_that("map of scalars", {
   expect_equal(attr(out[[1]], "type"), "string")
 })
 
+test_that("location name for lists", {
+  api <- list(
+    shapes = list(
+      StructureShape = list(
+        type = "structure",
+        members = list(
+          List = list(
+            shape = "ListShape"
+          )
+        )
+      ),
+      ListShape = list(
+        type = "list",
+        member = list(
+          shape = "StringShape",
+          locationName = "Foo"
+        ),
+        flattened = TRUE
+      ),
+      StringShape = list(
+        type = "string"
+      )
+    )
+  )
+  out <- make_shape(list(shape = "StructureShape"), api = api)
+  expect_equal(attr(out$List, "type"), "list")
+  expect_equal(attr(out$List, "locationNameList"), "Foo")
+
+})
+
+test_that("location name for maps", {
+  api <- list(
+    shapes = list(
+      StructureShape = list(
+        type = "structure",
+        members = list(
+          Map = list(
+            shape = "MapShape"
+          )
+        )
+      ),
+      MapShape = list(
+        type = "map",
+        key = list(
+          shape = "StringShape",
+          locationName = "Foo"
+        ),
+        value = list(
+          shape = "StringShape",
+          locationName = "Bar"
+        ),
+        flattened = TRUE,
+        locationName = "Map"
+      ),
+      StringShape = list(
+        type = "string"
+      )
+    )
+  )
+  out <- make_shape(list(shape = "StructureShape"), api = api)
+  expect_equal(attr(out$Map, "type"), "map")
+  expect_equal(attr(out$Map, "locationNameKey"), "Foo")
+  expect_equal(attr(out$Map, "locationNameValue"), "Bar")
+})
+
 test_that("stop loops", {
   api <- list(
     shapes = list(


### PR DESCRIPTION
* JSON strings can contain certain special characters, e.g. newlines, only if they are escaped. Add `json_convert_string` to properly convert string values. Without this fix, requests with arguments containing characters like newlines will fail.

    This comes up in e.g. `paws.comprehend` when trying to send long strings of text with newlines.

* Lists and maps use location name attributes `locationNameList`, `locationNameKey`, and `locationNameValue` which we previously did not have. These are derived from a given shape's `locationName`.

* Fix how `query_unmarshal` handles flattened lists and maps.

* Use `as.numeric` instead of `as.integer` for `long`-type API response data, since a long is a 64-bit integer and an R integer can represent only 32-bit integers, whereas an R double/numeric can represent any 64-bit integer.