### PR TITLE
Add usage documentation

### DIFF
--- a/make.paws/R/make_docs.R
+++ b/make.paws/R/make_docs.R
@@ -1,3 +1,120 @@
+# Make an operation's Roxygen documentation.
+make_docs <- function(operation, api) {
+  title <- make_doc_title(operation)
+  description <- make_doc_desc(operation)
+  usage <- make_doc_usage(operation, api)
+  params <- make_doc_params(operation, api)
+  return <- make_doc_return(operation)
+  examples <- make_doc_examples(operation)
+  export <- "#' @export"
+  docs <- glue::glue_collapse(
+    c(title,
+      description,
+      usage,
+      params,
+      # return,
+      examples,
+      export),
+    sep = "\n#'\n"
+  )
+  return(as.character(docs))
+}
+
+# Make the documentation title.
+make_doc_title <- function(operation) {
+  docs <- convert(operation$documentation, wrap = FALSE)
+  title <- first_sentence(docs)
+  title <- glue::glue("#' {title}")
+  return(as.character(title))
+}
+
+# Make the description and details documentation.
+make_doc_desc <- function(operation) {
+  docs <- convert(operation$documentation, wrap = FALSE)
+  docs <- escape_special_characters(docs)
+  description <- glue::glue("#' {docs}")
+  description <- glue::glue_collapse(description, sep = "\n")
+  return(as.character(description))
+}
+
+# Make the parameter documentation.
+make_doc_params <- function(operation, api) {
+  if (!is.null(operation$input$shape)) {
+    shapes <- api$shapes
+    shape <- shapes[[operation$input$shape]]
+    inputs <- get_inputs(shape)
+    params <- sapply(inputs, function(input) {
+      param <- input$member_name
+      required <- input$required
+      documentation <- convert(input$documentation, wrap = FALSE)
+      documentation <- glue::glue_collapse(documentation, sep = "\n")
+      if (required) {
+        documentation <- glue::glue("&#91;required&#93; {documentation}")
+      }
+      documentation <- glue::glue("@param {param} {documentation}")
+      lines <- strsplit(documentation, "\n")[[1]]
+      lines <- glue::glue("#' {lines}")
+      lines
+    })
+    params <- glue::glue_collapse(unlist(params), sep = "\n")
+  } else {
+    params <- ""
+  }
+  return(as.character(params))
+}
+
+# Return a string showing the operation's usage, including all parameters.
+make_doc_usage <- function(operation, api) {
+  op_name <- get_operation_name(operation)
+  shape_name <- operation$input$shape
+  if (!is.null(shape_name)) {
+    shape <- make_shape(list(shape = shape_name), api)
+    args <- list_to_string(add_example_values(shape), quote = FALSE)
+    call <- gsub("^list", op_name, args)
+    call <- clean_example(call)
+    usage <- comment(paste(c("@usage", call), collapse = "\n"), "#'")
+    return(usage)
+  }
+  return("")
+}
+
+# Return a string with a description of the operation's return value.
+# TODO: Implement.
+make_doc_return <- function(operation, api) {
+  output <- operation$output
+  "#' @return"
+}
+
+# Return a string with an operation example's arguments.
+make_doc_example_args <- function(input) {
+  if (length(input) == 0) return("")
+  args <- paste(trimws(utils::capture.output(dput(input))), collapse = "")
+  result <- gsub("^list\\((.*)\\)$", "\\1", args)
+  return(result)
+}
+
+# Make an operation example.
+make_doc_example <- function(example, op_name) {
+  args <- make_doc_example_args(example$input)
+  call <- glue::glue("{op_name}({args})")
+  call <- clean_example(call)
+  desc <- comment(break_lines(example$description))
+  result <- paste(desc, call, sep = "\n")
+  return(result)
+}
+
+# Make all operation examples provided in the operation object.
+make_doc_examples <- function(operation) {
+  func <- get_operation_name(operation)
+  examples <- lapply(operation$examples, make_doc_example, op_name = func)
+  result <- paste(examples, collapse = "\n\n")
+  result <- paste(c("@examples", result), collapse = "\n")
+  result <- comment(result, "#'")
+  return(result)
+}
+
+#-------------------------------------------------------------------------------
+
 # Write a UTF-8 encoded file
 # Use `writeLines(..., useBytes = TRUE)` to write UTF-8 on Windows. Otherwise
 # Pandoc will occasionally fail with errors like `pandoc.exe: Cannot decode
@@ -56,6 +173,30 @@ fix_markdown_chars <- function(x, translate = c("\\[" = "&#91;", "\\]" = "&#93;"
     to <- translate[i]
     result <- gsub(from, to, result, fixed = TRUE)
   }
+  return(result)
+}
+
+# Convert an R list to a string.
+# The resulting string will not be valid for lists whose names are invalid.
+list_to_string <- function(x, quote = TRUE) {
+
+  if (is.atomic(x) && length(x) == 1 && is.null(names(x))) {
+    if (quote && is.character(x)) s <- sprintf('"%s"', x)
+    else s <- as.character(x)
+    return(s)
+  }
+
+  result <- "list("
+  for (i in seq_along(x)) {
+    key <- names(x)[i]
+    value <- list_to_string(x[[i]], quote)
+    if (!is.null(key) && key != "") s <- sprintf("%s = %s", key, value)
+    else s <- value
+    if (i > 1) s <- paste0(", ", s)
+    result <- paste0(result, s)
+  }
+  result <- paste0(result, ")")
+
   return(result)
 }
 
@@ -218,7 +359,7 @@ html_to_markdown <- function(html, wrap = TRUE) {
   result
 }
 
-# Convert documentation from HTML to Markdown.
+# Convert documentation to Markdown.
 convert <- function(docs, wrap = TRUE) {
   if (is.null(docs) || docs == "") return("")
   if (grepl("^<", docs)) {
@@ -236,100 +377,32 @@ first_sentence <- function(x) {
   return(first)
 }
 
-# Make the documentation title.
-make_doc_title <- function(operation) {
-  docs <- convert(operation$documentation, wrap = FALSE)
-  title <- first_sentence(docs)
-  title <- glue::glue("#' {title}")
-  return(as.character(title))
-}
-
-# Make the description and details documentation.
-make_doc_desc <- function(operation) {
-  docs <- convert(operation$documentation, wrap = FALSE)
-  docs <- escape_special_characters(docs)
-  description <- glue::glue("#' {docs}")
-  description <- glue::glue_collapse(description, sep = "\n")
-  return(as.character(description))
-}
-
-# Make the parameter documentation.
-make_doc_params <- function(operation, api) {
-  if (!is.null(operation$input$shape)) {
-    shapes <- api$shapes
-    shape <- shapes[[operation$input$shape]]
-    inputs <- get_inputs(shape)
-    params <- sapply(inputs, function(input) {
-      param <- input$member_name
-      required <- input$required
-      documentation <- convert(input$documentation, wrap = FALSE)
-      documentation <- glue::glue_collapse(documentation, sep = "\n")
-      if (required) {
-        documentation <- glue::glue("&#91;required&#93; {documentation}")
-      }
-      documentation <- glue::glue("@param {param} {documentation}")
-      lines <- strsplit(documentation, "\n")[[1]]
-      lines <- glue::glue("#' {lines}")
-      lines
-    })
-    params <- glue::glue_collapse(unlist(params), sep = "\n")
+# Add example values, e.g. "string" for strings, to an input or output shape.
+add_example_values <- function(shape) {
+  if (type(shape) == "scalar") {
+    t <- tag_get(shape, "type")
+    if (tag_has(shape, "enum")) {
+      t <- "enum"
+      enum <- tag_get(shape, "enum")
+    }
+    result <- switch(
+      t,
+      blob = "raw",
+      boolean = "TRUE|FALSE",
+      double = "123.0",
+      enum = paste0(sprintf('"%s"', enum), collapse = "|"),
+      float = "123.0",
+      integer = "123",
+      long = "123",
+      string = '"string"',
+      timestamp = "timestamp",
+      t
+    )
   } else {
-    params <- ""
+    result <- shape
+    for (i in seq_along(result)) {
+      result[[i]] <- add_example_values(result[[i]])
+    }
   }
-  return(as.character(params))
-}
-
-# Return a string with a description of the operation's return value.
-# TODO: Implement.
-make_doc_return <- function(operation) {
-  output <- operation$output
-  "#' @return"
-}
-
-# Return a string with an operation example's arguments.
-make_doc_example_args <- function(input) {
-  if (length(input) == 0) return("")
-  args <- paste(trimws(utils::capture.output(dput(input))), collapse = "")
-  result <- gsub("^list\\((.*)\\)$", "\\1", args)
   return(result)
-}
-
-# Make an operation example.
-make_doc_example <- function(example, op_name) {
-  args <- make_doc_example_args(example$input)
-  call <- glue::glue("{op_name}({args})")
-  call <- clean_example(call)
-  desc <- comment(break_lines(example$description))
-  result <- paste(desc, call, sep = "\n")
-  return(result)
-}
-
-# Make all operation examples provided in the operation object.
-make_doc_examples <- function(operation) {
-  func <- get_operation_name(operation)
-  examples <- lapply(operation$examples, make_doc_example, op_name = func)
-  result <- paste(examples, collapse = "\n\n")
-  result <- paste(c("@examples", result), collapse = "\n")
-  result <- comment(result, "#'")
-  return(result)
-}
-
-# Make the R function documentation.
-make_docs <- function(operation, api) {
-  title <- make_doc_title(operation)
-  description <- make_doc_desc(operation)
-  params <- make_doc_params(operation, api)
-  return <- make_doc_return(operation)
-  examples <- make_doc_examples(operation)
-  export <- "#' @export"
-  docs <- glue::glue_collapse(
-    c(title,
-      description,
-      params,
-      # return,
-      examples,
-      export),
-    sep = "\n#'\n"
-  )
-  return(as.character(docs))
 }

--- a/make.paws/R/make_package.R
+++ b/make.paws/R/make_package.R
@@ -257,7 +257,7 @@ make_imports <- function() {
   package <- methods::getPackageName()
   imports_file <- system_file("extdata/imports.csv", package = package)
   imports <- readLines(imports_file)
-  defaults <- rownames(installed.packages(priority="high"))
+  defaults <- rownames(utils::installed.packages(priority="high"))
   description <- paste(setdiff(imports, defaults), collapse = ",\n")
   return(description)
 }

--- a/make.paws/R/tags.R
+++ b/make.paws/R/tags.R
@@ -7,6 +7,12 @@ tag_get <- function(object, tag) {
   return("")
 }
 
+# Returns whether the object has the given tag.
+tag_has <- function(object, tag) {
+  tags <- attr(object, "tags", exact = TRUE)
+  return(tag %in% names(tags))
+}
+
 # Add a tag to an object, which we can access later using e.g.
 # `tag_get(object, "locationName")`. This is used to store metadata about an
 # API shape, such as its location or type.

--- a/make.paws/tests/testthat/test_make_docs.R
+++ b/make.paws/tests/testthat/test_make_docs.R
@@ -98,6 +98,22 @@ test_that("convert", {
   expect_equal(convert(text), expected)
 })
 
+test_that("mask", {
+  foo <- list(
+    a = list(
+      "abc",
+      "xyz",
+      123
+    )
+  )
+  masks <- list("b" = "&#98;", "z" = "&#122;")
+  result <- mask(foo, masks)
+  expect_equal(result$a[[1]], "a&#98;c")
+  expect_equal(result$a[[2]], "xy&#122;")
+  expect_equal(result$a[[3]], foo$a[[3]])
+  expect_equal(foo, unmask(mask(foo, masks), masks))
+})
+
 test_that("first_sentence", {
   expect_equal(first_sentence(""), "")
   expect_equal(first_sentence("foo."), "foo")
@@ -121,7 +137,7 @@ test_that("make_doc_desc", {
   expect_equal(make_doc_desc(operation), expected)
 })
 
-test_that("make_doc_desc_with_percent_sign", {
+test_that("make_doc_desc with percent sign", {
   operation <- list(documentation = "<body><p>Foo%</p><p>Bar</p></body>")
   expected <- paste(
     "#' Foo\\%",
@@ -130,6 +146,81 @@ test_that("make_doc_desc_with_percent_sign", {
     sep = "\n"
   )
   expect_equal(make_doc_desc(operation), expected)
+})
+
+test_that("make_doc_usage", {
+  operation <- list(
+    name = "operation",
+    input = list(
+      shape = "OperationShape"
+    )
+  )
+  api <- list(
+    shapes = list(
+      OperationShape = list(
+        type = "structure",
+        members = list(
+          Foo = list(
+            shape = "FooShape"
+          ),
+          Bar = list(
+            shape = "BarShape"
+          )
+        )
+      ),
+      FooShape = list(
+        type = "string"
+      ),
+      BarShape = list(
+        type = "structure",
+        members = list(
+          Baz = list(
+            shape = "BazShape"
+          ),
+          Qux = list(
+            shape = "QuxShape"
+          ),
+          Quux = list(
+            shape = "QuuxShape"
+          ),
+          Quuz = list(
+            shape = "QuuzShape"
+          )
+        )
+      ),
+      BazShape = list(
+        type = "integer"
+      ),
+      QuxShape = list(
+        type = "double"
+      ),
+      QuuxShape = list(
+        type = "boolean"
+      ),
+      QuuzShape = list(
+        type = "enum",
+        enum = list(
+          "a", "b", "c"
+        )
+      )
+    )
+  )
+
+  actual <- make_doc_usage(operation, api)
+  expected <- paste(
+    "#' @usage",
+    "#' operation(",
+    "#'   Foo = \"string\",",
+    "#'   Bar = list(",
+    "#'     Baz = 123,",
+    "#'     Qux = 123.0,",
+    "#'     Quux = TRUE|FALSE,",
+    "#'     Quuz = \"a\"|\"b\"|\"c\"",
+    "#'   )",
+    "#' )",
+    sep = "\n"
+  )
+  expect_equal(actual, expected)
 })
 
 test_that("make_doc_params", {

--- a/make.paws/tests/testthat/test_make_interface.R
+++ b/make.paws/tests/testthat/test_make_interface.R
@@ -4,14 +4,18 @@ test_that("scalar", {
   api <- list(
     shapes = list(
       FooShape = list(
-        type = "string"
+        type = "string",
+        enum = list(
+          "value1",
+          "value2"
+        )
       )
     )
   )
   out <- make_shape(list(shape = "FooShape"), api = api)
   expect_length(out, 0)
   expect_equal(tag_get(out, "type"), "string")
-  expect_equal(tag_get(out, "shape"), "FooShape")
+  expect_equal(tag_get(out, "enum"), c("value1", "value2"))
 })
 
 test_that("structure with one scalar member", {


### PR DESCRIPTION
* Add a usage section to each function's documentation, showing all possible parameters and example values.
* Reorganize `make_docs.R` to put the `make_docs_...` functions at the top.
* Store enum values in the interfaces, and no longer store the shape name. We do not use shape name in the SDK packages, only when generating the packages.