### PR TITLE
Handle missing operation descriptions

### DIFF
--- a/make.paws/R/make_docs.R
+++ b/make.paws/R/make_docs.R
@@ -353,6 +353,7 @@ postprocess <- function(markdown) {
 
 # Convert HTML to markdown
 html_to_markdown <- function(html, wrap = TRUE) {
+  if (is.null(html)) return("")
   preprocessed <- preprocess(html)
   temp_in <- tempfile()
   write_utf8(preprocessed, temp_in)
@@ -371,6 +372,7 @@ html_to_markdown <- function(html, wrap = TRUE) {
 }
 
 html_to_text <- function(html) {
+  if (is.null(html)) return("")
   temp_in <- tempfile()
   write_utf8(html, temp_in)
   temp_out <- tempfile()

--- a/make.paws/tests/testthat/test_make_docs.R
+++ b/make.paws/tests/testthat/test_make_docs.R
@@ -62,6 +62,9 @@ test_that("postprocess", {
 })
 
 test_that("html_to_markdown", {
+  text <- NULL
+  expect_equal(html_to_markdown(text), "")
+
   text <- ""
   expect_equal(html_to_markdown(text), text)
 

--- a/make.paws/tests/testthat/test_make_docs.R
+++ b/make.paws/tests/testthat/test_make_docs.R
@@ -121,6 +121,10 @@ test_that("first_sentence", {
 })
 
 test_that("make_doc_title", {
+  operation <- list()
+  expected <- "#' "
+  expect_equal(make_doc_title(operation), expected)
+
   operation <- list(documentation = "<body><p>Foo. Bar.</p></body>")
   expected <- "#' Foo"
   expect_equal(make_doc_title(operation), expected)


### PR DESCRIPTION
Previously, `html_to_text` would fail if run on `NULL`, as when an operation had no description. Return `""` when the input is `NULL`.