### PR TITLE
WIP: REST protocol bug fixes

### DIFF
--- a/make.paws/DESCRIPTION
+++ b/make.paws/DESCRIPTION
@@ -12,6 +12,7 @@ License: Apache License (>= 2.0)
 Encoding: UTF-8
 LazyData: true
 Suggests: 
+    base64enc,
     digest,
     httr,
     ini

--- a/make.paws/R/convert.R
+++ b/make.paws/R/convert.R
@@ -52,14 +52,14 @@ convert_timestamp <- function(timestamp, format = NULL) {
 # e.g. "Zm9v" -> "foo".
 base64_to_utf8 <- function(value) {
   if (length(value) == 0) return(character(0))
-  return(intToUtf8(jsonlite::base64_dec(value)))
+  return(intToUtf8(base64enc::base64decode(value)))
 }
 
 # Convert a string to a base64-encoded value.
 # e.g. "foo" (raw: 66 6f 6f) -> "Zm9v".
 utf8_to_base64 <- function(value) {
   if (length(value) == 0) return(character(0))
-  return(jsonlite::base64_enc(value))
+  return(base64enc::base64encode(value))
 }
 
 # Return a strptime format string for a given timestamp format.

--- a/make.paws/R/handlers_rest.R
+++ b/make.paws/R/handlers_rest.R
@@ -224,13 +224,10 @@ rest_payload_type <- function(values) {
   if (!is_valid(values)) {
     return("")
   }
-  field <- values[["_"]]
-  if (!is.null(field)) {
-    payload_name <- get_tag(field, "payload")
-    if (payload_name != "") {
-      payload <- values[[payload_name]]
-      return(get_tag(payload, "type"))
-    }
+  payload_name <- get_tag(values, "payload")
+  if (payload_name != "") {
+    payload <- values[[payload_name]]
+    return(get_tag(payload, "type"))
   }
   return("")
 }

--- a/make.paws/R/handlers_rest.R
+++ b/make.paws/R/handlers_rest.R
@@ -129,8 +129,13 @@ rest_unmarshal_meta <- function(request) {
 }
 
 # Unmarshal the body from a REST protocol API response.
-# TODO: Implement. Check whether we already have this functionality elsewhere.
 rest_unmarshal <- function(request) {
+  values <- request$data
+  payload_name <- get_tag(values, "payload")
+  if (payload_name != "") {
+    values[[payload_name]] <- request$http_response$body
+    request$data <- values
+  }
   return(request)
 }
 


### PR DESCRIPTION
* Fix base64 encoding and decoding by using the `base64enc` package. The `jsonlite` package's base64 encoder inserts newlines which cannot be included in JSON and cause AWS to return serialization errors.

* Fix `rest_payload_type` which needs to look at the output object's `payload` attribute, not the `_` element's `payload` attribute. There is no `_` element in our implementation.

* Implement the REST unmarshal handler.