### PR TITLE
Delete testthat.R file

### DIFF
--- a/make.paws/R/make_package.R
+++ b/make.paws/R/make_package.R
@@ -100,14 +100,12 @@ copy_customizations <- function(api, path) {
 
 # Generate tests for the package and write them to the tests folder.
 write_tests <- function(api, path) {
-  testthat <- make_testthat_file(api)
-  tests <- make_tests(api)
   package <- package_name(api)
   filename <- paste0("test_", package, ".R")
   test_path <- file.path(path, "tests")
-  testthat <- add_edit_warning(testthat)
+
+  tests <- make_tests(api)
   tests <- add_edit_warning(tests)
-  write_list(testthat, file.path(test_path, "testthat.R"))
   write_list(tests, file.path(test_path, "testthat", filename))
 }
 

--- a/make.paws/R/make_tests.R
+++ b/make.paws/R/make_tests.R
@@ -51,26 +51,6 @@ run_tests_internal <- function(path, timeout = 180) {
 
 #-------------------------------------------------------------------------------
 
-# Make the testthat.R file template.
-TESTTHAT_TEMPLATE <- make_code_template({
-  library(testthat)
-  library(.PACKAGE)
-  test_check(.PACKAGE_QUOTED)
-})
-
-# Make the contents of the testthat.R file which runs a package's tests.
-make_testthat_file <- function(api) {
-  name <- package_name(api)
-  result <- render_code_template(
-    template = TESTTHAT_TEMPLATE,
-    values = list(
-      .PACKAGE = as.symbol(name),
-      .PACKAGE_QUOTED = name
-    )
-  )
-  return(result)
-}
-
 # Make the individual test template.
 # The template must be defined outside `make_test` for code coverage to work.
 TEST_TEMPLATE <- make_code_template({

--- a/make.paws/tests/testthat/test_make_tests.R
+++ b/make.paws/tests/testthat/test_make_tests.R
@@ -17,21 +17,6 @@ format_test_code <- function(code) {
   return(result)
 }
 
-test_that("make_testthat_file", {
-  api <- list(
-    name = "example"
-  )
-  a <- make_testthat_file(api)
-  e <- code({
-    library(testthat)
-    library(paws.example)
-    test_check("paws.example")
-  })
-  actual <- format_test_code(a)
-  expected <- format_test_code(e)
-  expect_equal(actual, expected)
-})
-
 test_that("make_test no arguments", {
   operation <- list(
     name = "foo"


### PR DESCRIPTION
Delete all code for making the testthat.R file.

We actually don't need testthat.R for the command in our makefile to run a package's integration tests. It works without any changes.