### PR TITLE
Support old endpoint format

### DIFF
--- a/paws.common/R/client.R
+++ b/paws.common/R/client.R
@@ -81,6 +81,10 @@ resolver_endpoint <- function(service, region, endpoints, scheme = "https") {
     return(match)
   }
   e <- endpoints[[get_region_pattern(region, endpoints)]]
+  # TODO: Delete old endpoint format handling once all packages are updated.
+  if (is.character(e)) {
+    e <- list(endpoint = e, global = FALSE)
+  }
   endpoint <- gsub("{service}", service, e$endpoint, fixed = TRUE)
   endpoint <- gsub("{region}", region, endpoint, fixed = TRUE)
   endpoint <- gsub("^(.+://)?", sprintf("%s://", scheme), endpoint)

--- a/paws.common/tests/testthat/test_client.R
+++ b/paws.common/tests/testthat/test_client.R
@@ -19,3 +19,15 @@ test_that("resolver_endpoint", {
   expect_equal(r$endpoint, "https://us-west.amazonaws.com")
   expect_equal(r$signing_region, "us-east-1")
 })
+
+test_that("resolver_endpoint old endpoint format handling", {
+  endpoints <- list(
+    "*" = "{service}.{region}.amazonaws.com",
+    "us-east-*" = "https://{service}.amazonaws.com",
+    "us-west-*" = "http://us-west.amazonaws.com"
+  )
+
+  r <- resolver_endpoint("service", "region", endpoints)
+  expect_equal(r$endpoint, "https://service.region.amazonaws.com")
+  expect_equal(r$signing_region, "region")
+})


### PR DESCRIPTION
* Support the old endpoint format, used in the current CRAN packages.