### PR TITLE
Fix IAM credential provider

### DIFF
--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: paws.common
 Type: Package
 Title: Paws Low-Level Amazon Web Services API
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(
         person("David", "Kretch", email = "david.kretch@gmail.com", role = c("aut", "cre")),
         person("Adam", "Banker", email = "adam.banker39@gmail.com", role = "aut"),

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -60,7 +60,7 @@ get_iam_role <- function() {
 
   if (is.null(iam_role_response)) return(NULL)
 
-  iam_role_response_body <- jsonlite::fromJSON(iam_role_response$body)
+  iam_role_response_body <- jsonlite::fromJSON(rawToChar(iam_role_response$body))
   iam_instance_prof_arn <- iam_role_response_body$InstanceProfileArn
 
   iam_role <- basename(iam_instance_prof_arn)

--- a/paws.common/R/credential_providers.R
+++ b/paws.common/R/credential_providers.R
@@ -80,7 +80,7 @@ iam_credentials_provider <- function() {
 
   if (is.null(credentials_response)) return(NULL)
 
-  credentials_response_body <- jsonlite::fromJSON(credentials_response$body)
+  credentials_response_body <- jsonlite::fromJSON(rawToChar(credentials_response$body))
 
   access_key_id <- credentials_response_body$AccessKeyId
   secret_access_key <- credentials_response_body$SecretAccessKey

--- a/paws.common/R/signer_v4.R
+++ b/paws.common/R/signer_v4.R
@@ -129,9 +129,11 @@ sign_with_body <- function(signer, request, body, service, region,
     unsigned_payload = signer$unsigned_payload
   )
 
-  # TODO: Fix.
-  sort_list <- function(x) x[sort(names(x))]
-  if (!is.null(ctx$query)) {
+  sort_list <- function(x) {
+    if (length(x) == 0) return(x)
+    x[sort(names(x))]
+  }
+  if (!is.null(ctx$query) && length(ctx$query) > 0) {
     ctx$query <- sort_list(ctx$query)
   }
 


### PR DESCRIPTION
* Convert EC2 metadata response body from raw to char before attempting to decode its JSON payload. (#169)
* Fix warning when attempting to sort zero query parameters by checking for a non-empty list before sorting.