### PR TITLE
Check the container role for credentials before the instance role

### DIFF
--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -111,6 +111,27 @@ get_profile_name <- function(profile = "") {
   return(profile)
 }
 
+# Gets the job role credentials by making an http request
+get_job_role_credentials <- function() {
+
+  credentials_uri <- Sys.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+  metadata_url <- file.path("http://169.254.170.2", credentials_uri)
+  metadata_request <-
+    new_http_request("GET", metadata_url)
+
+  metadata_response <- tryCatch({
+    issue(metadata_request)
+  }, error = function (e){
+    NULL
+  })
+
+  if (is.null(metadata_response) || metadata_response$status_code != 200) {
+    return(NULL)
+  }
+
+  return(metadata_response)
+}
+
 # Gets the instance metadata by making an http request
 get_instance_metadata <- function(query_path = "") {
 

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -112,7 +112,7 @@ get_profile_name <- function(profile = "") {
 }
 
 # Gets the job role credentials by making an http request
-get_job_role_credentials <- function() {
+get_container_credentials <- function() {
 
   credentials_uri <- Sys.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
   metadata_url <- file.path("http://169.254.170.2", credentials_uri)

--- a/paws.common/R/credential_providers.R
+++ b/paws.common/R/credential_providers.R
@@ -73,8 +73,16 @@ credentials_file_provider <- function() {
 # Retrieve credentials for ECS and EC2 IAM Role
 iam_credentials_provider <- function() {
 
+  # Initialize to NULL
+  credentials_response <- NULL
+
+  container_credentials_uri <-
+    Sys.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+
   # Look for job role credentials first
-  credentials_response <- get_job_role_credentials()
+  if (container_credentials_uri != "") {
+    credentials_response <- get_job_role_credentials()
+  }
 
   # Look for instance credentials if no job role credentials
   if (is.null(credentials_response)) {

--- a/paws.common/R/credentials.R
+++ b/paws.common/R/credentials.R
@@ -15,6 +15,7 @@ Credentials <- struct(
     r_env_provider,
     os_env_provider,
     credentials_file_provider,
+    container_credentials_provider,
     iam_credentials_provider,
     no_credentials
   )


### PR DESCRIPTION
It checks if the associated job role has credentials before checking the instance role. This pull request addresses #226. I tested it by running a batch job with the cran version of paws, as well as with my branch and it only worked on my branch as expected. I also tested out my branch on an ec2 instance with a proper role.

One issue is that running paws on an ec2 instance with a role takes longer because it needs to wait for the job role check to time out first. Let me know if you have any ideas for how to improve this.