### PR TITLE
Add lists of operations for each service in the generated docs

### DIFF
--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -226,7 +226,7 @@ escape_special_chars <- function(text) {
   result
 }
 
-# Escape unmatched characters. Assumes
+# Escape unmatched characters.
 # R documentation will fail if there are unmatched quotes in code snippets.
 # See https://developer.r-project.org/parseRd.pdf.
 escape_unmatched_quotes <- function(x) {

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -25,10 +25,7 @@ make_docs <- function(operation, api) {
 
 # Make the documentation title.
 make_doc_title <- function(operation) {
-  docs <- paste(html_to_text(operation$documentation), collapse = " ")
-  docs <- gsub(" +", " ", docs)
-  title <- first_sentence(docs)
-  title <- mask(title, c("[" = "&#91;", "]" = "&#93;"))
+  title <- get_operation_title(operation)
   title <- comment(break_lines(title), "#'")
   return(as.character(title))
 }
@@ -273,6 +270,15 @@ list_to_string <- function(x, quote = TRUE) {
   result <- paste0(result, ")")
 
   return(result)
+}
+
+# Returns the title of an operation (the first sentence of its description).
+get_operation_title <- function(operation) {
+  docs <- paste(html_to_text(operation$documentation), collapse = " ")
+  docs <- gsub(" +", " ", docs)
+  title <- first_sentence(docs)
+  title <- mask(title, c("[" = "&#91;", "]" = "&#93;"))
+  title
 }
 
 # Add example values, e.g. "string" for strings, to an input or output shape.

--- a/make.paws/R/service.R
+++ b/make.paws/R/service.R
@@ -85,6 +85,7 @@ service_description <- function(api) {
   paste("@description", desc, sep = "\n")
 }
 
+# Returns a list of the API's operations with links to their docs.
 service_operations <- function(api) {
   rows <- lapply(api$operations, function(op) {
     op_name <- get_operation_name(op)

--- a/make.paws/R/service.R
+++ b/make.paws/R/service.R
@@ -88,9 +88,9 @@ service_description <- function(api) {
 service_operations <- function(api) {
   rows <- lapply(api$operations, function(op) {
     op_name <- get_operation_name(op)
-    op_doc_title <- paste0(package_name(api), "_", op_name)
+    doc_name <- paste0(package_name(api), "_", op_name)
     data.frame(
-      name = link(text = op_name, ref = op_doc_title),
+      name = link(text = op_name, ref = doc_name),
       desc = get_operation_title(op)
     )
   })

--- a/make.paws/R/text.R
+++ b/make.paws/R/text.R
@@ -75,7 +75,7 @@ tabular <- function(df, ...) {
         contents, "\n}\n", sep = "")
 }
 
-# Return a single LaTeX link to a function in the same package.
+# Return a LaTeX link to a documentation page in the same package.
 # See https://cran.r-project.org/web/packages/roxygen2/vignettes/formatting.html
 link <- function(text, ref) {
   stopifnot(is.character(text) && length(text) == 1)

--- a/make.paws/R/text.R
+++ b/make.paws/R/text.R
@@ -58,3 +58,26 @@ unmask <- function(object, masks) {
   }
   return(mask(object, unmasks))
 }
+
+# Returns a LaTeX table, given a data frame.
+# Source: https://cran.r-project.org/web/packages/roxygen2/vignettes/formatting.html
+tabular <- function(df, ...) {
+  stopifnot(is.data.frame(df))
+
+  align <- function(x) if (is.numeric(x)) "r" else "l"
+  col_align <- vapply(df, align, character(1))
+
+  cols <- lapply(df, format, ...)
+  contents <- do.call("paste",
+                      c(cols, list(sep = " \\tab ", collapse = "\\cr\n  ")))
+
+  paste("\\tabular{", paste(col_align, collapse = ""), "}{\n  ",
+        contents, "\n}\n", sep = "")
+}
+
+# Return a single LaTeX link to a function in the same package.
+# See https://cran.r-project.org/web/packages/roxygen2/vignettes/formatting.html
+link <- function(text, ref) {
+  stopifnot(is.character(text) && length(text) == 1)
+  paste("\\link[=", ref, "]{", text, "}", sep = "")
+}


### PR DESCRIPTION
On each API's documentation page, add a list of all the operations supported, and links to each operation's individual documentation page.

Addresses issue #94 item "There would be a page in the documentation for each service, which links to its operations."