### PR TITLE
Fix CRAN warnings

### DIFF
--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -134,9 +134,12 @@ make_doc_example <- function(example, op_name) {
   lines <- strsplit(call, "\n")[[1]]
   truncated <- lapply(lines, function(x) {
     trunc <- gsub('^(.{92})(.*)"(.)?$', '\\1..."\\3', x)
+    # Delete extra unmatched quotation marks.
     if (stringr::str_count(trunc, '\"') %% 2 != 0) {
       trunc <- gsub('\\\\"[^"]*"(,)?$', '..."\\1', trunc)
     }
+    # Fix special case \..." -> ..." (extra backslash)
+    trunc <- gsub('\\\\+(\\.){3}"(,)?$', '..."\\2', trunc)
     trunc
   })
   call <- paste(truncated, collapse = "\n")

--- a/make.paws/R/utils.R
+++ b/make.paws/R/utils.R
@@ -1,8 +1,9 @@
 # Return a call defining the structure of the given object x.
 get_structure <- function(x) {
-  result <- paste(deparse(x), collapse = "")
+  result <- paste(deparse(x, width.cutoff = 500), collapse = "")
   result <- gsub(" *, *", ", ", result)
   result <- gsub(" *= *", " = ", result)
+  result <- gsub("\\( +", "(", result)
   result
 }
 


### PR DESCRIPTION
* Avoid extra backslashes at the end of strings in the examples, e.g. `"abc\..."`.
* Delete extra spaces in very long structures due to line breaks, e.g. `structure(foo = list(    bar = ...))`.