### PR TITLE
Fix Paws CRAN notes/warnings and other issues

### DIFF
--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -233,7 +233,7 @@ escape_special_chars <- function(text) {
   # Unicode character codes: \\uxxxx to `U+xxxx`
   result <- gsub("\\\\\\\\u([0-9a-fA-F]{4})", "`U+\\1`", result)
 
-  # Escape character codes: e.g. \n to `\\n`
+  # Control character codes: e.g. \n to `\\n`
   result <- gsub("(\\\\)+([a-zA-Z])\\b", "`\\\\\\\\\\2`", result)
 
   result

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -233,8 +233,8 @@ escape_special_chars <- function(text) {
   # Unicode character codes: \\uxxxx to `U+xxxx`
   result <- gsub("\\\\\\\\u([0-9a-fA-F]{4})", "`U+\\1`", result)
 
-  # Newline code: \\n to `\\n`
-  result <- gsub("\\\\\\\\n", "`\\\\n`", result)
+  # Escape character codes: e.g. \n to `\\n`
+  result <- gsub("(\\\\)+([a-zA-Z])\\b", "`\\\\\\\\\\2`", result)
 
   result
 }

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -52,7 +52,7 @@ make_doc_usage <- function(operation, api) {
   service_name <- package_name(api)
   operation_name <- get_operation_name(operation)
   args <- paste(params, collapse = ", ")
-  usage <- glue::glue("{service_name}${operation_name}({args})")
+  usage <- glue::glue("{service_name}_{operation_name}({args})")
   usage <- break_lines(usage, at = c("\\s", "\\("))
   usage <- gsub("\n *$", "", usage) # delete empty lines
   usage <- gsub("\n", "\n  ", usage) # indent subsequent lines

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -54,7 +54,8 @@ make_doc_usage <- function(operation, api) {
   args <- paste(params, collapse = ", ")
   usage <- glue::glue("{service_name}${operation_name}({args})")
   usage <- break_lines(usage, at = c("\\s", "\\("))
-  usage <- gsub("\n", "\n  ", usage)
+  usage <- gsub("\n *$", "", usage) # delete empty lines
+  usage <- gsub("\n", "\n  ", usage) # indent subsequent lines
   usage <- comment(usage, "#'")
   usage <- paste("#' @usage", usage, sep = "\n")
   usage
@@ -163,6 +164,7 @@ first_sentence <- function(x) {
 break_lines <- function(s, chars = 72, at = "\\s") {
   regex <- sprintf("(.{1,%i})(%s|$)", chars, paste(at, collapse = "|"))
   result <- gsub(regex, "\\1\\2\n", s)
+  result <- gsub(" +\n", "\n", result)
   return(result)
 }
 

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -218,11 +218,24 @@ clean_html_node <- function(node) {
 # See https://developer.r-project.org/parseRd.pdf.
 escape_special_chars <- function(text) {
   result <- text
+
+  # Single \ -- not following another \ and not preceding a special character
   result <- gsub("(?<!\\\\)\\\\(?![\\\\%{}'\"`\\*~\\[\\]])", "\\\\\\\\", result, perl = TRUE)
-  result <- gsub("`\\`", "`\\\\`", result, fixed = TRUE) # Special case: `\`
+
+  # Special case: `\`
+  result <- gsub("`\\`", "`\\\\`", result, fixed = TRUE)
+
+  # Special characters -- not already escaped
   for (char in c("%", "{", "}")) {
     result <- gsub(paste0("(?<!\\\\)", char), paste0("\\\\", char), result, perl = TRUE)
   }
+
+  # Unicode character codes: \\uxxxx to `U+xxxx`
+  result <- gsub("\\\\\\\\u([0-9a-fA-F]{4})", "`U+\\1`", result)
+
+  # Newline code: \\n to `\\n`
+  result <- gsub("\\\\\\\\n", "`\\\\n`", result)
+
   result
 }
 

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -278,6 +278,10 @@ get_operation_title <- function(operation) {
   docs <- gsub(" +", " ", docs)
   title <- first_sentence(docs)
   title <- mask(title, c("[" = "&#91;", "]" = "&#93;"))
+  if (length(title) == 0 || title == "") {
+    title <- gsub("_", " ", get_operation_name(operation))
+    substr(title, 1, 1) <- toupper(substr(title, 1, 1))
+  }
   title
 }
 

--- a/make.paws/R/operations.R
+++ b/make.paws/R/operations.R
@@ -40,7 +40,7 @@ operation_template <- template(
     response <- send_request(request)
     return(response)
   }
-  ${service}$${function_name} <- ${service}_${function_name}
+  .${service}$operations$${function_name} <- ${service}_${function_name}
   `
 )
 

--- a/make.paws/R/service.R
+++ b/make.paws/R/service.R
@@ -14,7 +14,7 @@ service_file_template <- template(
   #' ${operations}
   #'
   #' @section Using operations:
-  #' ${service} <- paws::${service}
+  #' ${service} <- paws::${service}()
   #' ${service}$operation()
   #'
   #' @rdname ${service}
@@ -82,7 +82,7 @@ service_description <- function(api) {
     if (desc[1] == service_title(api)) desc <- desc[-1]
     if (desc[1] == "") desc <- desc[-1]
   }
-  desc <- comment(desc, "#'")
+  desc <- comment(paste(desc, collapse = "\n"), "#'")
   paste("@description", desc, sep = "\n")
 }
 

--- a/make.paws/R/service.R
+++ b/make.paws/R/service.R
@@ -11,11 +11,9 @@ service_file_template <- template(
   #'
   #' ${description}
   #'
-  #' ${operations}
+  #' ${example}
   #'
-  #' @section Using operations:
-  #' ${service} <- paws::${service}()
-  #' ${service}$operation()
+  #' ${operations}
   #'
   #' @rdname ${service}
   #' @export
@@ -53,6 +51,7 @@ make_service <- function(api) {
     service_file_template,
     title = service_title(api),
     description = service_description(api),
+    example = service_example(api),
     operations = service_operations(api),
     service = package_name(api),
     protocol = protocol_package(api),
@@ -84,6 +83,20 @@ service_description <- function(api) {
   }
   desc <- comment(paste(desc, collapse = "\n"), "#'")
   paste("@description", desc, sep = "\n")
+}
+
+# Returns an example showing how to use the service.
+# It was necessary to separate this from the template because the template
+# can't contain ` characters.
+service_example <- function(api) {
+  service <- package_name(api)
+  glue::glue(gsub("^ +", "",
+  "@section Example:
+  #' ```
+  #' {service} <- paws::{service}()
+  #' {service}$operation()
+  #' ```
+  "))
 }
 
 # Returns a list of the API's operations with links to their docs.

--- a/make.paws/R/service.R
+++ b/make.paws/R/service.R
@@ -13,7 +13,7 @@ service_file_template <- template(
   #'
   #' ${operations}
   #'
-  #' @usage
+  #' @section Using operations:
   #' ${service} <- paws::${service}
   #' ${service}$operation()
   #'

--- a/make.paws/R/service.R
+++ b/make.paws/R/service.R
@@ -17,15 +17,16 @@ service_file_template <- template(
   #' ${service} <- paws::${service}
   #' ${service}$operation()
   #'
-  #' @format
-  #' A list of operations for ${title}.
-  #'
   #' @rdname ${service}
   #' @export
-  ${service} <- list()
+  ${service} <- function() {
+    .${service}$operations
+  }
 
   # Private API objects: metadata, handlers, interfaces, etc.
   .${service} <- list()
+
+  .${service}$operations <- list()
 
   .${service}$metadata <- list(
     service_name = ${service_name},

--- a/make.paws/R/tests.R
+++ b/make.paws/R/tests.R
@@ -32,7 +32,8 @@ make_tests <- function(api) {
 test_template <- template(
   `
   test_that(${operation_name}, {
-    expect_error(${call}, ${outcome})
+    svc <- paws::${service_name}()
+    expect_error(svc$${call}, ${outcome})
   })
   `
 )
@@ -41,10 +42,10 @@ test_template <- template(
 make_test <- function(operation, api, args, outcome) {
   operation <- get_operation_name(operation)
   service <- package_name(api)
-  fn <- sprintf("%s$%s", service, operation)
-  call <- make_call(fn, args)
+  call <- make_call(operation, args)
   test <- render(
     test_template,
+    service_name = service,
     operation_name = quoted(operation),
     call = call,
     outcome = outcome

--- a/make.paws/R/tests.R
+++ b/make.paws/R/tests.R
@@ -3,7 +3,9 @@ NULL
 
 test_file_template <- template(
   `
-  context(${service})
+  context("${service}")
+
+  svc <- paws::${service}()
 
   ${tests}
   `
@@ -23,7 +25,7 @@ make_tests <- function(api) {
   tests <- paste(tests, collapse = "\n\n")
   render(
     test_file_template,
-    service = quoted(package_name(api)),
+    service = package_name(api),
     tests = tests
   )
 }
@@ -31,8 +33,7 @@ make_tests <- function(api) {
 # Make the individual test template.
 test_template <- template(
   `
-  test_that(${operation_name}, {
-    svc <- paws::${service_name}()
+  test_that("${operation_name}", {
     expect_error(svc$${call}, ${outcome})
   })
   `
@@ -45,8 +46,7 @@ make_test <- function(operation, api, args, outcome) {
   call <- make_call(operation, args)
   test <- render(
     test_template,
-    service_name = service,
-    operation_name = quoted(operation),
+    operation_name = operation,
     call = call,
     outcome = outcome
   )

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -375,6 +375,10 @@ test_that("convert", {
   text <- "<body><p>foo</p><p>bar<code>'baz</code></p></body>"
   expected <- c("foo", "", "bar`\\'baz`")
   expect_equal(convert(text), expected)
+
+  text <- "<p>foo \\a \\b</p>"
+  expected <- c("foo `\\\\a` `\\\\b`")
+  expect_equal(convert(text), expected)
 })
 
 test_that("first_sentence", {

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -1,8 +1,8 @@
 context("Make documentation")
 
 test_that("make_doc_title", {
-  operation <- list()
-  expected <- "#' "
+  operation <- list(name = "FooOperation")
+  expected <- "#' Foo operation"
   expect_equal(make_doc_title(operation), expected)
 
   operation <- list(documentation = "<body><p>Foo. Bar.</p></body>")

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -365,7 +365,7 @@ test_that("convert", {
   expect_equal(convert(text), expected)
 
   text <- "<body>foo \\bar { \\u0123 <code>baz'</code></body>"
-  expected <- "foo \\\\bar \\{ \\\\u0123 `baz\\'`"
+  expected <- "foo \\\\bar \\{ `U+0123` `baz\\'`"
   expect_equal(convert(text), expected)
 
   text <- '<p> <code>{ "actors": {}, "title": {"format": "text","max_phrases": 2,"pre_tag": "<b>","post_tag": "</b>"} }</code></p>'

--- a/make.paws/tests/testthat/test_operations.R
+++ b/make.paws/tests/testthat/test_operations.R
@@ -42,7 +42,7 @@ test_that("make_operation", {
     #' Foo.
     #'
     #' @usage
-    #' api$operation(Input1, Input2, Input3)
+    #' api_operation(Input1, Input2, Input3)
     #'
     #' @param Input1
     #' @param Input2

--- a/make.paws/tests/testthat/test_operations.R
+++ b/make.paws/tests/testthat/test_operations.R
@@ -71,7 +71,7 @@ test_that("make_operation", {
       response <- send_request(request)
       return(response)
     }
-    api$operation <- api_operation")
+    .api$operations$operation <- api_operation")
 
   actual <- formatR::tidy_source(text = a, output = FALSE)
   expected <- formatR::tidy_source(text = e, output = FALSE)

--- a/make.paws/tests/testthat/test_operations.R
+++ b/make.paws/tests/testthat/test_operations.R
@@ -41,6 +41,9 @@ test_that("make_operation", {
     #'
     #' Foo.
     #'
+    #' @usage
+    #' api$operation(Input1, Input2, Input3)
+    #'
     #' @param Input1
     #' @param Input2
     #' @param Input3

--- a/make.paws/tests/testthat/test_tests.R
+++ b/make.paws/tests/testthat/test_tests.R
@@ -29,7 +29,7 @@ test_that("make_test no arguments", {
   a <- make_test(operation, api, NULL, NA)
   e <- code({
     test_that("foo", {
-      expect_error(api$foo(), NA)
+      expect_error(svc$foo(), NA)
     })
   })
   actual <- format_test_code(a)
@@ -49,7 +49,7 @@ test_that("make_test with arguments", {
   a <- make_test(operation, api, list('"bar"', 123), NA)
   e <- code({
     test_that("foo", {
-      expect_error(api$foo("bar", 123), NA)
+      expect_error(svc$foo("bar", 123), NA)
     })
   })
   actual <- format_test_code(a)
@@ -105,16 +105,18 @@ test_that("make_tests", {
   e <- code({
     context("api")
 
+    svc <- paws::api()
+
     test_that("describe_foo", {
-      expect_error(api$describe_foo(), NA)
+      expect_error(svc$describe_foo(), NA)
     })
 
     test_that("describe_foo", {
-      expect_error(api$describe_foo(MaxResults = 20), NA)
+      expect_error(svc$describe_foo(MaxResults = 20), NA)
     })
 
     test_that("list_bar", {
-      expect_error(api$list_bar(), NA)
+      expect_error(svc$list_bar(), NA)
     })
   })
   actual <- format_test_code(a)


### PR DESCRIPTION
* If an operation has no documentation, make the operation name into the documentation title. This fixes warnings for operations that were missing titles.

* Fix the "unknown macro" warnings by changing "\\uxxxx" to "`U+xxxx`" and control characters e.g. "\n" to "`\\n`".

* Fix the service descriptions, which were cut off after the first line.

* Break long lines in the usage section to avoid R CMD check warnings.

* Make the service objects (e.g. `ec2`) into functions. Example usage: `ec2 <- paws::ec2()`.

    This is in anticipation of the future Paws API, in which you would set custom configuration for each API (e.g. change the region, endpoint, etc.) by adding arguments to the function.

    Currently the service functions accept no arguments. This means that code written against this API will run in future versions that accept some arguments, but code written against future versions won't run in this version, which I think is desireable.
