### PR TITLE
Replaces double backticks with single backtick in example comments

### DIFF
--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -146,6 +146,8 @@ make_doc_example <- function(example, op_name) {
 
   call <- paste0("\\donttest{", call, "}")
   desc <- comment(break_lines(example$description))
+  # Replace double backticks with single backtick
+  desc <- gsub('``', '`', desc)
   result <- paste(desc, call, sep = "\n")
   return(result)
 }

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -146,8 +146,8 @@ make_doc_example <- function(example, op_name) {
 
   call <- paste0("\\donttest{", call, "}")
   desc <- comment(break_lines(example$description))
-  # Replace double backticks with single backtick
-  desc <- gsub('``', '`', desc)
+  # Replace exactly double backticks with single backtick
+  desc <- gsub("(?<!`)`{2}(?!`)", "`", desc, perl = T)
   result <- paste(desc, call, sep = "\n")
   return(result)
 }

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -351,6 +351,34 @@ test_that("make_doc_examples", {
     sep = "\n"
   )
   expect_equal(actual, expected)
+
+  operation <- list(
+    name = "Operation",
+    examples = list(
+      list(
+        input = list(
+          "Foo" = "bar",
+          "Baz" = list(
+            "Qux" = 123
+          )
+        ),
+        description = "Description with inline ```code```"
+      )
+    )
+  )
+  actual <- make_doc_examples(operation, api)
+  expected <- paste(
+    "#' @examples",
+    "#' # Description with inline ```code```",
+    "#' \\donttest{svc$operation(",
+    "#'   Foo = \"bar\",",
+    "#'   Baz = list(",
+    "#'     Qux = 123",
+    "#'   )",
+    "#' )}",
+    sep = "\n"
+  )
+  expect_equal(actual, expected)
 })
 
 test_that("clean_markdown", {

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -323,6 +323,34 @@ test_that("make_doc_examples", {
     sep = "\n"
   )
   expect_equal(actual, expected)
+
+  operation <- list(
+    name = "Operation",
+    examples = list(
+      list(
+        input = list(
+          "Foo" = "bar",
+          "Baz" = list(
+            "Qux" = 123
+          )
+        ),
+        description = "Description with inline ``code``"
+      )
+    )
+  )
+  actual <- make_doc_examples(operation, api)
+  expected <- paste(
+    "#' @examples",
+    "#' # Description with inline `code`",
+    "#' \\donttest{svc$operation(",
+    "#'   Foo = \"bar\",",
+    "#'   Baz = list(",
+    "#'     Qux = 123",
+    "#'   )",
+    "#' )}",
+    sep = "\n"
+  )
+  expect_equal(actual, expected)
 })
 
 test_that("clean_markdown", {


### PR DESCRIPTION
Replaces double backticks with single backticks in example comments for service functions. This makes it consistent with other R packages.