### PR TITLE
Escape URIs, e.g. S3 query strings with non-alphanumeric characters

### DIFF
--- a/paws.common/R/handlers_rest.R
+++ b/paws.common/R/handlers_rest.R
@@ -219,15 +219,19 @@ rest_unmarshal_header_map <- function(values, prefix, type) {
 #-------------------------------------------------------------------------------
 
 # Return a URL with duplicate "/" characters removed.
-# TODO: Implement.
 clean_path <- function(url) {
+  url$path <- gsub("/+", "/", url$path)
+  url$raw_path <- gsub("/+", "/", url$raw_path)
   return(url)
 }
 
 # Return a string with special characters escaped, e.g. " " -> "%20".
-# TODO: Implement.
 escape_path <- function(string, encode_sep) {
-  return(string)
+  path <- URLencode(string, TRUE)
+  if (!encode_sep) {
+    path <- gsub("%2F", "/", path)
+  }
+  return(path)
 }
 
 # Return the type of a payload if there is one, otherwise return "".

--- a/paws.common/tests/testthat/test_handlers_rest.R
+++ b/paws.common/tests/testthat/test_handlers_rest.R
@@ -1,0 +1,51 @@
+context("REST")
+
+test_that("clean_path", {
+  url <- Url(
+    path = "//foo//bar",
+    scheme = "https",
+    host = "host"
+  )
+  actual <- build_url(clean_path(url))
+  expected <- "https://host/foo/bar"
+  expect_equal(actual, expected)
+})
+
+test_that("escape_path", {
+  string <- "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~`!@#$%^&*()=+[{]}\\|;:'\",<>/?"
+  actual <- escape_path(string, FALSE)
+  expected <- "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~%60%21%40%23%24%25%5E%26%2A%28%29%3D%2B%5B%7B%5D%7D%5C%7C%3B%3A%27%22%2C%3C%3E/%3F"
+  expect_equal(actual, expected)
+})
+
+svc <- Client(
+  client_info = ClientInfo(
+    endpoint = "https://test"
+  )
+)
+svc$handlers$build <- HandlerList(rest_build)
+
+test_that("build request with URL requiring escaping", {
+  op1 <- Operation(
+    name = "OperationName",
+    http_method = "GET",
+    http_path = "/{bucket}/{key+}"
+  )
+  op_input1 <- function(Bucket, Key) {
+    args <- list(Bucket = Bucket, Key = Key)
+    interface <- Structure(
+      Bucket = Scalar(type = "string", .tags = list(location = "uri", locationName = "bucket")),
+      Key = Scalar(type = "string", .tags = list(location = "uri", locationName = "key"))
+    )
+    return(populate(args, interface))
+  }
+  input <- op_input1(
+    Bucket = "mybucket",
+    Key = "my/cool+thing space/object世界"
+  )
+  req <- new_request(svc, op1, input, NULL)
+  req <- build(req)
+  r <- req$http_request
+  expect_equal(r$url$path, "/mybucket/my/cool+thing space/object世界")
+  expect_equal(r$url$raw_path, "/mybucket/my/cool%2Bthing%20space/object%E4%B8%96%E7%95%8C")
+})


### PR DESCRIPTION
This bug fix allows uploading files to S3 with paths like "a=b/foo".  Previously, characters like "=" were not escaped and this caused the operation to fail.