### PR TITLE
Add utils package qualification for URLencode

### DIFF
--- a/paws.common/R/handlers_rest.R
+++ b/paws.common/R/handlers_rest.R
@@ -227,7 +227,7 @@ clean_path <- function(url) {
 
 # Return a string with special characters escaped, e.g. " " -> "%20".
 escape_path <- function(string, encode_sep) {
-  path <- URLencode(string, TRUE)
+  path <- utils::URLencode(string, TRUE)
   if (!encode_sep) {
     path <- gsub("%2F", "/", path)
   }


### PR DESCRIPTION
R CMD check throws a note for URLencode without utils::.