### PR TITLE
Handle null profile names when getting region

### DIFF
--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -100,7 +100,7 @@ get_os_env_variable <- function(var) {
 # Get the AWS profile to use. If none, return "default".
 get_profile_name <- function(profile = "") {
 
-  if (profile != "") return(profile)
+  if (!is.null(profile) && profile != "") return(profile)
 
   profile <- Sys.getenv("AWS_PROFILE")
 

--- a/paws.common/tests/testthat/test_config.R
+++ b/paws.common/tests/testthat/test_config.R
@@ -53,3 +53,9 @@ test_that("set_config", {
 
   expect_error(set_config(list(), list(foo = 123)))
 })
+
+test_that("get_region", {
+  Sys.setenv(AWS_REGION = "foo")
+  expect_equal(get_region(), "foo")
+  expect_equal(get_region(NULL), "foo")
+})

--- a/paws.common/tests/testthat/test_config.R
+++ b/paws.common/tests/testthat/test_config.R
@@ -59,3 +59,10 @@ test_that("get_region", {
   expect_equal(get_region(), "foo")
   expect_equal(get_region(NULL), "foo")
 })
+
+test_that("get_profile_name", {
+  Sys.setenv(AWS_PROFILE = "bar")
+  expect_equal(get_profile_name(), "bar")
+  expect_equal(get_profile_name(NULL), "bar")
+  expect_equal(get_profile_name("foo"), "foo")
+})


### PR DESCRIPTION
* Handle null profile names when getting region. This comes up when using an old paws package with the new paws.common.