### PR TITLE
Update paws.common version number

### DIFF
--- a/cran/paws.analytics/DESCRIPTION
+++ b/cran/paws.analytics/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services analytics APIs, including
     'Elasticsearch' search engine, and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.application.integration/DESCRIPTION
+++ b/cran/paws.application.integration/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Interface to Amazon Web Services application integration
     <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.business.applications/DESCRIPTION
+++ b/cran/paws.business.applications/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services business applications APIs,
     service, and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.compute/DESCRIPTION
+++ b/cran/paws.compute/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services compute APIs, including
     containers, batch processing, and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.cost.management/DESCRIPTION
+++ b/cran/paws.cost.management/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services cost management APIs,
     <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.customer.engagement/DESCRIPTION
+++ b/cran/paws.customer.engagement/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services customer engagement APIs,
     and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.database/DESCRIPTION
+++ b/cran/paws.database/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services database APIs, including
     and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.developer.tools/DESCRIPTION
+++ b/cran/paws.developer.tools/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services developer tools APIs,
     more <https://aws.amazon.com/products/developer-tools/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.end.user.computing/DESCRIPTION
+++ b/cran/paws.end.user.computing/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services end user computing APIs,
     <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.game.development/DESCRIPTION
+++ b/cran/paws.game.development/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services game development APIs,
     <https://aws.amazon.com/gametech/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.internet.of.things/DESCRIPTION
+++ b/cran/paws.internet.of.things/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services internet of things ('IoT')
     devices. <https://aws.amazon.com/iot/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.machine.learning/DESCRIPTION
+++ b/cran/paws.machine.learning/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Interface to Amazon Web Services machine learning APIs,
     <https://aws.amazon.com/machine-learning/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.management/DESCRIPTION
+++ b/cran/paws.management/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Interface to Amazon Web Services management and governance
     more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.media.services/DESCRIPTION
+++ b/cran/paws.media.services/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services media services APIs,
     conversion, and more <https://aws.amazon.com/media-services/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.migration/DESCRIPTION
+++ b/cran/paws.migration/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services migration & transfer APIs,
     <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.mobile/DESCRIPTION
+++ b/cran/paws.mobile/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services mobile APIs, including the
     mobile applications, and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.networking/DESCRIPTION
+++ b/cran/paws.networking/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Interface to Amazon Web Services networking and content
     <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.robotics/DESCRIPTION
+++ b/cran/paws.robotics/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Interface to Amazon Web Services robotics APIs, including the
     robotics applications <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.security.identity/DESCRIPTION
+++ b/cran/paws.security.identity/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Interface to Amazon Web Services security, identity, and
     <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/cran/paws.storage/DESCRIPTION
+++ b/cran/paws.storage/DESCRIPTION
@@ -16,7 +16,7 @@ Description: Interface to Amazon Web Services storage APIs, including
     'Simple Storage Service' ('S3') and more <https://aws.amazon.com/>.
 License: Apache License (>= 2.0)
 Imports: 
-    paws.common (>= 0.2.3)
+    paws.common (>= 0.2.4)
 Suggests: 
     testthat
 Encoding: UTF-8

--- a/make.paws/R/cran_category.R
+++ b/make.paws/R/cran_category.R
@@ -14,7 +14,7 @@ make_category <- function(category, sdk_dir, out_dir) {
   services <- category$services
   title <- category$title
   description <- category$description
-  imports <- "paws.common (>= 0.2.3)"
+  imports <- "paws.common (>= 0.2.4)"
   version <- get_version(sdk_dir)
 
   if (is.null(name) || is.null(title) || is.null(description)) {

--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: paws.common
 Type: Package
 Title: Paws Low-Level Amazon Web Services API
-Version: 0.2.3
+Version: 0.2.4
 Authors@R: c(
         person("David", "Kretch", email = "david.kretch@gmail.com", role = c("aut", "cre")),
         person("Adam", "Banker", email = "adam.banker39@gmail.com", role = "aut"),

--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -1,3 +1,8 @@
+# paws.common 0.2.4
+
+* Add support for custom configuration per service, e.g.
+  `svc <- paws::svc(config = list(region = "us-west-1"))`.
+
 # paws.common 0.2.3
 
 * Fix support for non-default profiles in shared config files.


### PR DESCRIPTION
* Update paws.common version number to 0.2.4.
* Update all packages that depend on paws.common to require version 0.2.4.