### PR TITLE
Update paws.common version number to 0.2.0

### DIFF
--- a/cran/paws.analytics/DESCRIPTION
+++ b/cran/paws.analytics/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services analytics APIs,
     'Elasticsearch' search engine, and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.application.integration/DESCRIPTION
+++ b/cran/paws.application.integration/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Interface to Amazon Web Services application
     messaging, and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.business.applications/DESCRIPTION
+++ b/cran/paws.business.applications/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services business
     email and calendar service, and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.compute/DESCRIPTION
+++ b/cran/paws.compute/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Interface to Amazon Web Services compute APIs,
     <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.cost.management/DESCRIPTION
+++ b/cran/paws.cost.management/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services cost management
     <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.customer.engagement/DESCRIPTION
+++ b/cran/paws.customer.engagement/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services customer
     center service, and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.database/DESCRIPTION
+++ b/cran/paws.database/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services database APIs,
     database, and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.developer.tools/DESCRIPTION
+++ b/cran/paws.developer.tools/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Interface to Amazon Web Services developer tools
     <https://aws.amazon.com/products/developer-tools/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.end.user.computing/DESCRIPTION
+++ b/cran/paws.end.user.computing/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services end user computing
     more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.game.development/DESCRIPTION
+++ b/cran/paws.game.development/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services game development
     <https://aws.amazon.com/gametech/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.internet.of.things/DESCRIPTION
+++ b/cran/paws.internet.of.things/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services internet of things
     IoT devices. <https://aws.amazon.com/iot/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.machine.learning/DESCRIPTION
+++ b/cran/paws.machine.learning/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Interface to Amazon Web Services machine learning
     <https://aws.amazon.com/machine-learning/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.management/DESCRIPTION
+++ b/cran/paws.management/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Interface to Amazon Web Services management and
     more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.media.services/DESCRIPTION
+++ b/cran/paws.media.services/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services media services
     conversion, and more <https://aws.amazon.com/media-services/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.migration/DESCRIPTION
+++ b/cran/paws.migration/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services migration &
     Services <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.mobile/DESCRIPTION
+++ b/cran/paws.mobile/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services mobile APIs,
     back-end for mobile applications, and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.networking/DESCRIPTION
+++ b/cran/paws.networking/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Interface to Amazon Web Services networking and
     <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.robotics/DESCRIPTION
+++ b/cran/paws.robotics/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services robotics APIs,
     intelligent robotics applications <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.security.identity/DESCRIPTION
+++ b/cran/paws.security.identity/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Interface to Amazon Web Services security,
     resources, and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.storage/DESCRIPTION
+++ b/cran/paws.storage/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services storage APIs,
     <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.1.3)
+    paws.common (>= 0.2.0)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/make.paws/R/cran_category.R
+++ b/make.paws/R/cran_category.R
@@ -14,7 +14,7 @@ make_category <- function(category, sdk_dir, out_dir) {
   services <- category$services
   title <- category$title
   description <- category$description
-  imports <- "paws.common (>= 0.1.3)"
+  imports <- "paws.common (>= 0.2.0)"
   version <- get_version(sdk_dir)
 
   if (is.null(name) || is.null(title) || is.null(description)) {

--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: paws.common
 Type: Package
 Title: Paws Low-Level Amazon Web Services API
-Version: 0.1.3
+Version: 0.2.0
 Authors@R: c(
         person("David", "Kretch", email = "david.kretch@gmail.com", role = c("aut", "cre")),
         person("Adam", "Banker", email = "adam.banker39@gmail.com", role = "aut"),


### PR DESCRIPTION
The latest paws.common breaks with earlier versions of paws, so update the version number.