### PR TITLE
Fix query unmarshal error, add custom S3 unmarshal error

### DIFF
--- a/make.paws/R/xmlutil.R
+++ b/make.paws/R/xmlutil.R
@@ -166,13 +166,14 @@ xml_unmarshal <- function(data, interface, result_name = NULL) {
 
 # Unmarshal errors in `data` provided as a list.
 xml_unmarshal_error <- function(data) {
-  code <- unlist(data$Error$Code)
-  message <- unlist(data$Error$Message)
-  
+  root <- data[[1]]
+  code <- unlist(root$Error$Code)
+  message <- unlist(root$Error$Message)
+
   if (is.null(message) && is.null(code)) {
     return(NULL)
   }
-  
+
   error <- Error(code, message)
   return(error)
 }

--- a/make.paws/tests/testthat/test_handlers_query.R
+++ b/make.paws/tests/testthat/test_handlers_query.R
@@ -716,7 +716,7 @@ test_that("unmarshal error", {
   expect_equal(out$message, "Foo")
 })
 
-test_that("unmarshal error no message", {
+test_that("unmarshal error with an empty message", {
   data <- "<ErrorResponse><Error><Code>FooError</Code><Message></Message><RequestId>123</RequestId><HostId>ABC</HostId></Error></ErrorResponse>"
   request$http_response$body <- charToRaw(data)
   request <- query_unmarshal_error(request)
@@ -724,11 +724,18 @@ test_that("unmarshal error no message", {
   expect_equal(out$code, "FooError")
 })
 
-test_that("unmarshal error wrong shape", {
+test_that("unmarshal error with invalid XML", {
+  data <- "abc"
+  request$http_response$body <- charToRaw(data)
+  request <- query_unmarshal_error(request)
+  out <- request$error
+  expect_equal(out$code, "SerializationError")
+})
+
+test_that("unmarshal error with the wrong shape", {
   data <- "<Foo><Code>FooError</Code><Message>Foo</Message><RequestId>123</RequestId><HostId>ABC</HostId></Foo>"
   request$http_response$body <- charToRaw(data)
   request <- query_unmarshal_error(request)
   out <- request$error
   expect_equal(out$code, "SerializationError")
-  expect_equal(out$message, "failed to decode query XML error response")
 })

--- a/make.paws/tests/testthat/test_handlers_query.R
+++ b/make.paws/tests/testthat/test_handlers_query.R
@@ -708,7 +708,7 @@ test_that("unmarshal enums", {
 request <- list()
 
 test_that("unmarshal error", {
-  data <- "<Error><Code>FooError</Code><Message>Foo</Message><RequestId>123</RequestId><HostId>ABC</HostId></Error>"
+  data <- "<ErrorResponse><Error><Code>FooError</Code><Message>Foo</Message><RequestId>123</RequestId><HostId>ABC</HostId></Error></ErrorResponse>"
   request$http_response$body <- charToRaw(data)
   request <- query_unmarshal_error(request)
   out <- request$error
@@ -717,12 +717,11 @@ test_that("unmarshal error", {
 })
 
 test_that("unmarshal error no message", {
-  data <- ""
+  data <- "<ErrorResponse><Error><Code>FooError</Code><Message></Message><RequestId>123</RequestId><HostId>ABC</HostId></Error></ErrorResponse>"
   request$http_response$body <- charToRaw(data)
   request <- query_unmarshal_error(request)
   out <- request$error
-  expect_equal(out$code, "SerializationError")
-  expect_equal(out$message, "failed to read from query HTTP response body")
+  expect_equal(out$code, "FooError")
 })
 
 test_that("unmarshal error wrong shape", {


### PR DESCRIPTION
* Fix the XML error response handler, which should expect a root element ("ErrorResponse").
* Add a custom S3 error response handler, which expects no root element.