### PR TITLE
Make XML requests skip empty arguments

### DIFF
--- a/paws.common/R/xmlutil.R
+++ b/paws.common/R/xmlutil.R
@@ -136,6 +136,7 @@ xml_build_scalar <- function(params) {
   # converts <foo>abc</foo> to `list(foo = list("abc"))`, when we want
   # `list(foo = "abc")`.
   data <- unlist(params)
+  if (length(data) == 0) return(NULL)
   t <- tag_get(params, "type")
   convert <- switch(
     t,

--- a/paws.common/R/xmlutil.R
+++ b/paws.common/R/xmlutil.R
@@ -95,7 +95,7 @@ xml_build_structure <- function(params) {
 
     parsed <- xml_build(child)
 
-    if (!is.null(parsed)) {
+    if (length(parsed) > 0) {
       location_name <- tag_get(child, "locationName")
       if (location_name == "") location_name <- name
 

--- a/paws.common/tests/testthat/test_handlers_restxml.R
+++ b/paws.common/tests/testthat/test_handlers_restxml.R
@@ -13,7 +13,7 @@ svc$handlers$build <- HandlerList(restxml_build)
 
 #-------------------------------------------------------------------------------
 
-# Rest tests
+# REST tests
 
 test_that("no parameters", {
   op1 <- Operation(
@@ -237,7 +237,7 @@ test_that("Basic XML Case1", {
     Description = "bar",
     Name = "foo"
   )
-  
+
   req <- new_request(svc, op_test, input, NULL)
   req <- build(req)
   r <- req$body
@@ -433,7 +433,7 @@ test_that("List of Structures Case1", {
           list(Element = "three")
       )
   )
-  
+
   req <- new_request(svc, op_test, input, NULL)
   req <- build(req)
   r <- req$body
@@ -462,6 +462,28 @@ test_that("Blob Case1", {
   r <- req$body
   expect_equal(r, '<OperationRequest xmlns="https://foo/"><StructureParam xmlns="https://foo/"><b xmlns="https://foo/">Zm9v</b></StructureParam></OperationRequest>')
 })
+
+test_that("skip empty argument", {
+  op_test <- Operation(name = "OperationName")
+  op_input_test <- function(Description, Name = NULL) {
+    args <- list(Description = Description, Name = Name)
+    interface <- Structure(
+      Description = Scalar(type = "string"),
+      Name = Scalar(type = "string"),
+      .tags = list(locationName = "OperationRequest", xmlURI = "https://foo/")
+    )
+    return(populate(args, interface))
+  }
+  input <- op_input_test(
+    Description = "bar"
+  )
+
+  req <- new_request(svc, op_test, input, NULL)
+  req <- build(req)
+  r <- req$body
+  expect_equal(r, '<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">bar</Description></OperationRequest>')
+})
+
 
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
Currently, `xml_build_structure` is designed to skip empty arguments, but since it uses `!is.null`, it will process everything that gets a default value like `logical(0)`, which is not null.

This means that if you fail to supply an argument, it will still appear in the request body like `<Foo/>`.

This merge request corrects that by checking for `length(x) > 0`, and also by explicitly converting all scalars of length 0 to NULL.