### PR TITLE
Update AppVeyor config to fix recent errors

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,14 +23,6 @@ environment:
     - TEST_DIR: paws.common
     - TEST_DIR: make.paws
 
-for:
-  - 
-    matrix:
-      only:
-        - TEST_DIR: make.paws
-    build_script:
-      - Rscript -e "library(devtools); install('../paws.common')"
-
 before_build:
   - cp ../travis-tool.sh travis-tool.sh
   - cp travis-tool.sh.cmd %TEST_DIR%/travis-tool.sh.cmd
@@ -39,6 +31,14 @@ before_build:
 
 build_script:
   - travis-tool.sh install_deps
+
+for:
+  - 
+    matrix:
+      only:
+        - TEST_DIR: make.paws
+    after_build:
+      - Rscript -e "library(devtools); install('../paws.common', upgrade = FALSE)"
 
 before_test:
   - cinst pandoc


### PR DESCRIPTION
* A recent AppVeyor update caused the existing AppVeyor config to fail
when checking make.paws.  It was attempting to install the branch
paws.common (specified in the build_script for only make.paws) before
the general build_script, where it would fail because devtools was not
installed.  Now this step is specified in the after_build step, so it
will only run after the build_script.