### PR TITLE
Fix misc CRAN submission issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: r
 
 cache: packages
 
+r_github_packages:
+  - r-lib/covr
+
 install:
   - R -e "devtools::install_deps('paws.common', dep = T)"
   - R -e "devtools::install_deps('make.paws', dep = T)"

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ list:
 build: ${PACKAGES}
 	@echo "build the AWS SDK packages"
 
-${PACKAGES}:
+${PACKAGES}: deps
 	@echo "build $@"
 	@API=$$(grep -e "^$@\b" PACKAGES.txt | awk '{ print $$2 }') && \
 	Rscript -e "library(make.paws); make_package('$$API', '${IN_DIR}', '${OUT_DIR}')" && \

--- a/make.paws/DESCRIPTION
+++ b/make.paws/DESCRIPTION
@@ -29,8 +29,7 @@ Suggests:
     covr,
     testthat
 Remotes:
-    paws-r/paws/paws.common,
-    r-lib/covr
+    paws-r/paws/paws.common
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))
 RoxygenNote: 6.1.1

--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -1,13 +1,13 @@
 Package: paws.common
 Type: Package
-Title: Paws AWS SDK Common Functions
+Title: Paws Amazon Web Services API Package Common Functions
 Version: 0.1.0
 Authors@R: c(
     person("David", "Kretch", email = "david.kretch@gmail.com", role = c("aut", "cre")),
     person("Adam", "Banker", email = "adam.banker39@gmail.com", role = "aut"),
     person("Amazon.com, Inc.", role = "cph")
   )
-Description: Common functions for the Paws AWS SDKs.
+Description: Common functions for the Paws Amazon Web Services API packages.
 License: Apache License (>= 2.0)
 Encoding: UTF-8
 LazyData: true

--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R: c(
     person("Adam", "Banker", email = "adam.banker39@gmail.com", role = "aut"),
     person("Amazon.com, Inc.", role = "cph")
   )
-Description: paws.common provides common functions for the Paws AWS SDKs.
+Description: Common functions for the Paws AWS SDKs.
 License: Apache License (>= 2.0)
 Encoding: UTF-8
 LazyData: true
@@ -23,8 +23,6 @@ Imports:
 Suggests:
     covr,
     testthat
-Remotes:
-    r-lib/covr
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))
 RoxygenNote: 6.1.1

--- a/paws.common/R/request.R
+++ b/paws.common/R/request.R
@@ -16,7 +16,7 @@ Operation <- struct(
 #' @param name The API operation name.
 #' @param http_method The HTTP method, e.g. `"GET"` or `"POST"`.
 #' @param http_path The HTTP path.
-#' @param paginator Currently unusued.
+#' @param paginator Currently unused.
 #' @param before_presign_fn Currently unused.
 #'
 #' @export

--- a/paws.common/man/new_operation.Rd
+++ b/paws.common/man/new_operation.Rd
@@ -14,7 +14,7 @@ new_operation(name, http_method, http_path, paginator,
 
 \item{http_path}{The HTTP path.}
 
-\item{paginator}{Currently unusued.}
+\item{paginator}{Currently unused.}
 
 \item{before_presign_fn}{Currently unused.}
 }

--- a/paws.common/tests/testthat/test_net.R
+++ b/paws.common/tests/testthat/test_net.R
@@ -3,10 +3,10 @@ context("Network")
 test_that("issue", {
   req <- HttpRequest(
     method = "GET",
-    url = parse_url("https://jsonplaceholder.typicode.com/todos/1")
+    url = parse_url("https://httpbin.org/json")
   )
   resp <- issue(req)
   expect_equal(resp$status_code, 200)
   expect_error(body <- jsonlite::fromJSON(rawToChar(resp$body)), NA)
-  expect_equal(body$id, 1)
+  expect_equal(body$slideshow$title, "Sample Slide Show")
 })


### PR DESCRIPTION
* The description cannot start with the package name.
* Remove typos and acronyms (e.g. "AWS" and "SDK") that get flagged as notes.
* Remove the Remotes section, which CRAN packages cannot have. Move the GitHub repo for `covr` to the Travis config file.
* Use `httpbin.org` to test network resources, like the `httr` package does.