### PR TITLE
Clarify custom config not yet on CRAN

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -8,7 +8,7 @@ credentials.
 Credentials can be set in the following five ways, and Paws will look
 for them in this order.
 
-1.  Custom service config.
+1.  Custom service config. (NOT YET AVAILABLE ON CRAN)
 2.  R environment variables.
 3.  System environment variables (Mac and Linux Only).
 4.  AWS credentials file.
@@ -18,7 +18,9 @@ If you are running the package on an instance with an appropriate IAM
 role, Paws will use it automatically and you don’t need to do anything
 extra.
 
-## Setting Credentials with Custom Service Config
+## Setting Credentials with Custom Service Config*
+
+\* Option not yet available on CRAN
 
 Pass in the credentials directly for a given service with the following
 command:
@@ -103,12 +105,14 @@ In order to use a Paws package, you must also set your AWS region.
 
 Paws will look for the region in the following four places, in order:
 
-1.  Custom service config.
+1.  Custom service config. (NOT YET AVAILABLE ON CRAN)
 2.  `AWS_REGION` R environment variable.
 3.  `AWS_REGION` system environment variable (Mac and Linux Only).
 4.  AWS config file.
 
-## Setting Region with Custom Service Config
+## Setting Region with Custom Service Config*
+
+\* Option not yet available on CRAN
 
 Pass in the region directly for a given service with the following
 command:
@@ -172,11 +176,13 @@ profile.
 However, you may want to use another profile, which you can choose in
 the following ways:
 
-1.  Custom service config.
+1.  Custom service config. (NOT YET AVAILABLE ON CRAN)
 2.  `AWS_PROFILE` R environment variable.
 3.  `AWS_PROFILE` system environment variable - (Mac and Linux Only)
 
-## Setting Profile with Custom Service Config
+## Setting Profile with Custom Service Config*
+
+\* Option not yet available on CRAN
 
 Pass in the profile directly for a given service with the following
 command:


### PR DESCRIPTION
Updated doc/credentials.md to alert users that the custom config option is only available in the development version and not on CRAN