### PR TITLE
Change definition lists to ordinary paragraphs

### DIFF
--- a/cran/paws.analytics/R/athena_operations.R
+++ b/cran/paws.analytics/R/athena_operations.R
@@ -532,8 +532,9 @@ athena_list_named_queries <- function(NextToken = NULL, MaxResults = NULL, WorkG
 #' specified workgroup. Requires you to have access to the workgroup in
 #' which the queries ran.
 #' 
-#' For code samples using the AWS SDK for Java, see Examples and Code
-#' Samples in the *Amazon Athena User Guide*.
+#' For code samples using the AWS SDK for Java, see [Examples and Code
+#' Samples](http://docs.aws.amazon.com/athena/latest/ug/code-samples.html)
+#' in the *Amazon Athena User Guide*.
 #'
 #' @usage
 #' athena_list_query_executions(NextToken, MaxResults, WorkGroup)
@@ -658,8 +659,9 @@ athena_list_work_groups <- function(NextToken = NULL, MaxResults = NULL) {
 #' Runs the SQL query statements contained in the `Query`. Requires you to
 #' have access to the workgroup in which the query ran.
 #' 
-#' For code samples using the AWS SDK for Java, see Examples and Code
-#' Samples in the *Amazon Athena User Guide*.
+#' For code samples using the AWS SDK for Java, see [Examples and Code
+#' Samples](http://docs.aws.amazon.com/athena/latest/ug/code-samples.html)
+#' in the *Amazon Athena User Guide*.
 #'
 #' @usage
 #' athena_start_query_execution(QueryString, ClientRequestToken,

--- a/cran/paws.analytics/R/glue_operations.R
+++ b/cran/paws.analytics/R/glue_operations.R
@@ -3682,55 +3682,53 @@ glue_get_partition <- function(CatalogId = NULL, DatabaseName, TableName, Partit
 #' *Operators*: The following are the operators that you can use in the
 #' `Expression` API call:
 #' 
-#' =
+#' ### =
 #' 
-#' :   Checks whether the values of the two operands are equal; if yes,
-#'     then the condition becomes true.
+#' Checks whether the values of the two operands are equal; if yes, then
+#' the condition becomes true.
 #' 
-#'     Example: Assume \'variable a\' holds 10 and \'variable b\' holds 20.
+#' Example: Assume \'variable a\' holds 10 and \'variable b\' holds 20.
 #' 
-#'     (a = b) is not true.
+#' (a = b) is not true.
 #' 
-#' \\< \\>
+#' ### \\< \\>
 #' 
-#' :   Checks whether the values of two operands are equal; if the values
-#'     are not equal, then the condition becomes true.
+#' Checks whether the values of two operands are equal; if the values are
+#' not equal, then the condition becomes true.
 #' 
-#'     Example: (a \\< \\> b) is true.
+#' Example: (a \\< \\> b) is true.
 #' 
-#' \\>
+#' ### \\>
 #' 
-#' :   Checks whether the value of the left operand is greater than the
-#'     value of the right operand; if yes, then the condition becomes true.
+#' Checks whether the value of the left operand is greater than the value
+#' of the right operand; if yes, then the condition becomes true.
 #' 
-#'     Example: (a \\> b) is not true.
+#' Example: (a \\> b) is not true.
 #' 
-#' \\<
+#' ### \\<
 #' 
-#' :   Checks whether the value of the left operand is less than the value
-#'     of the right operand; if yes, then the condition becomes true.
+#' Checks whether the value of the left operand is less than the value of
+#' the right operand; if yes, then the condition becomes true.
 #' 
-#'     Example: (a \\< b) is true.
+#' Example: (a \\< b) is true.
 #' 
-#' \\>=
+#' ### \\>=
 #' 
-#' :   Checks whether the value of the left operand is greater than or
-#'     equal to the value of the right operand; if yes, then the condition
-#'     becomes true.
+#' Checks whether the value of the left operand is greater than or equal to
+#' the value of the right operand; if yes, then the condition becomes true.
 #' 
-#'     Example: (a \\>= b) is not true.
+#' Example: (a \\>= b) is not true.
 #' 
-#' \\<=
+#' ### \\<=
 #' 
-#' :   Checks whether the value of the left operand is less than or equal
-#'     to the value of the right operand; if yes, then the condition
-#'     becomes true.
+#' Checks whether the value of the left operand is less than or equal to
+#' the value of the right operand; if yes, then the condition becomes true.
 #' 
-#'     Example: (a \\<= b) is true.
+#' Example: (a \\<= b) is true.
 #' 
-#' AND, OR, IN, BETWEEN, LIKE, NOT, IS NULL
+#' ### AND, OR, IN, BETWEEN, LIKE, NOT, IS NULL
 #' 
-#' :   Logical operators.
+#' Logical operators.
 #' 
 #' *Supported Partition Key Types*: The following are the supported
 #' partition keys.

--- a/cran/paws.analytics/man/athena_list_query_executions.Rd
+++ b/cran/paws.analytics/man/athena_list_query_executions.Rd
@@ -21,8 +21,8 @@ specified workgroup. Requires you to have access to the workgroup in
 which the queries ran.
 }
 \details{
-For code samples using the AWS SDK for Java, see Examples and Code
-Samples in the \emph{Amazon Athena User Guide}.
+For code samples using the AWS SDK for Java, see \href{http://docs.aws.amazon.com/athena/latest/ug/code-samples.html}{Examples and Code Samples}
+in the \emph{Amazon Athena User Guide}.
 }
 \section{Request syntax}{
 \preformatted{svc$list_query_executions(

--- a/cran/paws.analytics/man/athena_start_query_execution.Rd
+++ b/cran/paws.analytics/man/athena_start_query_execution.Rd
@@ -38,8 +38,8 @@ Runs the SQL query statements contained in the \code{Query}. Requires you to
 have access to the workgroup in which the query ran.
 }
 \details{
-For code samples using the AWS SDK for Java, see Examples and Code
-Samples in the \emph{Amazon Athena User Guide}.
+For code samples using the AWS SDK for Java, see \href{http://docs.aws.amazon.com/athena/latest/ug/code-samples.html}{Examples and Code Samples}
+in the \emph{Amazon Athena User Guide}.
 }
 \section{Request syntax}{
 \preformatted{svc$start_query_execution(

--- a/cran/paws.analytics/man/glue_get_partitions.Rd
+++ b/cran/paws.analytics/man/glue_get_partitions.Rd
@@ -24,50 +24,59 @@ expression.
 
 \emph{Operators}: The following are the operators that you can use in the
 \code{Expression} API call:
+\subsection{=}{
 
-=
+Checks whether the values of the two operands are equal; if yes, then
+the condition becomes true.
 
-:   Checks whether the values of the two operands are equal; if yes,
-then the condition becomes true.\preformatted{Example: Assume \\'variable a\\' holds 10 and \\'variable b\\' holds 20.
+Example: Assume \'variable a\' holds 10 and \'variable b\' holds 20.
 
 (a = b) is not true.
 }
 
-\\< \\>
+\subsection{\\< \\>}{
 
-:   Checks whether the values of two operands are equal; if the values
-are not equal, then the condition becomes true.\preformatted{Example: (a \\\\< \\\\> b) is true.
+Checks whether the values of two operands are equal; if the values are
+not equal, then the condition becomes true.
+
+Example: (a \\< \\> b) is true.
 }
 
-\\>
+\subsection{\\>}{
 
-:   Checks whether the value of the left operand is greater than the
-value of the right operand; if yes, then the condition becomes true.\preformatted{Example: (a \\\\> b) is not true.
+Checks whether the value of the left operand is greater than the value
+of the right operand; if yes, then the condition becomes true.
+
+Example: (a \\> b) is not true.
 }
 
-\\<
+\subsection{\\<}{
 
-:   Checks whether the value of the left operand is less than the value
-of the right operand; if yes, then the condition becomes true.\preformatted{Example: (a \\\\< b) is true.
+Checks whether the value of the left operand is less than the value of
+the right operand; if yes, then the condition becomes true.
+
+Example: (a \\< b) is true.
 }
 
-\\>=
+\subsection{\\>=}{
 
-:   Checks whether the value of the left operand is greater than or
-equal to the value of the right operand; if yes, then the condition
-becomes true.\preformatted{Example: (a \\\\>= b) is not true.
+Checks whether the value of the left operand is greater than or equal to
+the value of the right operand; if yes, then the condition becomes true.
+
+Example: (a \\>= b) is not true.
 }
 
-\\<=
+\subsection{\\<=}{
 
-:   Checks whether the value of the left operand is less than or equal
-to the value of the right operand; if yes, then the condition
-becomes true.\preformatted{Example: (a \\\\<= b) is true.
+Checks whether the value of the left operand is less than or equal to
+the value of the right operand; if yes, then the condition becomes true.
+
+Example: (a \\<= b) is true.
 }
 
-AND, OR, IN, BETWEEN, LIKE, NOT, IS NULL
+\subsection{AND, OR, IN, BETWEEN, LIKE, NOT, IS NULL}{
 
-:   Logical operators.
+Logical operators.
 
 \emph{Supported Partition Key Types}: The following are the supported
 partition keys.
@@ -89,7 +98,8 @@ The following list shows the valid operators on each type. When you
 define a crawler, the \code{partitionKey} type is created as a \code{STRING}, to
 be compatible with the catalog partitions.
 
-\emph{Sample API Call}:}
+\emph{Sample API Call}:
+}}
 
 \item{NextToken}{A continuation token, if this is not the first call to retrieve these
 partitions.}

--- a/cran/paws.business.applications/R/chime_service.R
+++ b/cran/paws.business.applications/R/chime_service.R
@@ -20,34 +20,33 @@ NULL
 #' CLI. Each API operation includes links to information about using it
 #' with a language-specific AWS SDK or the AWS CLI.
 #' 
-#' Using an AWS SDK
+#' ### Using an AWS SDK
 #' 
-#' :   You don\'t need to write code to calculate a signature for request
-#'     authentication. The SDK clients authenticate your requests by using
-#'     access keys that you provide. For more information about AWS SDKs,
-#'     see the [AWS Developer Center](http://aws.amazon.com/developer/).
+#' You don\'t need to write code to calculate a signature for request
+#' authentication. The SDK clients authenticate your requests by using
+#' access keys that you provide. For more information about AWS SDKs, see
+#' the [AWS Developer Center](http://aws.amazon.com/developer/).
 #' 
-#' Using the AWS CLI
+#' ### Using the AWS CLI
 #' 
-#' :   Use your access keys with the AWS CLI to make API calls. For
-#'     information about setting up the AWS CLI, see [Installing the AWS
-#'     Command Line
-#'     Interface](https://docs.aws.amazon.com/cli/latest/userguide/installing.html)
-#'     in the *AWS Command Line Interface User Guide*. For a list of
-#'     available Amazon Chime commands, see the [Amazon Chime
-#'     commands](https://docs.aws.amazon.com/cli/latest/reference/chime/index.html)
-#'     in the *AWS CLI Command Reference*.
+#' Use your access keys with the AWS CLI to make API calls. For information
+#' about setting up the AWS CLI, see [Installing the AWS Command Line
+#' Interface](https://docs.aws.amazon.com/cli/latest/userguide/installing.html)
+#' in the *AWS Command Line Interface User Guide*. For a list of available
+#' Amazon Chime commands, see the [Amazon Chime
+#' commands](https://docs.aws.amazon.com/cli/latest/reference/chime/index.html)
+#' in the *AWS CLI Command Reference*.
 #' 
-#' Using REST API
+#' ### Using REST API
 #' 
-#' :   If you use REST to make API calls, you must authenticate your
-#'     request by providing a signature. Amazon Chime supports signature
-#'     version 4. For more information, see [Signature Version 4 Signing
-#'     Process](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
-#'     in the *Amazon Web Services General Reference*.
+#' If you use REST to make API calls, you must authenticate your request by
+#' providing a signature. Amazon Chime supports signature version 4. For
+#' more information, see [Signature Version 4 Signing
+#' Process](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
+#' in the *Amazon Web Services General Reference*.
 #' 
-#'     When making REST API calls, use the service name `chime` and REST
-#'     endpoint `https://service.chime.aws.amazon.com`.
+#' When making REST API calls, use the service name `chime` and REST
+#' endpoint `https://service.chime.aws.amazon.com`.
 #' 
 #' Administrative permissions are controlled using AWS Identity and Access
 #' Management (IAM). For more information, see [Identity and Access

--- a/cran/paws.business.applications/man/chime.Rd
+++ b/cran/paws.business.applications/man/chime.Rd
@@ -23,34 +23,37 @@ You can use an AWS SDK, the AWS Command Line Interface (AWS CLI), or the
 REST API to make API calls. We recommend using an AWS SDK or the AWS
 CLI. Each API operation includes links to information about using it
 with a language-specific AWS SDK or the AWS CLI.
+\subsection{Using an AWS SDK}{
 
-Using an AWS SDK
-
-:   You don\'t need to write code to calculate a signature for request
+You don\'t need to write code to calculate a signature for request
 authentication. The SDK clients authenticate your requests by using
-access keys that you provide. For more information about AWS SDKs,
-see the \href{http://aws.amazon.com/developer/}{AWS Developer Center}.
-
-Using the AWS CLI
-
-:   Use your access keys with the AWS CLI to make API calls. For
-information about setting up the AWS CLI, see \href{https://docs.aws.amazon.com/cli/latest/userguide/installing.html}{Installing the AWS Command Line Interface}
-in the \emph{AWS Command Line Interface User Guide}. For a list of
-available Amazon Chime commands, see the \href{https://docs.aws.amazon.com/cli/latest/reference/chime/index.html}{Amazon Chime commands}
-in the \emph{AWS CLI Command Reference}.
-
-Using REST API
-
-:   If you use REST to make API calls, you must authenticate your
-request by providing a signature. Amazon Chime supports signature
-version 4. For more information, see \href{https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html}{Signature Version 4 Signing Process}
-in the \emph{Amazon Web Services General Reference}.\preformatted{When making REST API calls, use the service name `chime` and REST
-endpoint `https://service.chime.aws.amazon.com`.
+access keys that you provide. For more information about AWS SDKs, see
+the \href{http://aws.amazon.com/developer/}{AWS Developer Center}.
 }
+
+\subsection{Using the AWS CLI}{
+
+Use your access keys with the AWS CLI to make API calls. For information
+about setting up the AWS CLI, see \href{https://docs.aws.amazon.com/cli/latest/userguide/installing.html}{Installing the AWS Command Line Interface}
+in the \emph{AWS Command Line Interface User Guide}. For a list of available
+Amazon Chime commands, see the \href{https://docs.aws.amazon.com/cli/latest/reference/chime/index.html}{Amazon Chime commands}
+in the \emph{AWS CLI Command Reference}.
+}
+
+\subsection{Using REST API}{
+
+If you use REST to make API calls, you must authenticate your request by
+providing a signature. Amazon Chime supports signature version 4. For
+more information, see \href{https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html}{Signature Version 4 Signing Process}
+in the \emph{Amazon Web Services General Reference}.
+
+When making REST API calls, use the service name \code{chime} and REST
+endpoint \verb{https://service.chime.aws.amazon.com}.
 
 Administrative permissions are controlled using AWS Identity and Access
 Management (IAM). For more information, see \href{https://docs.aws.amazon.com/chime/latest/ag/security-iam.html}{Identity and Access Management for Amazon Chime} in
 the \emph{Amazon Chime Administration Guide}.
+}
 }
 \section{Service syntax}{
 \preformatted{svc <- chime(

--- a/cran/paws.compute/R/ec2_operations.R
+++ b/cran/paws.compute/R/ec2_operations.R
@@ -18003,8 +18003,9 @@ ec2_describe_transit_gateways <- function(TransitGatewayIds = NULL, Filters = NU
 #' Describes the specified attribute of the specified volume. You can
 #' specify only one attribute at a time.
 #' 
-#' For more information about EBS volumes, see Amazon EBS Volumes in the
-#' *Amazon Elastic Compute Cloud User Guide*.
+#' For more information about EBS volumes, see [Amazon EBS
+#' Volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumes.html)
+#' in the *Amazon Elastic Compute Cloud User Guide*.
 #'
 #' @usage
 #' ec2_describe_volume_attribute(Attribute, VolumeId, DryRun)

--- a/cran/paws.compute/R/elasticbeanstalk_operations.R
+++ b/cran/paws.compute/R/elasticbeanstalk_operations.R
@@ -2762,15 +2762,15 @@ elasticbeanstalk_update_environment <- function(ApplicationName = NULL, Environm
 #' operation, specify one of the following two virtual actions (or both)
 #' instead of the API operation name:
 #' 
-#' elasticbeanstalk:AddTags
+#' ### elasticbeanstalk:AddTags
 #' 
-#' :   Controls permission to call `UpdateTagsForResource` and pass a list
-#'     of tags to add in the `TagsToAdd` parameter.
+#' Controls permission to call `UpdateTagsForResource` and pass a list of
+#' tags to add in the `TagsToAdd` parameter.
 #' 
-#' elasticbeanstalk:RemoveTags
+#' ### elasticbeanstalk:RemoveTags
 #' 
-#' :   Controls permission to call `UpdateTagsForResource` and pass a list
-#'     of tag keys to remove in the `TagsToRemove` parameter.
+#' Controls permission to call `UpdateTagsForResource` and pass a list of
+#' tag keys to remove in the `TagsToRemove` parameter.
 #' 
 #' For details about creating a custom user policy, see [Creating a Custom
 #' User

--- a/cran/paws.compute/man/ec2_describe_volume_attribute.Rd
+++ b/cran/paws.compute/man/ec2_describe_volume_attribute.Rd
@@ -21,8 +21,8 @@ Describes the specified attribute of the specified volume. You can
 specify only one attribute at a time.
 }
 \details{
-For more information about EBS volumes, see Amazon EBS Volumes in the
-\emph{Amazon Elastic Compute Cloud User Guide}.
+For more information about EBS volumes, see \href{https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumes.html}{Amazon EBS Volumes}
+in the \emph{Amazon Elastic Compute Cloud User Guide}.
 }
 \section{Request syntax}{
 \preformatted{svc$describe_volume_attribute(

--- a/cran/paws.compute/man/elasticbeanstalk_update_tags_for_resource.Rd
+++ b/cran/paws.compute/man/elasticbeanstalk_update_tags_for_resource.Rd
@@ -32,18 +32,19 @@ environments. For details about environment tagging, see \href{https://docs.aws.
 If you create a custom IAM user policy to control permission to this
 operation, specify one of the following two virtual actions (or both)
 instead of the API operation name:
+\subsection{elasticbeanstalk:AddTags}{
 
-elasticbeanstalk:AddTags
+Controls permission to call \code{UpdateTagsForResource} and pass a list of
+tags to add in the \code{TagsToAdd} parameter.
+}
 
-:   Controls permission to call \code{UpdateTagsForResource} and pass a list
-of tags to add in the \code{TagsToAdd} parameter.
+\subsection{elasticbeanstalk:RemoveTags}{
 
-elasticbeanstalk:RemoveTags
-
-:   Controls permission to call \code{UpdateTagsForResource} and pass a list
-of tag keys to remove in the \code{TagsToRemove} parameter.
+Controls permission to call \code{UpdateTagsForResource} and pass a list of
+tag keys to remove in the \code{TagsToRemove} parameter.
 
 For details about creating a custom user policy, see \href{https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.iam.managed-policies.html#AWSHowTo.iam.policies}{Creating a Custom User Policy}.
+}
 }
 \section{Request syntax}{
 \preformatted{svc$update_tags_for_resource(

--- a/cran/paws.customer.engagement/R/connect_operations.R
+++ b/cran/paws.customer.engagement/R/connect_operations.R
@@ -310,57 +310,57 @@ connect_get_contact_attributes <- function(InstanceId, InitialContactId) {
 #' @param CurrentMetrics &#91;required&#93; The metrics to retrieve. Specify the name and unit for each metric. The
 #' following metrics are available:
 #' 
-#' AGENTS\\_AFTER\\_CONTACT\\_WORK
+#' ### AGENTS\\_AFTER\\_CONTACT\\_WORK
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_AVAILABLE
+#' ### AGENTS\\_AVAILABLE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_ERROR
+#' ### AGENTS\\_ERROR
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_NON\\_PRODUCTIVE
+#' ### AGENTS\\_NON\\_PRODUCTIVE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_ON\\_CALL
+#' ### AGENTS\\_ON\\_CALL
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_ON\\_CONTACT
+#' ### AGENTS\\_ON\\_CONTACT
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_ONLINE
+#' ### AGENTS\\_ONLINE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_STAFFED
+#' ### AGENTS\\_STAFFED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' CONTACTS\\_IN\\_QUEUE
+#' ### CONTACTS\\_IN\\_QUEUE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' CONTACTS\\_SCHEDULED
+#' ### CONTACTS\\_SCHEDULED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' OLDEST\\_CONTACT\\_AGE
+#' ### OLDEST\\_CONTACT\\_AGE
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#' SLOTS\\_ACTIVE
+#' ### SLOTS\\_ACTIVE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' SLOTS\\_AVAILABLE
+#' ### SLOTS\\_AVAILABLE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' @param NextToken The token for the next set of results. Use the value returned in the
 #' previous response in the next request to retrieve the next set of
 #' results.
@@ -496,159 +496,159 @@ connect_get_federation_token <- function(InstanceId) {
 #' @param HistoricalMetrics &#91;required&#93; The metrics to retrieve. Specify the name, unit, and statistic for each
 #' metric. The following historical metrics are available:
 #' 
-#' ABANDON\\_TIME
+#' ### ABANDON\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' AFTER\\_CONTACT\\_WORK\\_TIME
+#' ### AFTER\\_CONTACT\\_WORK\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' API\\_CONTACTS\\_HANDLED
+#' ### API\\_CONTACTS\\_HANDLED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CALLBACK\\_CONTACTS\\_HANDLED
+#' ### CALLBACK\\_CONTACTS\\_HANDLED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_ABANDONED
+#' ### CONTACTS\\_ABANDONED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_AGENT\\_HUNG\\_UP\\_FIRST
+#' ### CONTACTS\\_AGENT\\_HUNG\\_UP\\_FIRST
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_CONSULTED
+#' ### CONTACTS\\_CONSULTED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_HANDLED
+#' ### CONTACTS\\_HANDLED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_HANDLED\\_INCOMING
+#' ### CONTACTS\\_HANDLED\\_INCOMING
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_HANDLED\\_OUTBOUND
+#' ### CONTACTS\\_HANDLED\\_OUTBOUND
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_HOLD\\_ABANDONS
+#' ### CONTACTS\\_HOLD\\_ABANDONS
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_MISSED
+#' ### CONTACTS\\_MISSED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_QUEUED
+#' ### CONTACTS\\_QUEUED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_TRANSFERRED\\_IN
+#' ### CONTACTS\\_TRANSFERRED\\_IN
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_TRANSFERRED\\_IN\\_FROM\\_QUEUE
+#' ### CONTACTS\\_TRANSFERRED\\_IN\\_FROM\\_QUEUE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_TRANSFERRED\\_OUT
+#' ### CONTACTS\\_TRANSFERRED\\_OUT
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_TRANSFERRED\\_OUT\\_FROM\\_QUEUE
+#' ### CONTACTS\\_TRANSFERRED\\_OUT\\_FROM\\_QUEUE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' HANDLE\\_TIME
+#' ### HANDLE\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' HOLD\\_TIME
+#' ### HOLD\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' INTERACTION\\_AND\\_HOLD\\_TIME
+#' ### INTERACTION\\_AND\\_HOLD\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' INTERACTION\\_TIME
+#' ### INTERACTION\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' OCCUPANCY
+#' ### OCCUPANCY
 #' 
-#' :   Unit: PERCENT
+#' Unit: PERCENT
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' QUEUE\\_ANSWER\\_TIME
+#' ### QUEUE\\_ANSWER\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' QUEUED\\_TIME
+#' ### QUEUED\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: MAX
+#' Statistic: MAX
 #' 
-#' SERVICE\\_LEVEL
+#' ### SERVICE\\_LEVEL
 #' 
-#' :   Unit: PERCENT
+#' Unit: PERCENT
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#'     Threshold: Only \"Less than\" comparisons are supported, with the
-#'     following service level thresholds: 15, 20, 25, 30, 45, 60, 90, 120,
-#'     180, 240, 300, 600
+#' Threshold: Only \"Less than\" comparisons are supported, with the
+#' following service level thresholds: 15, 20, 25, 30, 45, 60, 90, 120,
+#' 180, 240, 300, 600
 #' @param NextToken The token for the next set of results. Use the value returned in the
 #' previous response in the next request to retrieve the next set of
 #' results.

--- a/cran/paws.customer.engagement/man/connect_get_current_metric_data.Rd
+++ b/cran/paws.customer.engagement/man/connect_get_current_metric_data.Rd
@@ -27,58 +27,70 @@ returned.}
 
 \item{CurrentMetrics}{[required] The metrics to retrieve. Specify the name and unit for each metric. The
 following metrics are available:
+\subsection{AGENTS\\_AFTER\\_CONTACT\\_WORK}{
 
-AGENTS\\_AFTER\\_CONTACT\\_WORK
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_AVAILABLE}{
 
-AGENTS\\_AVAILABLE
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_ERROR}{
 
-AGENTS\\_ERROR
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_NON\\_PRODUCTIVE}{
 
-AGENTS\\_NON\\_PRODUCTIVE
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_ON\\_CALL}{
 
-AGENTS\\_ON\\_CALL
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_ON\\_CONTACT}{
 
-AGENTS\\_ON\\_CONTACT
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_ONLINE}{
 
-AGENTS\\_ONLINE
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_STAFFED}{
 
-AGENTS\\_STAFFED
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{CONTACTS\\_IN\\_QUEUE}{
 
-CONTACTS\\_IN\\_QUEUE
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{CONTACTS\\_SCHEDULED}{
 
-CONTACTS\\_SCHEDULED
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{OLDEST\\_CONTACT\\_AGE}{
 
-OLDEST\\_CONTACT\\_AGE
+Unit: SECONDS
+}
 
-:   Unit: SECONDS
+\subsection{SLOTS\\_ACTIVE}{
 
-SLOTS\\_ACTIVE
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{SLOTS\\_AVAILABLE}{
 
-SLOTS\\_AVAILABLE
-
-:   Unit: COUNT}
+Unit: COUNT
+}}
 
 \item{NextToken}{The token for the next set of results. Use the value returned in the
 previous response in the next request to retrieve the next set of

--- a/cran/paws.customer.engagement/man/connect_get_metric_data.Rd
+++ b/cran/paws.customer.engagement/man/connect_get_metric_data.Rd
@@ -44,132 +44,181 @@ returned.}
 
 \item{HistoricalMetrics}{[required] The metrics to retrieve. Specify the name, unit, and statistic for each
 metric. The following historical metrics are available:
+\subsection{ABANDON\\_TIME}{
 
-ABANDON\\_TIME
+Unit: SECONDS
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Statistic: AVG
 }
 
-AFTER\\_CONTACT\\_WORK\\_TIME
+\subsection{AFTER\\_CONTACT\\_WORK\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Unit: SECONDS
+
+Statistic: AVG
 }
 
-API\\_CONTACTS\\_HANDLED
+\subsection{API\\_CONTACTS\\_HANDLED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CALLBACK\\_CONTACTS\\_HANDLED
+\subsection{CALLBACK\\_CONTACTS\\_HANDLED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_ABANDONED
+\subsection{CONTACTS\\_ABANDONED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_AGENT\\_HUNG\\_UP\\_FIRST
+\subsection{CONTACTS\\_AGENT\\_HUNG\\_UP\\_FIRST}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_CONSULTED
+\subsection{CONTACTS\\_CONSULTED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_HANDLED
+\subsection{CONTACTS\\_HANDLED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_HANDLED\\_INCOMING
+\subsection{CONTACTS\\_HANDLED\\_INCOMING}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_HANDLED\\_OUTBOUND
+\subsection{CONTACTS\\_HANDLED\\_OUTBOUND}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_HOLD\\_ABANDONS
+\subsection{CONTACTS\\_HOLD\\_ABANDONS}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_MISSED
+\subsection{CONTACTS\\_MISSED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_QUEUED
+\subsection{CONTACTS\\_QUEUED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_TRANSFERRED\\_IN
+\subsection{CONTACTS\\_TRANSFERRED\\_IN}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_TRANSFERRED\\_IN\\_FROM\\_QUEUE
+\subsection{CONTACTS\\_TRANSFERRED\\_IN\\_FROM\\_QUEUE}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_TRANSFERRED\\_OUT
+\subsection{CONTACTS\\_TRANSFERRED\\_OUT}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_TRANSFERRED\\_OUT\\_FROM\\_QUEUE
+\subsection{CONTACTS\\_TRANSFERRED\\_OUT\\_FROM\\_QUEUE}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-HANDLE\\_TIME
+\subsection{HANDLE\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Unit: SECONDS
+
+Statistic: AVG
 }
 
-HOLD\\_TIME
+\subsection{HOLD\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Unit: SECONDS
+
+Statistic: AVG
 }
 
-INTERACTION\\_AND\\_HOLD\\_TIME
+\subsection{INTERACTION\\_AND\\_HOLD\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Unit: SECONDS
+
+Statistic: AVG
 }
 
-INTERACTION\\_TIME
+\subsection{INTERACTION\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Unit: SECONDS
+
+Statistic: AVG
 }
 
-OCCUPANCY
+\subsection{OCCUPANCY}{
 
-:   Unit: PERCENT\preformatted{Statistic: AVG
+Unit: PERCENT
+
+Statistic: AVG
 }
 
-QUEUE\\_ANSWER\\_TIME
+\subsection{QUEUE\\_ANSWER\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Unit: SECONDS
+
+Statistic: AVG
 }
 
-QUEUED\\_TIME
+\subsection{QUEUED\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: MAX
+Unit: SECONDS
+
+Statistic: MAX
 }
 
-SERVICE\\_LEVEL
+\subsection{SERVICE\\_LEVEL}{
 
-:   Unit: PERCENT\preformatted{Statistic: AVG
+Unit: PERCENT
 
-Threshold: Only \\"Less than\\" comparisons are supported, with the
+Statistic: AVG
+
+Threshold: Only \"Less than\" comparisons are supported, with the
 following service level thresholds: 15, 20, 25, 30, 45, 60, 90, 120,
 180, 240, 300, 600
 }}

--- a/cran/paws.end.user.computing/R/appstream_operations.R
+++ b/cran/paws.end.user.computing/R/appstream_operations.R
@@ -287,18 +287,18 @@ appstream_create_directory_config <- function(DirectoryName, OrganizationalUnitD
 #' -   stream.graphics-pro.16xlarge
 #' @param FleetType The fleet type.
 #' 
-#' ALWAYS\\_ON
+#' ### ALWAYS\\_ON
 #' 
-#' :   Provides users with instant-on access to their apps. You are charged
-#'     for all running instances in your fleet, even if no users are
-#'     streaming apps.
+#' Provides users with instant-on access to their apps. You are charged for
+#' all running instances in your fleet, even if no users are streaming
+#' apps.
 #' 
-#' ON\\_DEMAND
+#' ### ON\\_DEMAND
 #' 
-#' :   Provide users with access to applications after they connect, which
-#'     takes one to two minutes. You are charged for instance streaming
-#'     when users are connected and a small hourly fee for instances that
-#'     are not streaming apps.
+#' Provide users with access to applications after they connect, which
+#' takes one to two minutes. You are charged for instance streaming when
+#' users are connected and a small hourly fee for instances that are not
+#' streaming apps.
 #' @param ComputeCapacity &#91;required&#93; The desired capacity for the fleet.
 #' @param VpcConfig The VPC configuration for the fleet.
 #' @param MaxUserDurationInSeconds The maximum amount of time that a streaming session can remain active,

--- a/cran/paws.end.user.computing/man/appstream_create_fleet.Rd
+++ b/cran/paws.end.user.computing/man/appstream_create_fleet.Rd
@@ -43,19 +43,20 @@ instance types are available:
 }}
 
 \item{FleetType}{The fleet type.
+\subsection{ALWAYS\\_ON}{
 
-ALWAYS\\_ON
+Provides users with instant-on access to their apps. You are charged for
+all running instances in your fleet, even if no users are streaming
+apps.
+}
 
-:   Provides users with instant-on access to their apps. You are charged
-for all running instances in your fleet, even if no users are
+\subsection{ON\\_DEMAND}{
+
+Provide users with access to applications after they connect, which
+takes one to two minutes. You are charged for instance streaming when
+users are connected and a small hourly fee for instances that are not
 streaming apps.
-
-ON\\_DEMAND
-
-:   Provide users with access to applications after they connect, which
-takes one to two minutes. You are charged for instance streaming
-when users are connected and a small hourly fee for instances that
-are not streaming apps.}
+}}
 
 \item{ComputeCapacity}{[required] The desired capacity for the fleet.}
 

--- a/cran/paws.internet.of.things/R/iot_operations.R
+++ b/cran/paws.internet.of.things/R/iot_operations.R
@@ -9657,34 +9657,33 @@ iot_update_thing_groups_for_thing <- function(thingName = NULL, thingGroupsToAdd
 #' @param arn &#91;required&#93; The ARN of the topic rule destination.
 #' @param status &#91;required&#93; The status of the topic rule destination. Valid values are:
 #' 
-#' IN\\_PROGRESS
+#' ### IN\\_PROGRESS
 #' 
-#' :   A topic rule destination was created but has not been confirmed. You
-#'     can set `status` to `IN_PROGRESS` by calling
-#'     `UpdateTopicRuleDestination`. Calling `UpdateTopicRuleDestination`
-#'     causes a new confirmation challenge to be sent to your confirmation
-#'     endpoint.
+#' A topic rule destination was created but has not been confirmed. You can
+#' set `status` to `IN_PROGRESS` by calling `UpdateTopicRuleDestination`.
+#' Calling `UpdateTopicRuleDestination` causes a new confirmation challenge
+#' to be sent to your confirmation endpoint.
 #' 
-#' ENABLED
+#' ### ENABLED
 #' 
-#' :   Confirmation was completed, and traffic to this destination is
-#'     allowed. You can set `status` to `DISABLED` by calling
-#'     `UpdateTopicRuleDestination`.
+#' Confirmation was completed, and traffic to this destination is allowed.
+#' You can set `status` to `DISABLED` by calling
+#' `UpdateTopicRuleDestination`.
 #' 
-#' DISABLED
+#' ### DISABLED
 #' 
-#' :   Confirmation was completed, and traffic to this destination is not
-#'     allowed. You can set `status` to `ENABLED` by calling
-#'     `UpdateTopicRuleDestination`.
+#' Confirmation was completed, and traffic to this destination is not
+#' allowed. You can set `status` to `ENABLED` by calling
+#' `UpdateTopicRuleDestination`.
 #' 
-#' ERROR
+#' ### ERROR
 #' 
-#' :   Confirmation could not be completed, for example if the confirmation
-#'     timed out. You can call `GetTopicRuleDestination` for details about
-#'     the error. You can set `status` to `IN_PROGRESS` by calling
-#'     `UpdateTopicRuleDestination`. Calling `UpdateTopicRuleDestination`
-#'     causes a new confirmation challenge to be sent to your confirmation
-#'     endpoint.
+#' Confirmation could not be completed, for example if the confirmation
+#' timed out. You can call `GetTopicRuleDestination` for details about the
+#' error. You can set `status` to `IN_PROGRESS` by calling
+#' `UpdateTopicRuleDestination`. Calling `UpdateTopicRuleDestination`
+#' causes a new confirmation challenge to be sent to your confirmation
+#' endpoint.
 #'
 #' @section Request syntax:
 #' ```

--- a/cran/paws.internet.of.things/man/iot_update_topic_rule_destination.Rd
+++ b/cran/paws.internet.of.things/man/iot_update_topic_rule_destination.Rd
@@ -10,35 +10,37 @@ iot_update_topic_rule_destination(arn, status)
 \item{arn}{[required] The ARN of the topic rule destination.}
 
 \item{status}{[required] The status of the topic rule destination. Valid values are:
+\subsection{IN\\_PROGRESS}{
 
-IN\\_PROGRESS
+A topic rule destination was created but has not been confirmed. You can
+set \code{status} to \code{IN_PROGRESS} by calling \code{UpdateTopicRuleDestination}.
+Calling \code{UpdateTopicRuleDestination} causes a new confirmation challenge
+to be sent to your confirmation endpoint.
+}
 
-:   A topic rule destination was created but has not been confirmed. You
-can set \code{status} to \code{IN_PROGRESS} by calling
+\subsection{ENABLED}{
+
+Confirmation was completed, and traffic to this destination is allowed.
+You can set \code{status} to \code{DISABLED} by calling
+\code{UpdateTopicRuleDestination}.
+}
+
+\subsection{DISABLED}{
+
+Confirmation was completed, and traffic to this destination is not
+allowed. You can set \code{status} to \code{ENABLED} by calling
+\code{UpdateTopicRuleDestination}.
+}
+
+\subsection{ERROR}{
+
+Confirmation could not be completed, for example if the confirmation
+timed out. You can call \code{GetTopicRuleDestination} for details about the
+error. You can set \code{status} to \code{IN_PROGRESS} by calling
 \code{UpdateTopicRuleDestination}. Calling \code{UpdateTopicRuleDestination}
 causes a new confirmation challenge to be sent to your confirmation
 endpoint.
-
-ENABLED
-
-:   Confirmation was completed, and traffic to this destination is
-allowed. You can set \code{status} to \code{DISABLED} by calling
-\code{UpdateTopicRuleDestination}.
-
-DISABLED
-
-:   Confirmation was completed, and traffic to this destination is not
-allowed. You can set \code{status} to \code{ENABLED} by calling
-\code{UpdateTopicRuleDestination}.
-
-ERROR
-
-:   Confirmation could not be completed, for example if the confirmation
-timed out. You can call \code{GetTopicRuleDestination} for details about
-the error. You can set \code{status} to \code{IN_PROGRESS} by calling
-\code{UpdateTopicRuleDestination}. Calling \code{UpdateTopicRuleDestination}
-causes a new confirmation challenge to be sent to your confirmation
-endpoint.}
+}}
 }
 \description{
 Updates a topic rule destination. You use this to change the status,

--- a/cran/paws.management/R/servicecatalog_operations.R
+++ b/cran/paws.management/R/servicecatalog_operations.R
@@ -492,51 +492,51 @@ servicecatalog_copy_product <- function(AcceptLanguage = NULL, SourceProductArn,
 #' @param Parameters &#91;required&#93; The constraint parameters, in JSON format. The syntax depends on the
 #' constraint type as follows:
 #' 
-#' LAUNCH
+#' ### LAUNCH
 #' 
-#' :   Specify the `RoleArn` property as follows:
+#' Specify the `RoleArn` property as follows:
 #' 
-#'     `\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\}`
+#' `\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\}`
 #' 
-#'     You cannot have both a `LAUNCH` and a `STACKSET` constraint.
+#' You cannot have both a `LAUNCH` and a `STACKSET` constraint.
 #' 
-#'     You also cannot have more than one `LAUNCH` constraint on a product
-#'     and portfolio.
+#' You also cannot have more than one `LAUNCH` constraint on a product and
+#' portfolio.
 #' 
-#' NOTIFICATION
+#' ### NOTIFICATION
 #' 
-#' :   Specify the `NotificationArns` property as follows:
+#' Specify the `NotificationArns` property as follows:
 #' 
-#'     `\{"NotificationArns" : \\["arn:aws:sns:us-east-1:123456789012:Topic"\\]\}`
+#' `\{"NotificationArns" : \\["arn:aws:sns:us-east-1:123456789012:Topic"\\]\}`
 #' 
-#' RESOURCE\\_UPDATE
+#' ### RESOURCE\\_UPDATE
 #' 
-#' :   Specify the `TagUpdatesOnProvisionedProduct` property as follows:
+#' Specify the `TagUpdatesOnProvisionedProduct` property as follows:
 #' 
-#'     `\{"Version":"2.0","Properties":\{"TagUpdateOnProvisionedProduct":"String"\}\}`
+#' `\{"Version":"2.0","Properties":\{"TagUpdateOnProvisionedProduct":"String"\}\}`
 #' 
-#'     The `TagUpdatesOnProvisionedProduct` property accepts a string value
-#'     of `ALLOWED` or `NOT_ALLOWED`.
+#' The `TagUpdatesOnProvisionedProduct` property accepts a string value of
+#' `ALLOWED` or `NOT_ALLOWED`.
 #' 
-#' STACKSET
+#' ### STACKSET
 #' 
-#' :   Specify the `Parameters` property as follows:
+#' Specify the `Parameters` property as follows:
 #' 
-#'     `\{"Version": "String", "Properties": \{"AccountList": \\[ "String" \\], "RegionList": \\[ "String" \\], "AdminRole": "String", "ExecutionRole": "String"\}\}`
+#' `\{"Version": "String", "Properties": \{"AccountList": \\[ "String" \\], "RegionList": \\[ "String" \\], "AdminRole": "String", "ExecutionRole": "String"\}\}`
 #' 
-#'     You cannot have both a `LAUNCH` and a `STACKSET` constraint.
+#' You cannot have both a `LAUNCH` and a `STACKSET` constraint.
 #' 
-#'     You also cannot have more than one `STACKSET` constraint on a
-#'     product and portfolio.
+#' You also cannot have more than one `STACKSET` constraint on a product
+#' and portfolio.
 #' 
-#'     Products with a `STACKSET` constraint will launch an AWS
-#'     CloudFormation stack set.
+#' Products with a `STACKSET` constraint will launch an AWS CloudFormation
+#' stack set.
 #' 
-#' TEMPLATE
+#' ### TEMPLATE
 #' 
-#' :   Specify the `Rules` property. For more information, see [Template
-#'     Constraint
-#'     Rules](http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html).
+#' Specify the `Rules` property. For more information, see [Template
+#' Constraint
+#' Rules](http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html).
 #' @param Type &#91;required&#93; The type of constraint.
 #' 
 #' -   `LAUNCH`
@@ -962,30 +962,30 @@ servicecatalog_create_provisioning_artifact <- function(AcceptLanguage = NULL, P
 #' @param DefinitionType &#91;required&#93; The service action definition type. For example, `SSM_AUTOMATION`.
 #' @param Definition &#91;required&#93; The self-service action definition. Can be one of the following:
 #' 
-#' Name
+#' ### Name
 #' 
-#' :   The name of the AWS Systems Manager Document. For example,
-#'     `AWS-RestartEC2Instance`.
+#' The name of the AWS Systems Manager Document. For example,
+#' `AWS-RestartEC2Instance`.
 #' 
-#' Version
+#' ### Version
 #' 
-#' :   The AWS Systems Manager automation document version. For example,
-#'     `"Version": "1"`
+#' The AWS Systems Manager automation document version. For example,
+#' `"Version": "1"`
 #' 
-#' AssumeRole
+#' ### AssumeRole
 #' 
-#' :   The Amazon Resource Name (ARN) of the role that performs the
-#'     self-service actions on your behalf. For example,
-#'     `"AssumeRole": "arn:aws:iam::12345678910:role/ActionRole"`.
+#' The Amazon Resource Name (ARN) of the role that performs the
+#' self-service actions on your behalf. For example,
+#' `"AssumeRole": "arn:aws:iam::12345678910:role/ActionRole"`.
 #' 
-#'     To reuse the provisioned product launch role, set to
-#'     `"AssumeRole": "LAUNCH_ROLE"`.
+#' To reuse the provisioned product launch role, set to
+#' `"AssumeRole": "LAUNCH_ROLE"`.
 #' 
-#' Parameters
+#' ### Parameters
 #' 
-#' :   The list of parameters in JSON format.
+#' The list of parameters in JSON format.
 #' 
-#'     For example: `\\[\{\"Name\":\"InstanceId\",\"Type\":\"TARGET\"\}\\]`.
+#' For example: `\\[\{\"Name\":\"InstanceId\",\"Type\":\"TARGET\"\}\\]`.
 #' @param Description The self-service action description.
 #' @param AcceptLanguage The language code.
 #' 
@@ -4007,51 +4007,51 @@ servicecatalog_terminate_provisioned_product <- function(ProvisionedProductName 
 #' @param Parameters The constraint parameters, in JSON format. The syntax depends on the
 #' constraint type as follows:
 #' 
-#' LAUNCH
+#' ### LAUNCH
 #' 
-#' :   Specify the `RoleArn` property as follows:
+#' Specify the `RoleArn` property as follows:
 #' 
-#'     `\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\}`
+#' `\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\}`
 #' 
-#'     You cannot have both a `LAUNCH` and a `STACKSET` constraint.
+#' You cannot have both a `LAUNCH` and a `STACKSET` constraint.
 #' 
-#'     You also cannot have more than one `LAUNCH` constraint on a product
-#'     and portfolio.
+#' You also cannot have more than one `LAUNCH` constraint on a product and
+#' portfolio.
 #' 
-#' NOTIFICATION
+#' ### NOTIFICATION
 #' 
-#' :   Specify the `NotificationArns` property as follows:
+#' Specify the `NotificationArns` property as follows:
 #' 
-#'     `\{"NotificationArns" : \\["arn:aws:sns:us-east-1:123456789012:Topic"\\]\}`
+#' `\{"NotificationArns" : \\["arn:aws:sns:us-east-1:123456789012:Topic"\\]\}`
 #' 
-#' RESOURCE\\_UPDATE
+#' ### RESOURCE\\_UPDATE
 #' 
-#' :   Specify the `TagUpdatesOnProvisionedProduct` property as follows:
+#' Specify the `TagUpdatesOnProvisionedProduct` property as follows:
 #' 
-#'     `\{"Version":"2.0","Properties":\{"TagUpdateOnProvisionedProduct":"String"\}\}`
+#' `\{"Version":"2.0","Properties":\{"TagUpdateOnProvisionedProduct":"String"\}\}`
 #' 
-#'     The `TagUpdatesOnProvisionedProduct` property accepts a string value
-#'     of `ALLOWED` or `NOT_ALLOWED`.
+#' The `TagUpdatesOnProvisionedProduct` property accepts a string value of
+#' `ALLOWED` or `NOT_ALLOWED`.
 #' 
-#' STACKSET
+#' ### STACKSET
 #' 
-#' :   Specify the `Parameters` property as follows:
+#' Specify the `Parameters` property as follows:
 #' 
-#'     `\{"Version": "String", "Properties": \{"AccountList": \\[ "String" \\], "RegionList": \\[ "String" \\], "AdminRole": "String", "ExecutionRole": "String"\}\}`
+#' `\{"Version": "String", "Properties": \{"AccountList": \\[ "String" \\], "RegionList": \\[ "String" \\], "AdminRole": "String", "ExecutionRole": "String"\}\}`
 #' 
-#'     You cannot have both a `LAUNCH` and a `STACKSET` constraint.
+#' You cannot have both a `LAUNCH` and a `STACKSET` constraint.
 #' 
-#'     You also cannot have more than one `STACKSET` constraint on a
-#'     product and portfolio.
+#' You also cannot have more than one `STACKSET` constraint on a product
+#' and portfolio.
 #' 
-#'     Products with a `STACKSET` constraint will launch an AWS
-#'     CloudFormation stack set.
+#' Products with a `STACKSET` constraint will launch an AWS CloudFormation
+#' stack set.
 #' 
-#' TEMPLATE
+#' ### TEMPLATE
 #' 
-#' :   Specify the `Rules` property. For more information, see [Template
-#'     Constraint
-#'     Rules](http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html).
+#' Specify the `Rules` property. For more information, see [Template
+#' Constraint
+#' Rules](http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html).
 #'
 #' @section Request syntax:
 #' ```

--- a/cran/paws.management/R/ssm_operations.R
+++ b/cran/paws.management/R/ssm_operations.R
@@ -3315,34 +3315,34 @@ ssm_describe_patch_groups <- function(MaxResults = NULL, Filters = NULL, NextTok
 #' The following section lists the properties that can be used in filters
 #' for each major operating system type:
 #' 
-#' WINDOWS
+#' ### WINDOWS
 #' 
-#' :   Valid properties: PRODUCT, PRODUCT\\_FAMILY, CLASSIFICATION,
-#'     MSRC\\_SEVERITY
+#' Valid properties: PRODUCT, PRODUCT\\_FAMILY, CLASSIFICATION,
+#' MSRC\\_SEVERITY
 #' 
-#' AMAZON\\_LINUX
+#' ### AMAZON\\_LINUX
 #' 
-#' :   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+#' Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
 #' 
-#' AMAZON\\_LINUX\\_2
+#' ### AMAZON\\_LINUX\\_2
 #' 
-#' :   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+#' Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
 #' 
-#' UBUNTU
+#' ### UBUNTU
 #' 
-#' :   Valid properties: PRODUCT, PRIORITY
+#' Valid properties: PRODUCT, PRIORITY
 #' 
-#' REDHAT\\_ENTERPRISE\\_LINUX
+#' ### REDHAT\\_ENTERPRISE\\_LINUX
 #' 
-#' :   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+#' Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
 #' 
-#' SUSE
+#' ### SUSE
 #' 
-#' :   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+#' Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
 #' 
-#' CENTOS
+#' ### CENTOS
 #' 
-#' :   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+#' Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
 #'
 #' @usage
 #' ssm_describe_patch_properties(OperatingSystem, Property, PatchSet,

--- a/cran/paws.management/man/servicecatalog_create_constraint.Rd
+++ b/cran/paws.management/man/servicecatalog_create_constraint.Rd
@@ -21,46 +21,54 @@ servicecatalog_create_constraint(AcceptLanguage, PortfolioId, ProductId,
 
 \item{Parameters}{[required] The constraint parameters, in JSON format. The syntax depends on the
 constraint type as follows:
+\subsection{LAUNCH}{
 
-LAUNCH
+Specify the \code{RoleArn} property as follows:
 
-:   Specify the \code{RoleArn} property as follows:\preformatted{`\\\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\\\}`
+\verb{\\\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\\\}}
 
-You cannot have both a `LAUNCH` and a `STACKSET` constraint.
+You cannot have both a \code{LAUNCH} and a \code{STACKSET} constraint.
 
-You also cannot have more than one `LAUNCH` constraint on a product
+You also cannot have more than one \code{LAUNCH} constraint on a product and
+portfolio.
+}
+
+\subsection{NOTIFICATION}{
+
+Specify the \code{NotificationArns} property as follows:
+
+\verb{\\\{"NotificationArns" : \\\["arn:aws:sns:us-east-1:123456789012:Topic"\\\]\\\}}
+}
+
+\subsection{RESOURCE\\_UPDATE}{
+
+Specify the \code{TagUpdatesOnProvisionedProduct} property as follows:
+
+\verb{\\\{"Version":"2.0","Properties":\\\{"TagUpdateOnProvisionedProduct":"String"\\\}\\\}}
+
+The \code{TagUpdatesOnProvisionedProduct} property accepts a string value of
+\code{ALLOWED} or \code{NOT_ALLOWED}.
+}
+
+\subsection{STACKSET}{
+
+Specify the \code{Parameters} property as follows:
+
+\verb{\\\{"Version": "String", "Properties": \\\{"AccountList": \\\[ "String" \\\], "RegionList": \\\[ "String" \\\], "AdminRole": "String", "ExecutionRole": "String"\\\}\\\}}
+
+You cannot have both a \code{LAUNCH} and a \code{STACKSET} constraint.
+
+You also cannot have more than one \code{STACKSET} constraint on a product
 and portfolio.
+
+Products with a \code{STACKSET} constraint will launch an AWS CloudFormation
+stack set.
 }
 
-NOTIFICATION
+\subsection{TEMPLATE}{
 
-:   Specify the \code{NotificationArns} property as follows:\preformatted{`\\\{"NotificationArns" : \\\["arn:aws:sns:us-east-1:123456789012:Topic"\\\]\\\}`
-}
-
-RESOURCE\\_UPDATE
-
-:   Specify the \code{TagUpdatesOnProvisionedProduct} property as follows:\preformatted{`\\\{"Version":"2.0","Properties":\\\{"TagUpdateOnProvisionedProduct":"String"\\\}\\\}`
-
-The `TagUpdatesOnProvisionedProduct` property accepts a string value
-of `ALLOWED` or `NOT_ALLOWED`.
-}
-
-STACKSET
-
-:   Specify the \code{Parameters} property as follows:\preformatted{`\\\{"Version": "String", "Properties": \\\{"AccountList": \\\[ "String" \\\], "RegionList": \\\[ "String" \\\], "AdminRole": "String", "ExecutionRole": "String"\\\}\\\}`
-
-You cannot have both a `LAUNCH` and a `STACKSET` constraint.
-
-You also cannot have more than one `STACKSET` constraint on a
-product and portfolio.
-
-Products with a `STACKSET` constraint will launch an AWS
-CloudFormation stack set.
-}
-
-TEMPLATE
-
-:   Specify the \code{Rules} property. For more information, see \href{http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html}{Template Constraint Rules}.}
+Specify the \code{Rules} property. For more information, see \href{http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html}{Template Constraint Rules}.
+}}
 
 \item{Type}{[required] The type of constraint.
 \itemize{

--- a/cran/paws.management/man/servicecatalog_create_service_action.Rd
+++ b/cran/paws.management/man/servicecatalog_create_service_action.Rd
@@ -13,28 +13,33 @@ servicecatalog_create_service_action(Name, DefinitionType, Definition,
 \item{DefinitionType}{[required] The service action definition type. For example, \code{SSM_AUTOMATION}.}
 
 \item{Definition}{[required] The self-service action definition. Can be one of the following:
+\subsection{Name}{
 
-Name
-
-:   The name of the AWS Systems Manager Document. For example,
+The name of the AWS Systems Manager Document. For example,
 \code{AWS-RestartEC2Instance}.
-
-Version
-
-:   The AWS Systems Manager automation document version. For example,
-\code{"Version": "1"}
-
-AssumeRole
-
-:   The Amazon Resource Name (ARN) of the role that performs the
-self-service actions on your behalf. For example,
-\code{"AssumeRole": "arn:aws:iam::12345678910:role/ActionRole"}.\preformatted{To reuse the provisioned product launch role, set to
-`"AssumeRole": "LAUNCH_ROLE"`.
 }
 
-Parameters
+\subsection{Version}{
 
-:   The list of parameters in JSON format.\preformatted{For example: `\\\[\\\{\\"Name\\":\\"InstanceId\\",\\"Type\\":\\"TARGET\\"\\\}\\\]`.
+The AWS Systems Manager automation document version. For example,
+\code{"Version": "1"}
+}
+
+\subsection{AssumeRole}{
+
+The Amazon Resource Name (ARN) of the role that performs the
+self-service actions on your behalf. For example,
+\code{"AssumeRole": "arn:aws:iam::12345678910:role/ActionRole"}.
+
+To reuse the provisioned product launch role, set to
+\code{"AssumeRole": "LAUNCH_ROLE"}.
+}
+
+\subsection{Parameters}{
+
+The list of parameters in JSON format.
+
+For example: \verb{\\\[\\\{\\"Name\\":\\"InstanceId\\",\\"Type\\":\\"TARGET\\"\\\}\\\]}.
 }}
 
 \item{Description}{The self-service action description.}

--- a/cran/paws.management/man/servicecatalog_update_constraint.Rd
+++ b/cran/paws.management/man/servicecatalog_update_constraint.Rd
@@ -21,46 +21,54 @@ servicecatalog_update_constraint(AcceptLanguage, Id, Description,
 
 \item{Parameters}{The constraint parameters, in JSON format. The syntax depends on the
 constraint type as follows:
+\subsection{LAUNCH}{
 
-LAUNCH
+Specify the \code{RoleArn} property as follows:
 
-:   Specify the \code{RoleArn} property as follows:\preformatted{`\\\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\\\}`
+\verb{\\\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\\\}}
 
-You cannot have both a `LAUNCH` and a `STACKSET` constraint.
+You cannot have both a \code{LAUNCH} and a \code{STACKSET} constraint.
 
-You also cannot have more than one `LAUNCH` constraint on a product
+You also cannot have more than one \code{LAUNCH} constraint on a product and
+portfolio.
+}
+
+\subsection{NOTIFICATION}{
+
+Specify the \code{NotificationArns} property as follows:
+
+\verb{\\\{"NotificationArns" : \\\["arn:aws:sns:us-east-1:123456789012:Topic"\\\]\\\}}
+}
+
+\subsection{RESOURCE\\_UPDATE}{
+
+Specify the \code{TagUpdatesOnProvisionedProduct} property as follows:
+
+\verb{\\\{"Version":"2.0","Properties":\\\{"TagUpdateOnProvisionedProduct":"String"\\\}\\\}}
+
+The \code{TagUpdatesOnProvisionedProduct} property accepts a string value of
+\code{ALLOWED} or \code{NOT_ALLOWED}.
+}
+
+\subsection{STACKSET}{
+
+Specify the \code{Parameters} property as follows:
+
+\verb{\\\{"Version": "String", "Properties": \\\{"AccountList": \\\[ "String" \\\], "RegionList": \\\[ "String" \\\], "AdminRole": "String", "ExecutionRole": "String"\\\}\\\}}
+
+You cannot have both a \code{LAUNCH} and a \code{STACKSET} constraint.
+
+You also cannot have more than one \code{STACKSET} constraint on a product
 and portfolio.
+
+Products with a \code{STACKSET} constraint will launch an AWS CloudFormation
+stack set.
 }
 
-NOTIFICATION
+\subsection{TEMPLATE}{
 
-:   Specify the \code{NotificationArns} property as follows:\preformatted{`\\\{"NotificationArns" : \\\["arn:aws:sns:us-east-1:123456789012:Topic"\\\]\\\}`
-}
-
-RESOURCE\\_UPDATE
-
-:   Specify the \code{TagUpdatesOnProvisionedProduct} property as follows:\preformatted{`\\\{"Version":"2.0","Properties":\\\{"TagUpdateOnProvisionedProduct":"String"\\\}\\\}`
-
-The `TagUpdatesOnProvisionedProduct` property accepts a string value
-of `ALLOWED` or `NOT_ALLOWED`.
-}
-
-STACKSET
-
-:   Specify the \code{Parameters} property as follows:\preformatted{`\\\{"Version": "String", "Properties": \\\{"AccountList": \\\[ "String" \\\], "RegionList": \\\[ "String" \\\], "AdminRole": "String", "ExecutionRole": "String"\\\}\\\}`
-
-You cannot have both a `LAUNCH` and a `STACKSET` constraint.
-
-You also cannot have more than one `STACKSET` constraint on a
-product and portfolio.
-
-Products with a `STACKSET` constraint will launch an AWS
-CloudFormation stack set.
-}
-
-TEMPLATE
-
-:   Specify the \code{Rules} property. For more information, see \href{http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html}{Template Constraint Rules}.}
+Specify the \code{Rules} property. For more information, see \href{http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html}{Template Constraint Rules}.
+}}
 }
 \description{
 Updates the specified constraint.

--- a/cran/paws.management/man/ssm_describe_patch_properties.Rd
+++ b/cran/paws.management/man/ssm_describe_patch_properties.Rd
@@ -35,35 +35,41 @@ DescribePatchBaselines.
 \details{
 The following section lists the properties that can be used in filters
 for each major operating system type:
+\subsection{WINDOWS}{
 
-WINDOWS
-
-:   Valid properties: PRODUCT, PRODUCT\\_FAMILY, CLASSIFICATION,
+Valid properties: PRODUCT, PRODUCT\\_FAMILY, CLASSIFICATION,
 MSRC\\_SEVERITY
+}
 
-AMAZON\\_LINUX
+\subsection{AMAZON\\_LINUX}{
 
-:   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+}
 
-AMAZON\\_LINUX\\_2
+\subsection{AMAZON\\_LINUX\\_2}{
 
-:   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+}
 
-UBUNTU
+\subsection{UBUNTU}{
 
-:   Valid properties: PRODUCT, PRIORITY
+Valid properties: PRODUCT, PRIORITY
+}
 
-REDHAT\\_ENTERPRISE\\_LINUX
+\subsection{REDHAT\\_ENTERPRISE\\_LINUX}{
 
-:   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+}
 
-SUSE
+\subsection{SUSE}{
 
-:   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+}
 
-CENTOS
+\subsection{CENTOS}{
 
-:   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+}
 }
 \section{Request syntax}{
 \preformatted{svc$describe_patch_properties(

--- a/cran/paws.media.services/R/kinesisvideoarchivedmedia_operations.R
+++ b/cran/paws.media.services/R/kinesisvideoarchivedmedia_operations.R
@@ -27,14 +27,14 @@ NULL
 #' 
 #' -   The video track of each fragment must contain codec private data in
 #'     the Advanced Video Coding (AVC) for H.264 format and HEVC for H.265
-#'     format. For more information, see MPEG-4 specification ISO/IEC
-#'     14496-15. For information about adapting stream data to a given
-#'     format, see [NAL Adaptation
+#'     format. For more information, see [MPEG-4 specification ISO/IEC
+#'     14496-15](https://www.iso.org/standard/55980.html). For information
+#'     about adapting stream data to a given format, see [NAL Adaptation
 #'     Flags](http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html).
 #' 
 #' -   The audio track (if present) of each fragment must contain codec
-#'     private data in the AAC format (AAC specification ISO/IEC 13818-7)
-#'     or the [MS Wave
+#'     private data in the AAC format ([AAC specification ISO/IEC
+#'     13818-7](https://www.iso.org/standard/43345.html)) or the [MS Wave
 #'     format](http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html).
 #' 
 #' The following procedure shows how to use MPEG-DASH with Kinesis Video

--- a/cran/paws.media.services/man/kinesisvideoarchivedmedia_get_dash_streaming_session_url.Rd
+++ b/cran/paws.media.services/man/kinesisvideoarchivedmedia_get_dash_streaming_session_url.Rd
@@ -158,12 +158,10 @@ AAC) or A\\_MS/ACM (for G.711).
 \item Data retention must be greater than 0.
 \item The video track of each fragment must contain codec private data in
 the Advanced Video Coding (AVC) for H.264 format and HEVC for H.265
-format. For more information, see MPEG-4 specification ISO/IEC
-14496-15. For information about adapting stream data to a given
-format, see \href{http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html}{NAL Adaptation Flags}.
+format. For more information, see \href{https://www.iso.org/standard/55980.html}{MPEG-4 specification ISO/IEC 14496-15}. For information
+about adapting stream data to a given format, see \href{http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html}{NAL Adaptation Flags}.
 \item The audio track (if present) of each fragment must contain codec
-private data in the AAC format (AAC specification ISO/IEC 13818-7)
-or the \href{http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html}{MS Wave format}.
+private data in the AAC format (\href{https://www.iso.org/standard/43345.html}{AAC specification ISO/IEC 13818-7}) or the \href{http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html}{MS Wave format}.
 }
 
 The following procedure shows how to use MPEG-DASH with Kinesis Video

--- a/cran/paws.networking/R/globalaccelerator_service.R
+++ b/cran/paws.networking/R/globalaccelerator_service.R
@@ -35,66 +35,63 @@ NULL
 #' Global Accelerator includes components that work together to help you
 #' improve performance and availability for your applications:
 #' 
-#' Static IP address
+#' ### Static IP address
 #' 
-#' :   AWS Global Accelerator provides you with a set of static IP
-#'     addresses which are anycast from the AWS edge network and serve as
-#'     the single fixed entry points for your clients. If you already have
-#'     Elastic Load Balancing or Elastic IP address resources set up for
-#'     your applications, you can easily add those to Global Accelerator to
-#'     allow the resources to be accessed by a Global Accelerator static IP
-#'     address.
+#' AWS Global Accelerator provides you with a set of static IP addresses
+#' which are anycast from the AWS edge network and serve as the single
+#' fixed entry points for your clients. If you already have Elastic Load
+#' Balancing or Elastic IP address resources set up for your applications,
+#' you can easily add those to Global Accelerator to allow the resources to
+#' be accessed by a Global Accelerator static IP address.
 #' 
-#' Accelerator
+#' ### Accelerator
 #' 
-#' :   An accelerator directs traffic to optimal endpoints over the AWS
-#'     global network to improve availability and performance for your
-#'     internet applications that have a global audience. Each accelerator
-#'     includes one or more listeners.
+#' An accelerator directs traffic to optimal endpoints over the AWS global
+#' network to improve availability and performance for your internet
+#' applications that have a global audience. Each accelerator includes one
+#' or more listeners.
 #' 
-#' Network zone
+#' ### Network zone
 #' 
-#' :   A network zone services the static IP addresses for your accelerator
-#'     from a unique IP subnet. Similar to an AWS Availability Zone, a
-#'     network zone is an isolated unit with its own set of physical
-#'     infrastructure. When you configure an accelerator, Global
-#'     Accelerator allocates two IPv4 addresses for it. If one IP address
-#'     from a network zone becomes unavailable due to IP address blocking
-#'     by certain client networks, or network disruptions, then client
-#'     applications can retry on the healthy static IP address from the
-#'     other isolated network zone.
+#' A network zone services the static IP addresses for your accelerator
+#' from a unique IP subnet. Similar to an AWS Availability Zone, a network
+#' zone is an isolated unit with its own set of physical infrastructure.
+#' When you configure an accelerator, Global Accelerator allocates two IPv4
+#' addresses for it. If one IP address from a network zone becomes
+#' unavailable due to IP address blocking by certain client networks, or
+#' network disruptions, then client applications can retry on the healthy
+#' static IP address from the other isolated network zone.
 #' 
-#' Listener
+#' ### Listener
 #' 
-#' :   A listener processes inbound connections from clients to Global
-#'     Accelerator, based on the protocol and port that you configure. Each
-#'     listener has one or more endpoint groups associated with it, and
-#'     traffic is forwarded to endpoints in one of the groups. You
-#'     associate endpoint groups with listeners by specifying the Regions
-#'     that you want to distribute traffic to. Traffic is distributed to
-#'     optimal endpoints within the endpoint groups associated with a
-#'     listener.
+#' A listener processes inbound connections from clients to Global
+#' Accelerator, based on the protocol and port that you configure. Each
+#' listener has one or more endpoint groups associated with it, and traffic
+#' is forwarded to endpoints in one of the groups. You associate endpoint
+#' groups with listeners by specifying the Regions that you want to
+#' distribute traffic to. Traffic is distributed to optimal endpoints
+#' within the endpoint groups associated with a listener.
 #' 
-#' Endpoint group
+#' ### Endpoint group
 #' 
-#' :   Each endpoint group is associated with a specific AWS Region.
-#'     Endpoint groups include one or more endpoints in the Region. You can
-#'     increase or reduce the percentage of traffic that would be otherwise
-#'     directed to an endpoint group by adjusting a setting called a
-#'     *traffic dial*. The traffic dial lets you easily do performance
-#'     testing or blue/green deployment testing for new releases across
-#'     different AWS Regions, for example.
+#' Each endpoint group is associated with a specific AWS Region. Endpoint
+#' groups include one or more endpoints in the Region. You can increase or
+#' reduce the percentage of traffic that would be otherwise directed to an
+#' endpoint group by adjusting a setting called a *traffic dial*. The
+#' traffic dial lets you easily do performance testing or blue/green
+#' deployment testing for new releases across different AWS Regions, for
+#' example.
 #' 
-#' Endpoint
+#' ### Endpoint
 #' 
-#' :   An endpoint is an Elastic IP address, Network Load Balancer, or
-#'     Application Load Balancer. Traffic is routed to endpoints based on
-#'     several factors, including the geo-proximity to the user, the health
-#'     of the endpoint, and the configuration options that you choose, such
-#'     as endpoint weights. For each endpoint, you can configure weights,
-#'     which are numbers that you can use to specify the proportion of
-#'     traffic to route to each one. This can be useful, for example, to do
-#'     performance testing within a Region.
+#' An endpoint is an Elastic IP address, Network Load Balancer, or
+#' Application Load Balancer. Traffic is routed to endpoints based on
+#' several factors, including the geo-proximity to the user, the health of
+#' the endpoint, and the configuration options that you choose, such as
+#' endpoint weights. For each endpoint, you can configure weights, which
+#' are numbers that you can use to specify the proportion of traffic to
+#' route to each one. This can be useful, for example, to do performance
+#' testing within a Region.
 #'
 #' @param
 #' config

--- a/cran/paws.networking/R/route53_operations.R
+++ b/cran/paws.networking/R/route53_operations.R
@@ -1049,109 +1049,107 @@ route53_create_hosted_zone <- function(Name, VPC = NULL, CallerReference, Hosted
 #' 
 #' -   DNS response code, such as `NoError` or `ServFail`
 #' 
-#' Log Group and Resource Policy
+#' ### Log Group and Resource Policy
 #' 
-#' :   Before you create a query logging configuration, perform the
-#'     following operations.
+#' Before you create a query logging configuration, perform the following
+#' operations.
 #' 
-#'     If you create a query logging configuration using the Route 53
-#'     console, Route 53 performs these operations automatically.
+#' If you create a query logging configuration using the Route 53 console,
+#' Route 53 performs these operations automatically.
 #' 
-#'     1.  Create a CloudWatch Logs log group, and make note of the ARN,
-#'         which you specify when you create a query logging configuration.
-#'         Note the following:
+#' 1.  Create a CloudWatch Logs log group, and make note of the ARN, which
+#'     you specify when you create a query logging configuration. Note the
+#'     following:
 #' 
-#'         -   You must create the log group in the us-east-1 region.
+#'     -   You must create the log group in the us-east-1 region.
 #' 
-#'         -   You must use the same AWS account to create the log group
-#'             and the hosted zone that you want to configure query logging
-#'             for.
+#'     -   You must use the same AWS account to create the log group and
+#'         the hosted zone that you want to configure query logging for.
 #' 
-#'         -   When you create log groups for query logging, we recommend
-#'             that you use a consistent prefix, for example:
+#'     -   When you create log groups for query logging, we recommend that
+#'         you use a consistent prefix, for example:
 #' 
-#'             `/aws/route53/<i>hosted zone name</i> `
+#'         `/aws/route53/<i>hosted zone name</i> `
 #' 
-#'             In the next step, you\'ll create a resource policy, which
-#'             controls access to one or more log groups and the associated
-#'             AWS resources, such as Route 53 hosted zones. There\'s a
-#'             limit on the number of resource policies that you can
-#'             create, so we recommend that you use a consistent prefix so
-#'             you can use the same resource policy for all the log groups
-#'             that you create for query logging.
+#'         In the next step, you\'ll create a resource policy, which
+#'         controls access to one or more log groups and the associated AWS
+#'         resources, such as Route 53 hosted zones. There\'s a limit on
+#'         the number of resource policies that you can create, so we
+#'         recommend that you use a consistent prefix so you can use the
+#'         same resource policy for all the log groups that you create for
+#'         query logging.
 #' 
-#'     2.  Create a CloudWatch Logs resource policy, and give it the
-#'         permissions that Route 53 needs to create log streams and to
-#'         send query logs to log streams. For the value of `Resource`,
-#'         specify the ARN for the log group that you created in the
-#'         previous step. To use the same resource policy for all the
-#'         CloudWatch Logs log groups that you created for query logging
-#'         configurations, replace the hosted zone name with `*`, for
-#'         example:
+#' 2.  Create a CloudWatch Logs resource policy, and give it the
+#'     permissions that Route 53 needs to create log streams and to send
+#'     query logs to log streams. For the value of `Resource`, specify the
+#'     ARN for the log group that you created in the previous step. To use
+#'     the same resource policy for all the CloudWatch Logs log groups that
+#'     you created for query logging configurations, replace the hosted
+#'     zone name with `*`, for example:
 #' 
-#'         `arn:aws:logs:us-east-1:123412341234:log-group:/aws/route53/*`
+#'     `arn:aws:logs:us-east-1:123412341234:log-group:/aws/route53/*`
 #' 
-#'         You can\'t use the CloudWatch console to create or edit a
-#'         resource policy. You must use the CloudWatch API, one of the AWS
-#'         SDKs, or the AWS CLI.
+#'     You can\'t use the CloudWatch console to create or edit a resource
+#'     policy. You must use the CloudWatch API, one of the AWS SDKs, or the
+#'     AWS CLI.
 #' 
-#' Log Streams and Edge Locations
+#' ### Log Streams and Edge Locations
 #' 
-#' :   When Route 53 finishes creating the configuration for DNS query
-#'     logging, it does the following:
+#' When Route 53 finishes creating the configuration for DNS query logging,
+#' it does the following:
 #' 
-#'     -   Creates a log stream for an edge location the first time that
-#'         the edge location responds to DNS queries for the specified
-#'         hosted zone. That log stream is used to log all queries that
-#'         Route 53 responds to for that edge location.
+#' -   Creates a log stream for an edge location the first time that the
+#'     edge location responds to DNS queries for the specified hosted zone.
+#'     That log stream is used to log all queries that Route 53 responds to
+#'     for that edge location.
 #' 
-#'     -   Begins to send query logs to the applicable log stream.
+#' -   Begins to send query logs to the applicable log stream.
 #' 
-#'     The name of each log stream is in the following format:
+#' The name of each log stream is in the following format:
 #' 
-#'     ` <i>hosted zone ID</i>/<i>edge location code</i> `
+#' ` <i>hosted zone ID</i>/<i>edge location code</i> `
 #' 
-#'     The edge location code is a three-letter code and an arbitrarily
-#'     assigned number, for example, DFW3. The three-letter code typically
-#'     corresponds with the International Air Transport Association airport
-#'     code for an airport near the edge location. (These abbreviations
-#'     might change in the future.) For a list of edge locations, see \"The
-#'     Route 53 Global Network\" on the [Route 53 Product
-#'     Details](http://aws.amazon.com/route53/details/) page.
+#' The edge location code is a three-letter code and an arbitrarily
+#' assigned number, for example, DFW3. The three-letter code typically
+#' corresponds with the International Air Transport Association airport
+#' code for an airport near the edge location. (These abbreviations might
+#' change in the future.) For a list of edge locations, see \"The Route 53
+#' Global Network\" on the [Route 53 Product
+#' Details](http://aws.amazon.com/route53/details/) page.
 #' 
-#' Queries That Are Logged
+#' ### Queries That Are Logged
 #' 
-#' :   Query logs contain only the queries that DNS resolvers forward to
-#'     Route 53. If a DNS resolver has already cached the response to a
-#'     query (such as the IP address for a load balancer for example.com),
-#'     the resolver will continue to return the cached response. It
-#'     doesn\'t forward another query to Route 53 until the TTL for the
-#'     corresponding resource record set expires. Depending on how many DNS
-#'     queries are submitted for a resource record set, and depending on
-#'     the TTL for that resource record set, query logs might contain
-#'     information about only one query out of every several thousand
-#'     queries that are submitted to DNS. For more information about how
-#'     DNS works, see [Routing Internet Traffic to Your Website or Web
-#'     Application](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/welcome-dns-service.html)
-#'     in the *Amazon Route 53 Developer Guide*.
+#' Query logs contain only the queries that DNS resolvers forward to Route
+#' 53. If a DNS resolver has already cached the response to a query (such
+#' as the IP address for a load balancer for example.com), the resolver
+#' will continue to return the cached response. It doesn\'t forward another
+#' query to Route 53 until the TTL for the corresponding resource record
+#' set expires. Depending on how many DNS queries are submitted for a
+#' resource record set, and depending on the TTL for that resource record
+#' set, query logs might contain information about only one query out of
+#' every several thousand queries that are submitted to DNS. For more
+#' information about how DNS works, see [Routing Internet Traffic to Your
+#' Website or Web
+#' Application](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/welcome-dns-service.html)
+#' in the *Amazon Route 53 Developer Guide*.
 #' 
-#' Log File Format
+#' ### Log File Format
 #' 
-#' :   For a list of the values in each query log and the format of each
-#'     value, see [Logging DNS
-#'     Queries](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html)
-#'     in the *Amazon Route 53 Developer Guide*.
+#' For a list of the values in each query log and the format of each value,
+#' see [Logging DNS
+#' Queries](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html)
+#' in the *Amazon Route 53 Developer Guide*.
 #' 
-#' Pricing
+#' ### Pricing
 #' 
-#' :   For information about charges for query logs, see [Amazon CloudWatch
-#'     Pricing](http://aws.amazon.com/cloudwatch/pricing/).
+#' For information about charges for query logs, see [Amazon CloudWatch
+#' Pricing](http://aws.amazon.com/cloudwatch/pricing/).
 #' 
-#' How to Stop Logging
+#' ### How to Stop Logging
 #' 
-#' :   If you want Route 53 to stop sending query logs to CloudWatch Logs,
-#'     delete the query logging configuration. For more information, see
-#'     [DeleteQueryLoggingConfig](https://docs.aws.amazon.com/Route53/latest/APIReference/API_DeleteQueryLoggingConfig.html).
+#' If you want Route 53 to stop sending query logs to CloudWatch Logs,
+#' delete the query logging configuration. For more information, see
+#' [DeleteQueryLoggingConfig](https://docs.aws.amazon.com/Route53/latest/APIReference/API_DeleteQueryLoggingConfig.html).
 #'
 #' @usage
 #' route53_create_query_logging_config(HostedZoneId,
@@ -3080,25 +3078,25 @@ route53_list_query_logging_configs <- function(HostedZoneId = NULL, NextToken = 
 #' You can use the name and type elements to specify the resource record
 #' set that the list begins with:
 #' 
-#' If you do not specify Name or Type
+#' ### If you do not specify Name or Type
 #' 
-#' :   The results begin with the first resource record set that the hosted
-#'     zone contains.
+#' The results begin with the first resource record set that the hosted
+#' zone contains.
 #' 
-#' If you specify Name but not Type
+#' ### If you specify Name but not Type
 #' 
-#' :   The results begin with the first resource record set in the list
-#'     whose name is greater than or equal to `Name`.
+#' The results begin with the first resource record set in the list whose
+#' name is greater than or equal to `Name`.
 #' 
-#' If you specify Type but not Name
+#' ### If you specify Type but not Name
 #' 
-#' :   Amazon Route 53 returns the `InvalidInput` error.
+#' Amazon Route 53 returns the `InvalidInput` error.
 #' 
-#' If you specify both Name and Type
+#' ### If you specify both Name and Type
 #' 
-#' :   The results begin with the first resource record set in the list
-#'     whose name is greater than or equal to `Name`, and whose type is
-#'     greater than or equal to `Type`.
+#' The results begin with the first resource record set in the list whose
+#' name is greater than or equal to `Name`, and whose type is greater than
+#' or equal to `Type`.
 #' 
 #' **Resource record sets that are PENDING**
 #' 

--- a/cran/paws.networking/man/globalaccelerator.Rd
+++ b/cran/paws.networking/man/globalaccelerator.Rd
@@ -38,67 +38,69 @@ to only healthy endpoints.
 
 Global Accelerator includes components that work together to help you
 improve performance and availability for your applications:
+\subsection{Static IP address}{
 
-Static IP address
+AWS Global Accelerator provides you with a set of static IP addresses
+which are anycast from the AWS edge network and serve as the single
+fixed entry points for your clients. If you already have Elastic Load
+Balancing or Elastic IP address resources set up for your applications,
+you can easily add those to Global Accelerator to allow the resources to
+be accessed by a Global Accelerator static IP address.
+}
 
-:   AWS Global Accelerator provides you with a set of static IP
-addresses which are anycast from the AWS edge network and serve as
-the single fixed entry points for your clients. If you already have
-Elastic Load Balancing or Elastic IP address resources set up for
-your applications, you can easily add those to Global Accelerator to
-allow the resources to be accessed by a Global Accelerator static IP
-address.
+\subsection{Accelerator}{
 
-Accelerator
+An accelerator directs traffic to optimal endpoints over the AWS global
+network to improve availability and performance for your internet
+applications that have a global audience. Each accelerator includes one
+or more listeners.
+}
 
-:   An accelerator directs traffic to optimal endpoints over the AWS
-global network to improve availability and performance for your
-internet applications that have a global audience. Each accelerator
-includes one or more listeners.
+\subsection{Network zone}{
 
-Network zone
+A network zone services the static IP addresses for your accelerator
+from a unique IP subnet. Similar to an AWS Availability Zone, a network
+zone is an isolated unit with its own set of physical infrastructure.
+When you configure an accelerator, Global Accelerator allocates two IPv4
+addresses for it. If one IP address from a network zone becomes
+unavailable due to IP address blocking by certain client networks, or
+network disruptions, then client applications can retry on the healthy
+static IP address from the other isolated network zone.
+}
 
-:   A network zone services the static IP addresses for your accelerator
-from a unique IP subnet. Similar to an AWS Availability Zone, a
-network zone is an isolated unit with its own set of physical
-infrastructure. When you configure an accelerator, Global
-Accelerator allocates two IPv4 addresses for it. If one IP address
-from a network zone becomes unavailable due to IP address blocking
-by certain client networks, or network disruptions, then client
-applications can retry on the healthy static IP address from the
-other isolated network zone.
+\subsection{Listener}{
 
-Listener
-
-:   A listener processes inbound connections from clients to Global
+A listener processes inbound connections from clients to Global
 Accelerator, based on the protocol and port that you configure. Each
-listener has one or more endpoint groups associated with it, and
-traffic is forwarded to endpoints in one of the groups. You
-associate endpoint groups with listeners by specifying the Regions
-that you want to distribute traffic to. Traffic is distributed to
-optimal endpoints within the endpoint groups associated with a
-listener.
+listener has one or more endpoint groups associated with it, and traffic
+is forwarded to endpoints in one of the groups. You associate endpoint
+groups with listeners by specifying the Regions that you want to
+distribute traffic to. Traffic is distributed to optimal endpoints
+within the endpoint groups associated with a listener.
+}
 
-Endpoint group
+\subsection{Endpoint group}{
 
-:   Each endpoint group is associated with a specific AWS Region.
-Endpoint groups include one or more endpoints in the Region. You can
-increase or reduce the percentage of traffic that would be otherwise
-directed to an endpoint group by adjusting a setting called a
-\emph{traffic dial}. The traffic dial lets you easily do performance
-testing or blue/green deployment testing for new releases across
-different AWS Regions, for example.
+Each endpoint group is associated with a specific AWS Region. Endpoint
+groups include one or more endpoints in the Region. You can increase or
+reduce the percentage of traffic that would be otherwise directed to an
+endpoint group by adjusting a setting called a \emph{traffic dial}. The
+traffic dial lets you easily do performance testing or blue/green
+deployment testing for new releases across different AWS Regions, for
+example.
+}
 
-Endpoint
+\subsection{Endpoint}{
 
-:   An endpoint is an Elastic IP address, Network Load Balancer, or
+An endpoint is an Elastic IP address, Network Load Balancer, or
 Application Load Balancer. Traffic is routed to endpoints based on
-several factors, including the geo-proximity to the user, the health
-of the endpoint, and the configuration options that you choose, such
-as endpoint weights. For each endpoint, you can configure weights,
-which are numbers that you can use to specify the proportion of
-traffic to route to each one. This can be useful, for example, to do
-performance testing within a Region.
+several factors, including the geo-proximity to the user, the health of
+the endpoint, and the configuration options that you choose, such as
+endpoint weights. For each endpoint, you can configure weights, which
+are numbers that you can use to specify the proportion of traffic to
+route to each one. This can be useful, for example, to do performance
+testing within a Region.
+}
 }
 \section{Service syntax}{
 \preformatted{svc <- globalaccelerator(

--- a/cran/paws.networking/man/route53_create_query_logging_config.Rd
+++ b/cran/paws.networking/man/route53_create_query_logging_config.Rd
@@ -36,105 +36,107 @@ receives for a specified public hosted zone, such as the following:
 \item DNS record type, such as A or AAAA
 \item DNS response code, such as \code{NoError} or \code{ServFail}
 }
+\subsection{Log Group and Resource Policy}{
 
-Log Group and Resource Policy
+Before you create a query logging configuration, perform the following
+operations.
 
-:   Before you create a query logging configuration, perform the
-following operations.\preformatted{If you create a query logging configuration using the Route 53
-console, Route 53 performs these operations automatically.
+If you create a query logging configuration using the Route 53 console,
+Route 53 performs these operations automatically.
+\enumerate{
+\item Create a CloudWatch Logs log group, and make note of the ARN, which
+you specify when you create a query logging configuration. Note the
+following:
+\itemize{
+\item You must create the log group in the us-east-1 region.
+\item You must use the same AWS account to create the log group and
+the hosted zone that you want to configure query logging for.
+\item When you create log groups for query logging, we recommend that
+you use a consistent prefix, for example:
 
-1.  Create a CloudWatch Logs log group, and make note of the ARN,
-    which you specify when you create a query logging configuration.
-    Note the following:
+\verb{/aws/route53/<i>hosted zone name</i> }
 
-    -   You must create the log group in the us-east-1 region.
+In the next step, you\'ll create a resource policy, which
+controls access to one or more log groups and the associated AWS
+resources, such as Route 53 hosted zones. There\'s a limit on
+the number of resource policies that you can create, so we
+recommend that you use a consistent prefix so you can use the
+same resource policy for all the log groups that you create for
+query logging.
+}
+\item Create a CloudWatch Logs resource policy, and give it the
+permissions that Route 53 needs to create log streams and to send
+query logs to log streams. For the value of \code{Resource}, specify the
+ARN for the log group that you created in the previous step. To use
+the same resource policy for all the CloudWatch Logs log groups that
+you created for query logging configurations, replace the hosted
+zone name with \code{*}, for example:
 
-    -   You must use the same AWS account to create the log group
-        and the hosted zone that you want to configure query logging
-        for.
+\verb{arn:aws:logs:us-east-1:123412341234:log-group:/aws/route53/*}
 
-    -   When you create log groups for query logging, we recommend
-        that you use a consistent prefix, for example:
-
-        `/aws/route53/<i>hosted zone name</i> `
-
-        In the next step, you\\'ll create a resource policy, which
-        controls access to one or more log groups and the associated
-        AWS resources, such as Route 53 hosted zones. There\\'s a
-        limit on the number of resource policies that you can
-        create, so we recommend that you use a consistent prefix so
-        you can use the same resource policy for all the log groups
-        that you create for query logging.
-
-2.  Create a CloudWatch Logs resource policy, and give it the
-    permissions that Route 53 needs to create log streams and to
-    send query logs to log streams. For the value of `Resource`,
-    specify the ARN for the log group that you created in the
-    previous step. To use the same resource policy for all the
-    CloudWatch Logs log groups that you created for query logging
-    configurations, replace the hosted zone name with `*`, for
-    example:
-
-    `arn:aws:logs:us-east-1:123412341234:log-group:/aws/route53/*`
-
-    You can\\'t use the CloudWatch console to create or edit a
-    resource policy. You must use the CloudWatch API, one of the AWS
-    SDKs, or the AWS CLI.
+You can\'t use the CloudWatch console to create or edit a resource
+policy. You must use the CloudWatch API, one of the AWS SDKs, or the
+AWS CLI.
+}
 }
 
-Log Streams and Edge Locations
+\subsection{Log Streams and Edge Locations}{
 
-:   When Route 53 finishes creating the configuration for DNS query
-logging, it does the following:\preformatted{-   Creates a log stream for an edge location the first time that
-    the edge location responds to DNS queries for the specified
-    hosted zone. That log stream is used to log all queries that
-    Route 53 responds to for that edge location.
-
--   Begins to send query logs to the applicable log stream.
+When Route 53 finishes creating the configuration for DNS query logging,
+it does the following:
+\itemize{
+\item Creates a log stream for an edge location the first time that the
+edge location responds to DNS queries for the specified hosted zone.
+That log stream is used to log all queries that Route 53 responds to
+for that edge location.
+\item Begins to send query logs to the applicable log stream.
+}
 
 The name of each log stream is in the following format:
 
-` <i>hosted zone ID</i>/<i>edge location code</i> `
+\verb{<i>hosted zone ID</i>/<i>edge location code</i>}
 
 The edge location code is a three-letter code and an arbitrarily
 assigned number, for example, DFW3. The three-letter code typically
 corresponds with the International Air Transport Association airport
-code for an airport near the edge location. (These abbreviations
-might change in the future.) For a list of edge locations, see \\"The
-Route 53 Global Network\\" on the [Route 53 Product
-Details](http://aws.amazon.com/route53/details/) page.
+code for an airport near the edge location. (These abbreviations might
+change in the future.) For a list of edge locations, see \"The Route 53
+Global Network\" on the \href{http://aws.amazon.com/route53/details/}{Route 53 Product Details} page.
 }
 
-Queries That Are Logged
+\subsection{Queries That Are Logged}{
 
-:   Query logs contain only the queries that DNS resolvers forward to
-Route 53. If a DNS resolver has already cached the response to a
-query (such as the IP address for a load balancer for example.com),
-the resolver will continue to return the cached response. It
-doesn\'t forward another query to Route 53 until the TTL for the
-corresponding resource record set expires. Depending on how many DNS
-queries are submitted for a resource record set, and depending on
-the TTL for that resource record set, query logs might contain
-information about only one query out of every several thousand
-queries that are submitted to DNS. For more information about how
-DNS works, see \href{https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/welcome-dns-service.html}{Routing Internet Traffic to Your Website or Web Application}
+Query logs contain only the queries that DNS resolvers forward to Route
+53. If a DNS resolver has already cached the response to a query (such
+as the IP address for a load balancer for example.com), the resolver
+will continue to return the cached response. It doesn\'t forward another
+query to Route 53 until the TTL for the corresponding resource record
+set expires. Depending on how many DNS queries are submitted for a
+resource record set, and depending on the TTL for that resource record
+set, query logs might contain information about only one query out of
+every several thousand queries that are submitted to DNS. For more
+information about how DNS works, see \href{https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/welcome-dns-service.html}{Routing Internet Traffic to Your Website or Web Application}
 in the \emph{Amazon Route 53 Developer Guide}.
+}
 
-Log File Format
+\subsection{Log File Format}{
 
-:   For a list of the values in each query log and the format of each
-value, see \href{https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html}{Logging DNS Queries}
+For a list of the values in each query log and the format of each value,
+see \href{https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html}{Logging DNS Queries}
 in the \emph{Amazon Route 53 Developer Guide}.
+}
 
-Pricing
+\subsection{Pricing}{
 
-:   For information about charges for query logs, see \href{http://aws.amazon.com/cloudwatch/pricing/}{Amazon CloudWatch Pricing}.
+For information about charges for query logs, see \href{http://aws.amazon.com/cloudwatch/pricing/}{Amazon CloudWatch Pricing}.
+}
 
-How to Stop Logging
+\subsection{How to Stop Logging}{
 
-:   If you want Route 53 to stop sending query logs to CloudWatch Logs,
+If you want Route 53 to stop sending query logs to CloudWatch Logs,
 delete the query logging configuration. For more information, see
 \href{https://docs.aws.amazon.com/Route53/latest/APIReference/API_DeleteQueryLoggingConfig.html}{DeleteQueryLoggingConfig}.
+}
 }
 \section{Request syntax}{
 \preformatted{svc$create_query_logging_config(

--- a/cran/paws.networking/man/route53_list_resource_record_sets.Rd
+++ b/cran/paws.networking/man/route53_list_resource_record_sets.Rd
@@ -79,26 +79,28 @@ sorts results by the record type.
 
 You can use the name and type elements to specify the resource record
 set that the list begins with:
+\subsection{If you do not specify Name or Type}{
 
-If you do not specify Name or Type
-
-:   The results begin with the first resource record set that the hosted
+The results begin with the first resource record set that the hosted
 zone contains.
+}
 
-If you specify Name but not Type
+\subsection{If you specify Name but not Type}{
 
-:   The results begin with the first resource record set in the list
-whose name is greater than or equal to \code{Name}.
+The results begin with the first resource record set in the list whose
+name is greater than or equal to \code{Name}.
+}
 
-If you specify Type but not Name
+\subsection{If you specify Type but not Name}{
 
-:   Amazon Route 53 returns the \code{InvalidInput} error.
+Amazon Route 53 returns the \code{InvalidInput} error.
+}
 
-If you specify both Name and Type
+\subsection{If you specify both Name and Type}{
 
-:   The results begin with the first resource record set in the list
-whose name is greater than or equal to \code{Name}, and whose type is
-greater than or equal to \code{Type}.
+The results begin with the first resource record set in the list whose
+name is greater than or equal to \code{Name}, and whose type is greater than
+or equal to \code{Type}.
 
 \strong{Resource record sets that are PENDING}
 
@@ -123,6 +125,7 @@ of results, get the values of \code{NextRecordName}, \code{NextRecordType}, and
 \code{NextRecordIdentifier} (if any) from the response. Then submit another
 \code{ListResourceRecordSets} request, and specify those values for
 \code{StartRecordName}, \code{StartRecordType}, and \code{StartRecordIdentifier}.
+}
 }
 \section{Request syntax}{
 \preformatted{svc$list_resource_record_sets(

--- a/cran/paws.robotics/R/robomaker_operations.R
+++ b/cran/paws.robotics/R/robomaker_operations.R
@@ -507,13 +507,13 @@ robomaker_create_simulation_application_version <- function(application, current
 #' is how credentials are passed in to your simulation job.
 #' @param failureBehavior The failure behavior the simulation job.
 #' 
-#' Continue
+#' ### Continue
 #' 
-#' :   Restart the simulation job in the same host instance.
+#' Restart the simulation job in the same host instance.
 #' 
-#' Fail
+#' ### Fail
 #' 
-#' :   Stop the simulation job and terminate the instance.
+#' Stop the simulation job and terminate the instance.
 #' @param robotApplications The robot application to use in the simulation job.
 #' @param simulationApplications The simulation application to use in the simulation job.
 #' @param dataSources The data sources for the simulation job.

--- a/cran/paws.robotics/man/robomaker_create_simulation_job.Rd
+++ b/cran/paws.robotics/man/robomaker_create_simulation_job.Rd
@@ -25,14 +25,15 @@ APIs that are specified in its associated policies on your behalf. This
 is how credentials are passed in to your simulation job.}
 
 \item{failureBehavior}{The failure behavior the simulation job.
+\subsection{Continue}{
 
-Continue
+Restart the simulation job in the same host instance.
+}
 
-:   Restart the simulation job in the same host instance.
+\subsection{Fail}{
 
-Fail
-
-:   Stop the simulation job and terminate the instance.}
+Stop the simulation job and terminate the instance.
+}}
 
 \item{robotApplications}{The robot application to use in the simulation job.}
 

--- a/cran/paws.security.identity/R/kms_operations.R
+++ b/cran/paws.security.identity/R/kms_operations.R
@@ -579,49 +579,49 @@ kms_create_grant <- function(KeyId, GranteePrincipal, RetiringPrincipal = NULL, 
 #' 
 #' To create different types of CMKs, use the following guidance:
 #' 
-#' Asymmetric CMKs
+#' ### Asymmetric CMKs
 #' 
-#' :   To create an asymmetric CMK, use the `CustomerMasterKeySpec`
-#'     parameter to specify the type of key material in the CMK. Then, use
-#'     the `KeyUsage` parameter to determine whether the CMK will be used
-#'     to encrypt and decrypt or sign and verify. You can\'t change these
-#'     properties after the CMK is created.
+#' To create an asymmetric CMK, use the `CustomerMasterKeySpec` parameter
+#' to specify the type of key material in the CMK. Then, use the `KeyUsage`
+#' parameter to determine whether the CMK will be used to encrypt and
+#' decrypt or sign and verify. You can\'t change these properties after the
+#' CMK is created.
 #' 
-#' Symmetric CMKs
+#' ### Symmetric CMKs
 #' 
-#' :   When creating a symmetric CMK, you don\'t need to specify the
-#'     `CustomerMasterKeySpec` or `KeyUsage` parameters. The default value
-#'     for `CustomerMasterKeySpec`, `SYMMETRIC_DEFAULT`, and the default
-#'     value for `KeyUsage`, `ENCRYPT_DECRYPT`, are the only valid values
-#'     for symmetric CMKs.
+#' When creating a symmetric CMK, you don\'t need to specify the
+#' `CustomerMasterKeySpec` or `KeyUsage` parameters. The default value for
+#' `CustomerMasterKeySpec`, `SYMMETRIC_DEFAULT`, and the default value for
+#' `KeyUsage`, `ENCRYPT_DECRYPT`, are the only valid values for symmetric
+#' CMKs.
 #' 
-#' Imported Key Material
+#' ### Imported Key Material
 #' 
-#' :   To import your own key material, begin by creating a symmetric CMK
-#'     with no key material. To do this, use the `Origin` parameter of
-#'     `CreateKey` with a value of `EXTERNAL`. Next, use
-#'     GetParametersForImport operation to get a public key and import
-#'     token, and use the public key to encrypt your key material. Then,
-#'     use ImportKeyMaterial with your import token to import the key
-#'     material. For step-by-step instructions, see [Importing Key
-#'     Material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-#'     in the **AWS Key Management Service Developer Guide** . You cannot
-#'     import the key material into an asymmetric CMK.
+#' To import your own key material, begin by creating a symmetric CMK with
+#' no key material. To do this, use the `Origin` parameter of `CreateKey`
+#' with a value of `EXTERNAL`. Next, use GetParametersForImport operation
+#' to get a public key and import token, and use the public key to encrypt
+#' your key material. Then, use ImportKeyMaterial with your import token to
+#' import the key material. For step-by-step instructions, see [Importing
+#' Key
+#' Material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+#' in the **AWS Key Management Service Developer Guide** . You cannot
+#' import the key material into an asymmetric CMK.
 #' 
-#' Custom Key Stores
+#' ### Custom Key Stores
 #' 
-#' :   To create a symmetric CMK in a [custom key
-#'     store](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
-#'     use the `CustomKeyStoreId` parameter to specify the custom key
-#'     store. You must also use the `Origin` parameter with a value of
-#'     `AWS_CLOUDHSM`. The AWS CloudHSM cluster that is associated with the
-#'     custom key store must have at least two active HSMs in different
-#'     Availability Zones in the AWS Region.
+#' To create a symmetric CMK in a [custom key
+#' store](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
+#' use the `CustomKeyStoreId` parameter to specify the custom key store.
+#' You must also use the `Origin` parameter with a value of `AWS_CLOUDHSM`.
+#' The AWS CloudHSM cluster that is associated with the custom key store
+#' must have at least two active HSMs in different Availability Zones in
+#' the AWS Region.
 #' 
-#'     You cannot create an asymmetric CMK in a custom key store. For
-#'     information about custom key stores in AWS KMS see [Using Custom Key
-#'     Stores](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-#'     in the **AWS Key Management Service Developer Guide** .
+#' You cannot create an asymmetric CMK in a custom key store. For
+#' information about custom key stores in AWS KMS see [Using Custom Key
+#' Stores](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
+#' in the **AWS Key Management Service Developer Guide** .
 #'
 #' @usage
 #' kms_create_key(Policy, Description, KeyUsage, CustomerMasterKeySpec,

--- a/cran/paws.security.identity/man/kms_create_key.Rd
+++ b/cran/paws.security.identity/man/kms_create_key.Rd
@@ -183,46 +183,48 @@ For information about symmetric and asymmetric CMKs, see \href{https://docs.aws.
 in the \emph{AWS Key Management Service Developer Guide}.
 
 To create different types of CMKs, use the following guidance:
+\subsection{Asymmetric CMKs}{
 
-Asymmetric CMKs
+To create an asymmetric CMK, use the \code{CustomerMasterKeySpec} parameter
+to specify the type of key material in the CMK. Then, use the \code{KeyUsage}
+parameter to determine whether the CMK will be used to encrypt and
+decrypt or sign and verify. You can\'t change these properties after the
+CMK is created.
+}
 
-:   To create an asymmetric CMK, use the \code{CustomerMasterKeySpec}
-parameter to specify the type of key material in the CMK. Then, use
-the \code{KeyUsage} parameter to determine whether the CMK will be used
-to encrypt and decrypt or sign and verify. You can\'t change these
-properties after the CMK is created.
+\subsection{Symmetric CMKs}{
 
-Symmetric CMKs
+When creating a symmetric CMK, you don\'t need to specify the
+\code{CustomerMasterKeySpec} or \code{KeyUsage} parameters. The default value for
+\code{CustomerMasterKeySpec}, \code{SYMMETRIC_DEFAULT}, and the default value for
+\code{KeyUsage}, \code{ENCRYPT_DECRYPT}, are the only valid values for symmetric
+CMKs.
+}
 
-:   When creating a symmetric CMK, you don\'t need to specify the
-\code{CustomerMasterKeySpec} or \code{KeyUsage} parameters. The default value
-for \code{CustomerMasterKeySpec}, \code{SYMMETRIC_DEFAULT}, and the default
-value for \code{KeyUsage}, \code{ENCRYPT_DECRYPT}, are the only valid values
-for symmetric CMKs.
+\subsection{Imported Key Material}{
 
-Imported Key Material
-
-:   To import your own key material, begin by creating a symmetric CMK
-with no key material. To do this, use the \code{Origin} parameter of
-\code{CreateKey} with a value of \code{EXTERNAL}. Next, use
-GetParametersForImport operation to get a public key and import
-token, and use the public key to encrypt your key material. Then,
-use ImportKeyMaterial with your import token to import the key
-material. For step-by-step instructions, see \href{https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html}{Importing Key Material}
+To import your own key material, begin by creating a symmetric CMK with
+no key material. To do this, use the \code{Origin} parameter of \code{CreateKey}
+with a value of \code{EXTERNAL}. Next, use GetParametersForImport operation
+to get a public key and import token, and use the public key to encrypt
+your key material. Then, use ImportKeyMaterial with your import token to
+import the key material. For step-by-step instructions, see \href{https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html}{Importing Key Material}
 in the \strong{AWS Key Management Service Developer Guide} . You cannot
 import the key material into an asymmetric CMK.
+}
 
-Custom Key Stores
+\subsection{Custom Key Stores}{
 
-:   To create a symmetric CMK in a \href{https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html}{custom key store},
-use the \code{CustomKeyStoreId} parameter to specify the custom key
-store. You must also use the \code{Origin} parameter with a value of
-\code{AWS_CLOUDHSM}. The AWS CloudHSM cluster that is associated with the
-custom key store must have at least two active HSMs in different
-Availability Zones in the AWS Region.\preformatted{You cannot create an asymmetric CMK in a custom key store. For
-information about custom key stores in AWS KMS see [Using Custom Key
-Stores](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-in the **AWS Key Management Service Developer Guide** .
+To create a symmetric CMK in a \href{https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html}{custom key store},
+use the \code{CustomKeyStoreId} parameter to specify the custom key store.
+You must also use the \code{Origin} parameter with a value of \code{AWS_CLOUDHSM}.
+The AWS CloudHSM cluster that is associated with the custom key store
+must have at least two active HSMs in different Availability Zones in
+the AWS Region.
+
+You cannot create an asymmetric CMK in a custom key store. For
+information about custom key stores in AWS KMS see \href{https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html}{Using Custom Key Stores}
+in the \strong{AWS Key Management Service Developer Guide} .
 }
 }
 \section{Request syntax}{

--- a/cran/paws.storage/R/s3_operations.R
+++ b/cran/paws.storage/R/s3_operations.R
@@ -340,162 +340,159 @@ s3_complete_multipart_upload <- function(Bucket, Key, MultipartUpload = NULL, Up
 #' 
 #' Following are other considerations when using `CopyObject`:
 #' 
-#' Versioning
+#' ### Versioning
 #' 
-#' :   By default, `x-amz-copy-source` identifies the current version of an
-#'     object to copy. (If the current version is a delete marker, Amazon
-#'     S3 behaves as if the object was deleted.) To copy a different
-#'     version, use the `versionId` subresource.
+#' By default, `x-amz-copy-source` identifies the current version of an
+#' object to copy. (If the current version is a delete marker, Amazon S3
+#' behaves as if the object was deleted.) To copy a different version, use
+#' the `versionId` subresource.
 #' 
-#'     If you enable versioning on the target bucket, Amazon S3 generates a
-#'     unique version ID for the object being copied. This version ID is
-#'     different from the version ID of the source object. Amazon S3
-#'     returns the version ID of the copied object in the
-#'     `x-amz-version-id` response header in the response.
+#' If you enable versioning on the target bucket, Amazon S3 generates a
+#' unique version ID for the object being copied. This version ID is
+#' different from the version ID of the source object. Amazon S3 returns
+#' the version ID of the copied object in the `x-amz-version-id` response
+#' header in the response.
 #' 
-#'     If you do not enable versioning or suspend it on the target bucket,
-#'     the version ID that Amazon S3 generates is always null.
+#' If you do not enable versioning or suspend it on the target bucket, the
+#' version ID that Amazon S3 generates is always null.
 #' 
-#'     If the source object\'s storage class is GLACIER, you must restore a
-#'     copy of this object before you can use it as a source object for the
-#'     copy operation. For more information, see .
+#' If the source object\'s storage class is GLACIER, you must restore a
+#' copy of this object before you can use it as a source object for the
+#' copy operation. For more information, see .
 #' 
-#' Access Permissions
+#' ### Access Permissions
 #' 
-#' :   When copying an object, you can optionally specify the accounts or
-#'     groups that should be granted specific permissions on the new
-#'     object. There are two ways to grant the permissions using the
-#'     request headers:
+#' When copying an object, you can optionally specify the accounts or
+#' groups that should be granted specific permissions on the new object.
+#' There are two ways to grant the permissions using the request headers:
 #' 
-#'     -   Specify a canned ACL with the `x-amz-acl` request header. For
-#'         more information, see [Canned
-#'         ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+#' -   Specify a canned ACL with the `x-amz-acl` request header. For more
+#'     information, see [Canned
+#'     ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
 #' 
-#'     -   Specify access permissions explicitly with the
-#'         `x-amz-grant-read`, `x-amz-grant-read-acp`,
-#'         `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers.
-#'         These parameters map to the set of permissions that Amazon S3
-#'         supports in an ACL. For more information, see [Access Control
-#'         List (ACL)
-#'         Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+#' -   Specify access permissions explicitly with the `x-amz-grant-read`,
+#'     `x-amz-grant-read-acp`, `x-amz-grant-write-acp`, and
+#'     `x-amz-grant-full-control` headers. These parameters map to the set
+#'     of permissions that Amazon S3 supports in an ACL. For more
+#'     information, see [Access Control List (ACL)
+#'     Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
 #' 
-#'     You can use either a canned ACL or specify access permissions
-#'     explicitly. You cannot do both.
+#' You can use either a canned ACL or specify access permissions
+#' explicitly. You cannot do both.
 #' 
-#' Server-Side- Encryption-Specific Request Headers
+#' ### Server-Side- Encryption-Specific Request Headers
 #' 
-#' :   To encrypt the target object, you must provide the appropriate
-#'     encryption-related request headers. The one you use depends on
-#'     whether you want to use AWS managed encryption keys or provide your
-#'     own encryption key.
+#' To encrypt the target object, you must provide the appropriate
+#' encryption-related request headers. The one you use depends on whether
+#' you want to use AWS managed encryption keys or provide your own
+#' encryption key.
 #' 
-#'     -   To encrypt the target object using server-side encryption with
-#'         an AWS managed encryption key, provide the following request
-#'         headers, as appropriate.
+#' -   To encrypt the target object using server-side encryption with an
+#'     AWS managed encryption key, provide the following request headers,
+#'     as appropriate.
 #' 
-#'         -   `x-amz-server-sideâ€‹-encryption`
+#'     -   `x-amz-server-sideâ€‹-encryption`
 #' 
-#'         -   `x-amz-server-side-encryption-aws-kms-key-id`
+#'     -   `x-amz-server-side-encryption-aws-kms-key-id`
 #' 
-#'         -   `x-amz-server-side-encryption-context`
+#'     -   `x-amz-server-side-encryption-context`
 #' 
-#'         If you specify `x-amz-server-side-encryption:aws:kms`, but
-#'         don\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-#'         Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-#'         data. If you want to use a customer managed AWS KMS CMK, you
-#'         must provide the `x-amz-server-side-encryption-aws-kms-key-id`
-#'         of the symmetric customer managed CMK. Amazon S3 only supports
-#'         symmetric CMKs and not asymmetric CMKs. For more information,
-#'         see [Using Symmetric and Asymmetric
-#'         Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-#'         in the *AWS Key Management Service Developer Guide*.
+#'     If you specify `x-amz-server-side-encryption:aws:kms`, but don\'t
+#'     provide `x-amz-server-side-encryption-aws-kms-key-id`, Amazon S3
+#'     uses the AWS managed CMK in AWS KMS to protect the data. If you want
+#'     to use a customer managed AWS KMS CMK, you must provide the
+#'     `x-amz-server-side-encryption-aws-kms-key-id` of the symmetric
+#'     customer managed CMK. Amazon S3 only supports symmetric CMKs and not
+#'     asymmetric CMKs. For more information, see [Using Symmetric and
+#'     Asymmetric
+#'     Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+#'     in the *AWS Key Management Service Developer Guide*.
 #' 
-#'         All GET and PUT requests for an object protected by AWS KMS fail
-#'         if you don\'t make them with SSL or by using SigV4.
+#'     All GET and PUT requests for an object protected by AWS KMS fail if
+#'     you don\'t make them with SSL or by using SigV4.
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in
-#'         KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in
+#'     KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#'     -   To encrypt the target object using server-side encryption with
-#'         an encryption key that you provide, use the following headers.
+#' -   To encrypt the target object using server-side encryption with an
+#'     encryption key that you provide, use the following headers.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
 #' 
-#'     -   If the source object is encrypted using server-side encryption
-#'         with customer-provided encryption keys, you must use the
-#'         following headers.
+#' -   If the source object is encrypted using server-side encryption with
+#'     customer-provided encryption keys, you must use the following
+#'     headers.
 #' 
-#'         -   x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+#'     -   x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-algorithm
 #' 
-#'         -   x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-key
+#'     -   x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-key
 #' 
-#'         -   x-amz-copy-source-â€‹server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+#'     -   x-amz-copy-source-â€‹server-sideâ€‹-encryptionâ€‹-customer-key-MD5
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in Amazon
-#'         KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in Amazon
+#'     KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#' Access-Control-List (ACL)-Specific Request Headers
+#' ### Access-Control-List (ACL)-Specific Request Headers
 #' 
-#' :   You also can use the following access control--related headers with
-#'     this operation. By default, all objects are private. Only the owner
-#'     has full access control. When adding a new object, you can grant
-#'     permissions to individual AWS accounts or to predefined groups
-#'     defined by Amazon S3. These permissions are then added to the access
-#'     control list (ACL) on the object. For more information, see [Using
-#'     ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
-#'     With this operation, you can grant access permissions using one of
-#'     the following two methods:
+#' You also can use the following access control--related headers with this
+#' operation. By default, all objects are private. Only the owner has full
+#' access control. When adding a new object, you can grant permissions to
+#' individual AWS accounts or to predefined groups defined by Amazon S3.
+#' These permissions are then added to the access control list (ACL) on the
+#' object. For more information, see [Using
+#' ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
+#' With this operation, you can grant access permissions using one of the
+#' following two methods:
 #' 
-#'     -   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set
-#'         of predefined ACLs, known as *canned ACLs*. Each canned ACL has
-#'         a predefined set of grantees and permissions. For more
-#'         information, see [Canned
-#'         ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+#' -   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set of
+#'     predefined ACLs, known as *canned ACLs*. Each canned ACL has a
+#'     predefined set of grantees and permissions. For more information,
+#'     see [Canned
+#'     ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
 #' 
-#'     -   Specify access permissions explicitly --- To explicitly grant
-#'         access permissions to specific AWS accounts or groups, use the
-#'         following headers. Each header maps to specific permissions that
-#'         Amazon S3 supports in an ACL. For more information, see [Access
-#'         Control List (ACL)
-#'         Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
-#'         In the header, you specify a list of grantees who get the
-#'         specific permission. To grant permissions explicitly, use:
+#' -   Specify access permissions explicitly --- To explicitly grant access
+#'     permissions to specific AWS accounts or groups, use the following
+#'     headers. Each header maps to specific permissions that Amazon S3
+#'     supports in an ACL. For more information, see [Access Control List
+#'     (ACL)
+#'     Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+#'     In the header, you specify a list of grantees who get the specific
+#'     permission. To grant permissions explicitly, use:
 #' 
-#'         -   x-amz-grant-read
+#'     -   x-amz-grant-read
 #' 
-#'         -   x-amz-grant-write
+#'     -   x-amz-grant-write
 #' 
-#'         -   x-amz-grant-read-acp
+#'     -   x-amz-grant-read-acp
 #' 
-#'         -   x-amz-grant-write-acp
+#'     -   x-amz-grant-write-acp
 #' 
-#'         -   x-amz-grant-full-control
+#'     -   x-amz-grant-full-control
 #' 
-#'         You specify each grantee as a type=value pair, where the type is
-#'         one of the following:
+#'     You specify each grantee as a type=value pair, where the type is one
+#'     of the following:
 #' 
-#'         -   `emailAddress` -- if the value specified is the email
-#'             address of an AWS account
+#'     -   `emailAddress` -- if the value specified is the email address of
+#'         an AWS account
 #' 
-#'         -   `id` -- if the value specified is the canonical user ID of
-#'             an AWS account
+#'     -   `id` -- if the value specified is the canonical user ID of an
+#'         AWS account
 #' 
-#'         -   `uri` -- if you are granting permissions to a predefined
-#'             group
+#'     -   `uri` -- if you are granting permissions to a predefined group
 #' 
-#'         For example, the following `x-amz-grant-read` header grants the
-#'         AWS accounts identified by email addresses permissions to read
-#'         object data and its metadata:
+#'     For example, the following `x-amz-grant-read` header grants the AWS
+#'     accounts identified by email addresses permissions to read object
+#'     data and its metadata:
 #' 
-#'         `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
+#'     `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
 #' 
 #' The following operations are related to `CopyObject`:
 #' 
@@ -876,130 +873,126 @@ s3_create_bucket <- function(ACL = NULL, Bucket, CreateBucketConfiguration = NUL
 #' For more information, see [Protecting Data Using Server-Side
 #' Encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html).
 #' 
-#' Access Permissions
+#' ### Access Permissions
 #' 
-#' :   When copying an object, you can optionally specify the accounts or
-#'     groups that should be granted specific permissions on the new
-#'     object. There are two ways to grant the permissions using the
-#'     request headers:
+#' When copying an object, you can optionally specify the accounts or
+#' groups that should be granted specific permissions on the new object.
+#' There are two ways to grant the permissions using the request headers:
 #' 
-#'     -   Specify a canned ACL with the `x-amz-acl` request header. For
-#'         more information, see [Canned
-#'         ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+#' -   Specify a canned ACL with the `x-amz-acl` request header. For more
+#'     information, see [Canned
+#'     ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
 #' 
-#'     -   Specify access permissions explicitly with the
-#'         `x-amz-grant-read`, `x-amz-grant-read-acp`,
-#'         `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers.
-#'         These parameters map to the set of permissions that Amazon S3
-#'         supports in an ACL. For more information, see [Access Control
-#'         List (ACL)
-#'         Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+#' -   Specify access permissions explicitly with the `x-amz-grant-read`,
+#'     `x-amz-grant-read-acp`, `x-amz-grant-write-acp`, and
+#'     `x-amz-grant-full-control` headers. These parameters map to the set
+#'     of permissions that Amazon S3 supports in an ACL. For more
+#'     information, see [Access Control List (ACL)
+#'     Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
 #' 
-#'     You can use either a canned ACL or specify access permissions
-#'     explicitly. You cannot do both.
+#' You can use either a canned ACL or specify access permissions
+#' explicitly. You cannot do both.
 #' 
-#' Server-Side- Encryption-Specific Request Headers
+#' ### Server-Side- Encryption-Specific Request Headers
 #' 
-#' :   You can optionally tell Amazon S3 to encrypt data at rest using
-#'     server-side encryption. Server-side encryption is for data
-#'     encryption at rest. Amazon S3 encrypts your data as it writes it to
-#'     disks in its data centers and decrypts it when you access it. The
-#'     option you use depends on whether you want to use AWS managed
-#'     encryption keys or provide your own encryption key.
+#' You can optionally tell Amazon S3 to encrypt data at rest using
+#' server-side encryption. Server-side encryption is for data encryption at
+#' rest. Amazon S3 encrypts your data as it writes it to disks in its data
+#' centers and decrypts it when you access it. The option you use depends
+#' on whether you want to use AWS managed encryption keys or provide your
+#' own encryption key.
 #' 
-#'     -   Use encryption keys managed by Amazon S3 or customer master keys
-#'         (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you
-#'         want AWS to manage the keys used to encrypt data, specify the
-#'         following headers in the request.
+#' -   Use encryption keys managed by Amazon S3 or customer master keys
+#'     (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you want
+#'     AWS to manage the keys used to encrypt data, specify the following
+#'     headers in the request.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryption
+#'     -   x-amz-server-sideâ€‹-encryption
 #' 
-#'         -   x-amz-server-side-encryption-aws-kms-key-id
+#'     -   x-amz-server-side-encryption-aws-kms-key-id
 #' 
-#'         -   x-amz-server-side-encryption-context
+#'     -   x-amz-server-side-encryption-context
 #' 
-#'         If you specify `x-amz-server-side-encryption:aws:kms`, but
-#'         don\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-#'         Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-#'         data.
+#'     If you specify `x-amz-server-side-encryption:aws:kms`, but don\'t
+#'     provide `x-amz-server-side-encryption-aws-kms-key-id`, Amazon S3
+#'     uses the AWS managed CMK in AWS KMS to protect the data.
 #' 
-#'         All GET and PUT requests for an object protected by AWS KMS fail
-#'         if you don\'t make them with SSL or by using SigV4.
+#'     All GET and PUT requests for an object protected by AWS KMS fail if
+#'     you don\'t make them with SSL or by using SigV4.
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in AWS
-#'         KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in AWS
+#'     KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#'     -   Use customer-provided encryption keys -- If you want to manage
-#'         your own encryption keys, provide all the following headers in
-#'         the request.
+#' -   Use customer-provided encryption keys -- If you want to manage your
+#'     own encryption keys, provide all the following headers in the
+#'     request.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in AWS
-#'         KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in AWS
+#'     KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#' Access-Control-List (ACL)-Specific Request Headers
+#' ### Access-Control-List (ACL)-Specific Request Headers
 #' 
-#' :   You also can use the following access control--related headers with
-#'     this operation. By default, all objects are private. Only the owner
-#'     has full access control. When adding a new object, you can grant
-#'     permissions to individual AWS accounts or to predefined groups
-#'     defined by Amazon S3. These permissions are then added to the access
-#'     control list (ACL) on the object. For more information, see [Using
-#'     ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
-#'     With this operation, you can grant access permissions using one of
-#'     the following two methods:
+#' You also can use the following access control--related headers with this
+#' operation. By default, all objects are private. Only the owner has full
+#' access control. When adding a new object, you can grant permissions to
+#' individual AWS accounts or to predefined groups defined by Amazon S3.
+#' These permissions are then added to the access control list (ACL) on the
+#' object. For more information, see [Using
+#' ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
+#' With this operation, you can grant access permissions using one of the
+#' following two methods:
 #' 
-#'     -   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set
-#'         of predefined ACLs, known as *canned ACLs*. Each canned ACL has
-#'         a predefined set of grantees and permissions. For more
-#'         information, see [Canned
-#'         ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+#' -   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set of
+#'     predefined ACLs, known as *canned ACLs*. Each canned ACL has a
+#'     predefined set of grantees and permissions. For more information,
+#'     see [Canned
+#'     ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
 #' 
-#'     -   Specify access permissions explicitly --- To explicitly grant
-#'         access permissions to specific AWS accounts or groups, use the
-#'         following headers. Each header maps to specific permissions that
-#'         Amazon S3 supports in an ACL. For more information, see [Access
-#'         Control List (ACL)
-#'         Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
-#'         In the header, you specify a list of grantees who get the
-#'         specific permission. To grant permissions explicitly, use:
+#' -   Specify access permissions explicitly --- To explicitly grant access
+#'     permissions to specific AWS accounts or groups, use the following
+#'     headers. Each header maps to specific permissions that Amazon S3
+#'     supports in an ACL. For more information, see [Access Control List
+#'     (ACL)
+#'     Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+#'     In the header, you specify a list of grantees who get the specific
+#'     permission. To grant permissions explicitly, use:
 #' 
-#'         -   x-amz-grant-read
+#'     -   x-amz-grant-read
 #' 
-#'         -   x-amz-grant-write
+#'     -   x-amz-grant-write
 #' 
-#'         -   x-amz-grant-read-acp
+#'     -   x-amz-grant-read-acp
 #' 
-#'         -   x-amz-grant-write-acp
+#'     -   x-amz-grant-write-acp
 #' 
-#'         -   x-amz-grant-full-control
+#'     -   x-amz-grant-full-control
 #' 
-#'         You specify each grantee as a type=value pair, where the type is
-#'         one of the following:
+#'     You specify each grantee as a type=value pair, where the type is one
+#'     of the following:
 #' 
-#'         -   `emailAddress` -- if the value specified is the email
-#'             address of an AWS account
+#'     -   `emailAddress` -- if the value specified is the email address of
+#'         an AWS account
 #' 
-#'         -   `id` -- if the value specified is the canonical user ID of
-#'             an AWS account
+#'     -   `id` -- if the value specified is the canonical user ID of an
+#'         AWS account
 #' 
-#'         -   `uri` -- if you are granting permissions to a predefined
-#'             group
+#'     -   `uri` -- if you are granting permissions to a predefined group
 #' 
-#'         For example, the following `x-amz-grant-read` header grants the
-#'         AWS accounts identified by email addresses permissions to read
-#'         object data and its metadata:
+#'     For example, the following `x-amz-grant-read` header grants the AWS
+#'     accounts identified by email addresses permissions to read object
+#'     data and its metadata:
 #' 
-#'         `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
+#'     `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
 #' 
 #' The following operations are related to `CreateMultipartUpload`:
 #' 
@@ -7315,216 +7308,214 @@ s3_put_bucket_website <- function(Bucket, ContentMD5 = NULL, WebsiteConfiguratio
 #' keys. For more information, see [Using Server-Side
 #' Encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html).
 #' 
-#' Access Permissions
+#' ### Access Permissions
 #' 
-#' :   You can optionally specify the accounts or groups that should be
-#'     granted specific permissions on the new object. There are two ways
-#'     to grant the permissions using the request headers:
+#' You can optionally specify the accounts or groups that should be granted
+#' specific permissions on the new object. There are two ways to grant the
+#' permissions using the request headers:
 #' 
-#'     -   Specify a canned ACL with the `x-amz-acl` request header. For
-#'         more information, see [Canned
-#'         ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+#' -   Specify a canned ACL with the `x-amz-acl` request header. For more
+#'     information, see [Canned
+#'     ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
 #' 
-#'     -   Specify access permissions explicitly with the
-#'         `x-amz-grant-read`, `x-amz-grant-read-acp`,
-#'         `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers.
-#'         These parameters map to the set of permissions that Amazon S3
-#'         supports in an ACL. For more information, see [Access Control
-#'         List (ACL)
-#'         Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+#' -   Specify access permissions explicitly with the `x-amz-grant-read`,
+#'     `x-amz-grant-read-acp`, `x-amz-grant-write-acp`, and
+#'     `x-amz-grant-full-control` headers. These parameters map to the set
+#'     of permissions that Amazon S3 supports in an ACL. For more
+#'     information, see [Access Control List (ACL)
+#'     Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
 #' 
-#'     You can use either a canned ACL or specify access permissions
-#'     explicitly. You cannot do both.
+#' You can use either a canned ACL or specify access permissions
+#' explicitly. You cannot do both.
 #' 
-#' Server-Side- Encryption-Specific Request Headers
+#' ### Server-Side- Encryption-Specific Request Headers
 #' 
-#' :   You can optionally tell Amazon S3 to encrypt data at rest using
-#'     server-side encryption. Server-side encryption is for data
-#'     encryption at rest. Amazon S3 encrypts your data as it writes it to
-#'     disks in its data centers and decrypts it when you access it. The
-#'     option you use depends on whether you want to use AWS managed
-#'     encryption keys or provide your own encryption key.
+#' You can optionally tell Amazon S3 to encrypt data at rest using
+#' server-side encryption. Server-side encryption is for data encryption at
+#' rest. Amazon S3 encrypts your data as it writes it to disks in its data
+#' centers and decrypts it when you access it. The option you use depends
+#' on whether you want to use AWS managed encryption keys or provide your
+#' own encryption key.
 #' 
-#'     -   Use encryption keys managed by Amazon S3 or customer master keys
-#'         (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you
-#'         want AWS to manage the keys used to encrypt data, specify the
-#'         following headers in the request.
+#' -   Use encryption keys managed by Amazon S3 or customer master keys
+#'     (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you want
+#'     AWS to manage the keys used to encrypt data, specify the following
+#'     headers in the request.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryption
+#'     -   x-amz-server-sideâ€‹-encryption
 #' 
-#'         -   x-amz-server-side-encryption-aws-kms-key-id
+#'     -   x-amz-server-side-encryption-aws-kms-key-id
 #' 
-#'         -   x-amz-server-side-encryption-context
+#'     -   x-amz-server-side-encryption-context
 #' 
-#'         If you specify `x-amz-server-side-encryption:aws:kms`, but
-#'         don\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-#'         Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-#'         data. If you want to use a customer managed AWS KMS CMK, you
-#'         must provide the `x-amz-server-side-encryption-aws-kms-key-id`
-#'         of the symmetric customer managed CMK. Amazon S3 only supports
-#'         symmetric CMKs and not asymmetric CMKs. For more information,
-#'         see [Using Symmetric and Asymmetric
-#'         Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-#'         in the *AWS Key Management Service Developer Guide*.
+#'     If you specify `x-amz-server-side-encryption:aws:kms`, but don\'t
+#'     provide `x-amz-server-side-encryption-aws-kms-key-id`, Amazon S3
+#'     uses the AWS managed CMK in AWS KMS to protect the data. If you want
+#'     to use a customer managed AWS KMS CMK, you must provide the
+#'     `x-amz-server-side-encryption-aws-kms-key-id` of the symmetric
+#'     customer managed CMK. Amazon S3 only supports symmetric CMKs and not
+#'     asymmetric CMKs. For more information, see [Using Symmetric and
+#'     Asymmetric
+#'     Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+#'     in the *AWS Key Management Service Developer Guide*.
 #' 
-#'         All GET and PUT requests for an object protected by AWS KMS fail
-#'         if you don\'t make them with SSL or by using SigV4.
+#'     All GET and PUT requests for an object protected by AWS KMS fail if
+#'     you don\'t make them with SSL or by using SigV4.
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in
-#'         AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in
+#'     AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#'     -   Use customer-provided encryption keys -- If you want to manage
-#'         your own encryption keys, provide all the following headers in
-#'         the request.
+#' -   Use customer-provided encryption keys -- If you want to manage your
+#'     own encryption keys, provide all the following headers in the
+#'     request.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in KMS (SSE-KMS), see [Protecting Data Using Server-Side
-#'         Encryption with CMKs stored in
-#'         AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in KMS (SSE-KMS), see [Protecting Data Using Server-Side Encryption
+#'     with CMKs stored in
+#'     AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#' Access-Control-List (ACL)-Specific Request Headers
+#' ### Access-Control-List (ACL)-Specific Request Headers
 #' 
-#' :   You also can use the following access control--related headers with
-#'     this operation. By default, all objects are private. Only the owner
-#'     has full access control. When adding a new object, you can grant
-#'     permissions to individual AWS accounts or to predefined groups
-#'     defined by Amazon S3. These permissions are then added to the Access
-#'     Control List (ACL) on the object. For more information, see [Using
-#'     ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
-#'     With this operation, you can grant access permissions using one of
-#'     the following two methods:
+#' You also can use the following access control--related headers with this
+#' operation. By default, all objects are private. Only the owner has full
+#' access control. When adding a new object, you can grant permissions to
+#' individual AWS accounts or to predefined groups defined by Amazon S3.
+#' These permissions are then added to the Access Control List (ACL) on the
+#' object. For more information, see [Using
+#' ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
+#' With this operation, you can grant access permissions using one of the
+#' following two methods:
 #' 
-#'     -   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set
-#'         of predefined ACLs, known as canned ACLs. Each canned ACL has a
-#'         predefined set of grantees and permissions. For more
-#'         information, see [Canned
-#'         ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+#' -   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set of
+#'     predefined ACLs, known as canned ACLs. Each canned ACL has a
+#'     predefined set of grantees and permissions. For more information,
+#'     see [Canned
+#'     ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
 #' 
-#'     -   Specify access permissions explicitly --- To explicitly grant
-#'         access permissions to specific AWS accounts or groups, use the
-#'         following headers. Each header maps to specific permissions that
-#'         Amazon S3 supports in an ACL. For more information, see [Access
-#'         Control List (ACL)
-#'         Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
-#'         In the header, you specify a list of grantees who get the
-#'         specific permission. To grant permissions explicitly use:
+#' -   Specify access permissions explicitly --- To explicitly grant access
+#'     permissions to specific AWS accounts or groups, use the following
+#'     headers. Each header maps to specific permissions that Amazon S3
+#'     supports in an ACL. For more information, see [Access Control List
+#'     (ACL)
+#'     Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+#'     In the header, you specify a list of grantees who get the specific
+#'     permission. To grant permissions explicitly use:
 #' 
-#'         -   x-amz-grant-read
+#'     -   x-amz-grant-read
 #' 
-#'         -   x-amz-grant-write
+#'     -   x-amz-grant-write
 #' 
-#'         -   x-amz-grant-read-acp
+#'     -   x-amz-grant-read-acp
 #' 
-#'         -   x-amz-grant-write-acp
+#'     -   x-amz-grant-write-acp
 #' 
-#'         -   x-amz-grant-full-control
+#'     -   x-amz-grant-full-control
 #' 
-#'         You specify each grantee as a type=value pair, where the type is
-#'         one of the following:
+#'     You specify each grantee as a type=value pair, where the type is one
+#'     of the following:
 #' 
-#'         -   `emailAddress` -- if the value specified is the email
-#'             address of an AWS account
+#'     -   `emailAddress` -- if the value specified is the email address of
+#'         an AWS account
 #' 
-#'             Using email addresses to specify a grantee is only supported
-#'             in the following AWS Regions:
+#'         Using email addresses to specify a grantee is only supported in
+#'         the following AWS Regions:
 #' 
-#'             -   US East (N. Virginia)
+#'         -   US East (N. Virginia)
 #' 
-#'             -   US West (N. California)
+#'         -   US West (N. California)
 #' 
-#'             -   US West (Oregon)
+#'         -   US West (Oregon)
 #' 
-#'             -   Asia Pacific (Singapore)
+#'         -   Asia Pacific (Singapore)
 #' 
-#'             -   Asia Pacific (Sydney)
+#'         -   Asia Pacific (Sydney)
 #' 
-#'             -   Asia Pacific (Tokyo)
+#'         -   Asia Pacific (Tokyo)
 #' 
-#'             -   EU (Ireland)
+#'         -   EU (Ireland)
 #' 
-#'             -   South America (SÃ£o Paulo)
+#'         -   South America (SÃ£o Paulo)
 #' 
-#'             For a list of all the Amazon S3 supported Regions and
-#'             endpoints, see [Regions and
-#'             Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
-#'             in the AWS General Reference
+#'         For a list of all the Amazon S3 supported Regions and endpoints,
+#'         see [Regions and
+#'         Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
+#'         in the AWS General Reference
 #' 
-#'         -   `id` -- if the value specified is the canonical user ID of
-#'             an AWS account
+#'     -   `id` -- if the value specified is the canonical user ID of an
+#'         AWS account
 #' 
-#'         -   `uri` -- if you are granting permissions to a predefined
-#'             group
+#'     -   `uri` -- if you are granting permissions to a predefined group
 #' 
-#'         For example, the following `x-amz-grant-read` header grants the
-#'         AWS accounts identified by email addresses permissions to read
-#'         object data and its metadata:
+#'     For example, the following `x-amz-grant-read` header grants the AWS
+#'     accounts identified by email addresses permissions to read object
+#'     data and its metadata:
 #' 
-#'         `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
+#'     `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
 #' 
-#' Server-Side- Encryption-Specific Request Headers
+#' ### Server-Side- Encryption-Specific Request Headers
 #' 
-#' :   You can optionally tell Amazon S3 to encrypt data at rest using
-#'     server-side encryption. Server-side encryption is for data
-#'     encryption at rest. Amazon S3 encrypts your data as it writes it to
-#'     disks in its data centers and decrypts it when you access it. The
-#'     option you use depends on whether you want to use AWS-managed
-#'     encryption keys or provide your own encryption key.
+#' You can optionally tell Amazon S3 to encrypt data at rest using
+#' server-side encryption. Server-side encryption is for data encryption at
+#' rest. Amazon S3 encrypts your data as it writes it to disks in its data
+#' centers and decrypts it when you access it. The option you use depends
+#' on whether you want to use AWS-managed encryption keys or provide your
+#' own encryption key.
 #' 
-#'     -   Use encryption keys managed by Amazon S3 or customer master keys
-#'         (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you
-#'         want AWS to manage the keys used to encrypt data, specify the
-#'         following headers in the request.
+#' -   Use encryption keys managed by Amazon S3 or customer master keys
+#'     (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you want
+#'     AWS to manage the keys used to encrypt data, specify the following
+#'     headers in the request.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryption
+#'     -   x-amz-server-sideâ€‹-encryption
 #' 
-#'         -   x-amz-server-side-encryption-aws-kms-key-id
+#'     -   x-amz-server-side-encryption-aws-kms-key-id
 #' 
-#'         -   x-amz-server-side-encryption-context
+#'     -   x-amz-server-side-encryption-context
 #' 
-#'         If you specify `x-amz-server-side-encryption:aws:kms`, but
-#'         don\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-#'         Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-#'         data. If you want to use a customer managed AWS KMS CMK, you
-#'         must provide the `x-amz-server-side-encryption-aws-kms-key-id`
-#'         of the symmetric customer managed CMK. Amazon S3 only supports
-#'         symmetric CMKs and not asymmetric CMKs. For more information,
-#'         see [Using Symmetric and Asymmetric
-#'         Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-#'         in the *AWS Key Management Service Developer Guide*.
+#'     If you specify `x-amz-server-side-encryption:aws:kms`, but don\'t
+#'     provide `x-amz-server-side-encryption-aws-kms-key-id`, Amazon S3
+#'     uses the AWS managed CMK in AWS KMS to protect the data. If you want
+#'     to use a customer managed AWS KMS CMK, you must provide the
+#'     `x-amz-server-side-encryption-aws-kms-key-id` of the symmetric
+#'     customer managed CMK. Amazon S3 only supports symmetric CMKs and not
+#'     asymmetric CMKs. For more information, see [Using Symmetric and
+#'     Asymmetric
+#'     Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+#'     in the *AWS Key Management Service Developer Guide*.
 #' 
-#'         All GET and PUT requests for an object protected by AWS KMS fail
-#'         if you don\'t make them with SSL or by using SigV4.
+#'     All GET and PUT requests for an object protected by AWS KMS fail if
+#'     you don\'t make them with SSL or by using SigV4.
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in AWS
-#'         KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in AWS
+#'     KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#'     -   Use customer-provided encryption keys -- If you want to manage
-#'         your own encryption keys, provide all the following headers in
-#'         the request.
+#' -   Use customer-provided encryption keys -- If you want to manage your
+#'     own encryption keys, provide all the following headers in the
+#'     request.
 #' 
-#'         If you use this feature, the ETag value that Amazon S3 returns
-#'         in the response is not the MD5 of the object.
+#'     If you use this feature, the ETag value that Amazon S3 returns in
+#'     the response is not the MD5 of the object.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in AWS
-#'         KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in AWS
+#'     KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
 #' **Storage Class Options**
 #' 

--- a/cran/paws.storage/man/s3_copy_object.Rd
+++ b/cran/paws.storage/man/s3_copy_object.Rd
@@ -215,157 +215,141 @@ The copy request charge is based on the storage class and Region you
 specify for the destination object. For pricing information, see \href{https://aws.amazon.com/s3/pricing/}{Amazon S3 Pricing}.
 
 Following are other considerations when using \code{CopyObject}:
+\subsection{Versioning}{
 
-Versioning
+By default, \code{x-amz-copy-source} identifies the current version of an
+object to copy. (If the current version is a delete marker, Amazon S3
+behaves as if the object was deleted.) To copy a different version, use
+the \code{versionId} subresource.
 
-:   By default, \code{x-amz-copy-source} identifies the current version of an
-object to copy. (If the current version is a delete marker, Amazon
-S3 behaves as if the object was deleted.) To copy a different
-version, use the \code{versionId} subresource.\preformatted{If you enable versioning on the target bucket, Amazon S3 generates a
+If you enable versioning on the target bucket, Amazon S3 generates a
 unique version ID for the object being copied. This version ID is
-different from the version ID of the source object. Amazon S3
-returns the version ID of the copied object in the
-`x-amz-version-id` response header in the response.
+different from the version ID of the source object. Amazon S3 returns
+the version ID of the copied object in the \code{x-amz-version-id} response
+header in the response.
 
-If you do not enable versioning or suspend it on the target bucket,
-the version ID that Amazon S3 generates is always null.
+If you do not enable versioning or suspend it on the target bucket, the
+version ID that Amazon S3 generates is always null.
 
-If the source object\\'s storage class is GLACIER, you must restore a
+If the source object\'s storage class is GLACIER, you must restore a
 copy of this object before you can use it as a source object for the
 copy operation. For more information, see .
 }
 
-Access Permissions
+\subsection{Access Permissions}{
 
-:   When copying an object, you can optionally specify the accounts or
-groups that should be granted specific permissions on the new
-object. There are two ways to grant the permissions using the
-request headers:\preformatted{-   Specify a canned ACL with the `x-amz-acl` request header. For
-    more information, see [Canned
-    ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
-
--   Specify access permissions explicitly with the
-    `x-amz-grant-read`, `x-amz-grant-read-acp`,
-    `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers.
-    These parameters map to the set of permissions that Amazon S3
-    supports in an ACL. For more information, see [Access Control
-    List (ACL)
-    Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+When copying an object, you can optionally specify the accounts or
+groups that should be granted specific permissions on the new object.
+There are two ways to grant the permissions using the request headers:
+\itemize{
+\item Specify a canned ACL with the \code{x-amz-acl} request header. For more
+information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL}{Canned ACL}.
+\item Specify access permissions explicitly with the \code{x-amz-grant-read},
+\code{x-amz-grant-read-acp}, \code{x-amz-grant-write-acp}, and
+\code{x-amz-grant-full-control} headers. These parameters map to the set
+of permissions that Amazon S3 supports in an ACL. For more
+information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html}{Access Control List (ACL) Overview}.
+}
 
 You can use either a canned ACL or specify access permissions
 explicitly. You cannot do both.
 }
 
-Server-Side- Encryption-Specific Request Headers
+\subsection{Server-Side- Encryption-Specific Request Headers}{
 
-:   To encrypt the target object, you must provide the appropriate
-encryption-related request headers. The one you use depends on
-whether you want to use AWS managed encryption keys or provide your
-own encryption key.\preformatted{-   To encrypt the target object using server-side encryption with
-    an AWS managed encryption key, provide the following request
-    headers, as appropriate.
-
-    -   `x-amz-server-sideâ€‹-encryption`
-
-    -   `x-amz-server-side-encryption-aws-kms-key-id`
-
-    -   `x-amz-server-side-encryption-context`
-
-    If you specify `x-amz-server-side-encryption:aws:kms`, but
-    don\\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-    Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-    data. If you want to use a customer managed AWS KMS CMK, you
-    must provide the `x-amz-server-side-encryption-aws-kms-key-id`
-    of the symmetric customer managed CMK. Amazon S3 only supports
-    symmetric CMKs and not asymmetric CMKs. For more information,
-    see [Using Symmetric and Asymmetric
-    Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-    in the *AWS Key Management Service Developer Guide*.
-
-    All GET and PUT requests for an object protected by AWS KMS fail
-    if you don\\'t make them with SSL or by using SigV4.
-
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in
-    KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
-
--   To encrypt the target object using server-side encryption with
-    an encryption key that you provide, use the following headers.
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
-
--   If the source object is encrypted using server-side encryption
-    with customer-provided encryption keys, you must use the
-    following headers.
-
-    -   x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-algorithm
-
-    -   x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-key
-
-    -   x-amz-copy-source-â€‹server-sideâ€‹-encryptionâ€‹-customer-key-MD5
-
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in Amazon
-    KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+To encrypt the target object, you must provide the appropriate
+encryption-related request headers. The one you use depends on whether
+you want to use AWS managed encryption keys or provide your own
+encryption key.
+\itemize{
+\item To encrypt the target object using server-side encryption with an
+AWS managed encryption key, provide the following request headers,
+as appropriate.
+\itemize{
+\item \verb{x-amz-server-sideâ€‹-encryption}
+\item \code{x-amz-server-side-encryption-aws-kms-key-id}
+\item \code{x-amz-server-side-encryption-context}
 }
 
-Access-Control-List (ACL)-Specific Request Headers
+If you specify \code{x-amz-server-side-encryption:aws:kms}, but don\'t
+provide \code{x-amz-server-side-encryption-aws-kms-key-id}, Amazon S3
+uses the AWS managed CMK in AWS KMS to protect the data. If you want
+to use a customer managed AWS KMS CMK, you must provide the
+\code{x-amz-server-side-encryption-aws-kms-key-id} of the symmetric
+customer managed CMK. Amazon S3 only supports symmetric CMKs and not
+asymmetric CMKs. For more information, see \href{https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html}{Using Symmetric and Asymmetric Keys}
+in the \emph{AWS Key Management Service Developer Guide}.
 
-:   You also can use the following access control--related headers with
-this operation. By default, all objects are private. Only the owner
-has full access control. When adding a new object, you can grant
-permissions to individual AWS accounts or to predefined groups
-defined by Amazon S3. These permissions are then added to the access
-control list (ACL) on the object. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html}{Using ACLs}.
-With this operation, you can grant access permissions using one of
-the following two methods:\preformatted{-   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set
-    of predefined ACLs, known as *canned ACLs*. Each canned ACL has
-    a predefined set of grantees and permissions. For more
-    information, see [Canned
-    ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+All GET and PUT requests for an object protected by AWS KMS fail if
+you don\'t make them with SSL or by using SigV4.
 
--   Specify access permissions explicitly --- To explicitly grant
-    access permissions to specific AWS accounts or groups, use the
-    following headers. Each header maps to specific permissions that
-    Amazon S3 supports in an ACL. For more information, see [Access
-    Control List (ACL)
-    Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
-    In the header, you specify a list of grantees who get the
-    specific permission. To grant permissions explicitly, use:
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in KMS}.
+\item To encrypt the target object using server-side encryption with an
+encryption key that you provide, use the following headers.
+\itemize{
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+}
+\item If the source object is encrypted using server-side encryption with
+customer-provided encryption keys, you must use the following
+headers.
+\itemize{
+\item x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+\item x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-key
+\item x-amz-copy-source-â€‹server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+}
 
-    -   x-amz-grant-read
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in Amazon KMS}.
+}
+}
 
-    -   x-amz-grant-write
+\subsection{Access-Control-List (ACL)-Specific Request Headers}{
 
-    -   x-amz-grant-read-acp
+You also can use the following access control--related headers with this
+operation. By default, all objects are private. Only the owner has full
+access control. When adding a new object, you can grant permissions to
+individual AWS accounts or to predefined groups defined by Amazon S3.
+These permissions are then added to the access control list (ACL) on the
+object. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html}{Using ACLs}.
+With this operation, you can grant access permissions using one of the
+following two methods:
+\itemize{
+\item Specify a canned ACL (\code{x-amz-acl}) --- Amazon S3 supports a set of
+predefined ACLs, known as \emph{canned ACLs}. Each canned ACL has a
+predefined set of grantees and permissions. For more information,
+see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL}{Canned ACL}.
+\item Specify access permissions explicitly --- To explicitly grant access
+permissions to specific AWS accounts or groups, use the following
+headers. Each header maps to specific permissions that Amazon S3
+supports in an ACL. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html}{Access Control List (ACL) Overview}.
+In the header, you specify a list of grantees who get the specific
+permission. To grant permissions explicitly, use:
+\itemize{
+\item x-amz-grant-read
+\item x-amz-grant-write
+\item x-amz-grant-read-acp
+\item x-amz-grant-write-acp
+\item x-amz-grant-full-control
+}
 
-    -   x-amz-grant-write-acp
+You specify each grantee as a type=value pair, where the type is one
+of the following:
+\itemize{
+\item \code{emailAddress} -- if the value specified is the email address of
+an AWS account
+\item \code{id} -- if the value specified is the canonical user ID of an
+AWS account
+\item \code{uri} -- if you are granting permissions to a predefined group
+}
 
-    -   x-amz-grant-full-control
+For example, the following \code{x-amz-grant-read} header grants the AWS
+accounts identified by email addresses permissions to read object
+data and its metadata:
 
-    You specify each grantee as a type=value pair, where the type is
-    one of the following:
-
-    -   `emailAddress` -- if the value specified is the email
-        address of an AWS account
-
-    -   `id` -- if the value specified is the canonical user ID of
-        an AWS account
-
-    -   `uri` -- if you are granting permissions to a predefined
-        group
-
-    For example, the following `x-amz-grant-read` header grants the
-    AWS accounts identified by email addresses permissions to read
-    object data and its metadata:
-
-    `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
+\verb{x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" }
 }
 
 The following operations are related to \code{CopyObject}:
@@ -375,6 +359,7 @@ The following operations are related to \code{CopyObject}:
 }
 
 For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html}{Copying Objects}.
+}
 }
 \section{Request syntax}{
 \preformatted{svc$copy_object(

--- a/cran/paws.storage/man/s3_create_multipart_upload.Rd
+++ b/cran/paws.storage/man/s3_create_multipart_upload.Rd
@@ -145,126 +145,111 @@ different account than the key, then you must have the permissions on
 both the key policy and your IAM user or role.
 
 For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html}{Protecting Data Using Server-Side Encryption}.
+\subsection{Access Permissions}{
 
-Access Permissions
-
-:   When copying an object, you can optionally specify the accounts or
-groups that should be granted specific permissions on the new
-object. There are two ways to grant the permissions using the
-request headers:\preformatted{-   Specify a canned ACL with the `x-amz-acl` request header. For
-    more information, see [Canned
-    ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
-
--   Specify access permissions explicitly with the
-    `x-amz-grant-read`, `x-amz-grant-read-acp`,
-    `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers.
-    These parameters map to the set of permissions that Amazon S3
-    supports in an ACL. For more information, see [Access Control
-    List (ACL)
-    Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+When copying an object, you can optionally specify the accounts or
+groups that should be granted specific permissions on the new object.
+There are two ways to grant the permissions using the request headers:
+\itemize{
+\item Specify a canned ACL with the \code{x-amz-acl} request header. For more
+information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL}{Canned ACL}.
+\item Specify access permissions explicitly with the \code{x-amz-grant-read},
+\code{x-amz-grant-read-acp}, \code{x-amz-grant-write-acp}, and
+\code{x-amz-grant-full-control} headers. These parameters map to the set
+of permissions that Amazon S3 supports in an ACL. For more
+information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html}{Access Control List (ACL) Overview}.
+}
 
 You can use either a canned ACL or specify access permissions
 explicitly. You cannot do both.
 }
 
-Server-Side- Encryption-Specific Request Headers
+\subsection{Server-Side- Encryption-Specific Request Headers}{
 
-:   You can optionally tell Amazon S3 to encrypt data at rest using
-server-side encryption. Server-side encryption is for data
-encryption at rest. Amazon S3 encrypts your data as it writes it to
-disks in its data centers and decrypts it when you access it. The
-option you use depends on whether you want to use AWS managed
-encryption keys or provide your own encryption key.\preformatted{-   Use encryption keys managed by Amazon S3 or customer master keys
-    (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you
-    want AWS to manage the keys used to encrypt data, specify the
-    following headers in the request.
-
-    -   x-amz-server-sideâ€‹-encryption
-
-    -   x-amz-server-side-encryption-aws-kms-key-id
-
-    -   x-amz-server-side-encryption-context
-
-    If you specify `x-amz-server-side-encryption:aws:kms`, but
-    don\\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-    Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-    data.
-
-    All GET and PUT requests for an object protected by AWS KMS fail
-    if you don\\'t make them with SSL or by using SigV4.
-
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in AWS
-    KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
-
--   Use customer-provided encryption keys -- If you want to manage
-    your own encryption keys, provide all the following headers in
-    the request.
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
-
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in AWS
-    KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+You can optionally tell Amazon S3 to encrypt data at rest using
+server-side encryption. Server-side encryption is for data encryption at
+rest. Amazon S3 encrypts your data as it writes it to disks in its data
+centers and decrypts it when you access it. The option you use depends
+on whether you want to use AWS managed encryption keys or provide your
+own encryption key.
+\itemize{
+\item Use encryption keys managed by Amazon S3 or customer master keys
+(CMKs) stored in AWS Key Management Service (AWS KMS) -- If you want
+AWS to manage the keys used to encrypt data, specify the following
+headers in the request.
+\itemize{
+\item x-amz-server-sideâ€‹-encryption
+\item x-amz-server-side-encryption-aws-kms-key-id
+\item x-amz-server-side-encryption-context
 }
 
-Access-Control-List (ACL)-Specific Request Headers
+If you specify \code{x-amz-server-side-encryption:aws:kms}, but don\'t
+provide \code{x-amz-server-side-encryption-aws-kms-key-id}, Amazon S3
+uses the AWS managed CMK in AWS KMS to protect the data.
 
-:   You also can use the following access control--related headers with
-this operation. By default, all objects are private. Only the owner
-has full access control. When adding a new object, you can grant
-permissions to individual AWS accounts or to predefined groups
-defined by Amazon S3. These permissions are then added to the access
-control list (ACL) on the object. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html}{Using ACLs}.
-With this operation, you can grant access permissions using one of
-the following two methods:\preformatted{-   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set
-    of predefined ACLs, known as *canned ACLs*. Each canned ACL has
-    a predefined set of grantees and permissions. For more
-    information, see [Canned
-    ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+All GET and PUT requests for an object protected by AWS KMS fail if
+you don\'t make them with SSL or by using SigV4.
 
--   Specify access permissions explicitly --- To explicitly grant
-    access permissions to specific AWS accounts or groups, use the
-    following headers. Each header maps to specific permissions that
-    Amazon S3 supports in an ACL. For more information, see [Access
-    Control List (ACL)
-    Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
-    In the header, you specify a list of grantees who get the
-    specific permission. To grant permissions explicitly, use:
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in AWS KMS}.
+\item Use customer-provided encryption keys -- If you want to manage your
+own encryption keys, provide all the following headers in the
+request.
+\itemize{
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+}
 
-    -   x-amz-grant-read
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in AWS KMS}.
+}
+}
 
-    -   x-amz-grant-write
+\subsection{Access-Control-List (ACL)-Specific Request Headers}{
 
-    -   x-amz-grant-read-acp
+You also can use the following access control--related headers with this
+operation. By default, all objects are private. Only the owner has full
+access control. When adding a new object, you can grant permissions to
+individual AWS accounts or to predefined groups defined by Amazon S3.
+These permissions are then added to the access control list (ACL) on the
+object. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html}{Using ACLs}.
+With this operation, you can grant access permissions using one of the
+following two methods:
+\itemize{
+\item Specify a canned ACL (\code{x-amz-acl}) --- Amazon S3 supports a set of
+predefined ACLs, known as \emph{canned ACLs}. Each canned ACL has a
+predefined set of grantees and permissions. For more information,
+see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL}{Canned ACL}.
+\item Specify access permissions explicitly --- To explicitly grant access
+permissions to specific AWS accounts or groups, use the following
+headers. Each header maps to specific permissions that Amazon S3
+supports in an ACL. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html}{Access Control List (ACL) Overview}.
+In the header, you specify a list of grantees who get the specific
+permission. To grant permissions explicitly, use:
+\itemize{
+\item x-amz-grant-read
+\item x-amz-grant-write
+\item x-amz-grant-read-acp
+\item x-amz-grant-write-acp
+\item x-amz-grant-full-control
+}
 
-    -   x-amz-grant-write-acp
+You specify each grantee as a type=value pair, where the type is one
+of the following:
+\itemize{
+\item \code{emailAddress} -- if the value specified is the email address of
+an AWS account
+\item \code{id} -- if the value specified is the canonical user ID of an
+AWS account
+\item \code{uri} -- if you are granting permissions to a predefined group
+}
 
-    -   x-amz-grant-full-control
+For example, the following \code{x-amz-grant-read} header grants the AWS
+accounts identified by email addresses permissions to read object
+data and its metadata:
 
-    You specify each grantee as a type=value pair, where the type is
-    one of the following:
-
-    -   `emailAddress` -- if the value specified is the email
-        address of an AWS account
-
-    -   `id` -- if the value specified is the canonical user ID of
-        an AWS account
-
-    -   `uri` -- if you are granting permissions to a predefined
-        group
-
-    For example, the following `x-amz-grant-read` header grants the
-    AWS accounts identified by email addresses permissions to read
-    object data and its metadata:
-
-    `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
+\verb{x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" }
 }
 
 The following operations are related to \code{CreateMultipartUpload}:
@@ -274,6 +259,7 @@ The following operations are related to \code{CreateMultipartUpload}:
 \item AbortMultipartUpload
 \item ListParts
 \item ListMultipartUploads
+}
 }
 }
 \section{Request syntax}{

--- a/cran/paws.storage/man/s3_put_object.Rd
+++ b/cran/paws.storage/man/s3_put_object.Rd
@@ -174,211 +174,183 @@ encryption, Amazon S3 encrypts your data as it writes it to disks in its
 data centers and decrypts the data when you access it. You have the
 option to provide your own encryption key or use AWS managed encryption
 keys. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html}{Using Server-Side Encryption}.
+\subsection{Access Permissions}{
 
-Access Permissions
-
-:   You can optionally specify the accounts or groups that should be
-granted specific permissions on the new object. There are two ways
-to grant the permissions using the request headers:\preformatted{-   Specify a canned ACL with the `x-amz-acl` request header. For
-    more information, see [Canned
-    ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
-
--   Specify access permissions explicitly with the
-    `x-amz-grant-read`, `x-amz-grant-read-acp`,
-    `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers.
-    These parameters map to the set of permissions that Amazon S3
-    supports in an ACL. For more information, see [Access Control
-    List (ACL)
-    Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+You can optionally specify the accounts or groups that should be granted
+specific permissions on the new object. There are two ways to grant the
+permissions using the request headers:
+\itemize{
+\item Specify a canned ACL with the \code{x-amz-acl} request header. For more
+information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL}{Canned ACL}.
+\item Specify access permissions explicitly with the \code{x-amz-grant-read},
+\code{x-amz-grant-read-acp}, \code{x-amz-grant-write-acp}, and
+\code{x-amz-grant-full-control} headers. These parameters map to the set
+of permissions that Amazon S3 supports in an ACL. For more
+information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html}{Access Control List (ACL) Overview}.
+}
 
 You can use either a canned ACL or specify access permissions
 explicitly. You cannot do both.
 }
 
-Server-Side- Encryption-Specific Request Headers
+\subsection{Server-Side- Encryption-Specific Request Headers}{
 
-:   You can optionally tell Amazon S3 to encrypt data at rest using
-server-side encryption. Server-side encryption is for data
-encryption at rest. Amazon S3 encrypts your data as it writes it to
-disks in its data centers and decrypts it when you access it. The
-option you use depends on whether you want to use AWS managed
-encryption keys or provide your own encryption key.\preformatted{-   Use encryption keys managed by Amazon S3 or customer master keys
-    (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you
-    want AWS to manage the keys used to encrypt data, specify the
-    following headers in the request.
-
-    -   x-amz-server-sideâ€‹-encryption
-
-    -   x-amz-server-side-encryption-aws-kms-key-id
-
-    -   x-amz-server-side-encryption-context
-
-    If you specify `x-amz-server-side-encryption:aws:kms`, but
-    don\\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-    Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-    data. If you want to use a customer managed AWS KMS CMK, you
-    must provide the `x-amz-server-side-encryption-aws-kms-key-id`
-    of the symmetric customer managed CMK. Amazon S3 only supports
-    symmetric CMKs and not asymmetric CMKs. For more information,
-    see [Using Symmetric and Asymmetric
-    Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-    in the *AWS Key Management Service Developer Guide*.
-
-    All GET and PUT requests for an object protected by AWS KMS fail
-    if you don\\'t make them with SSL or by using SigV4.
-
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in
-    AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
-
--   Use customer-provided encryption keys -- If you want to manage
-    your own encryption keys, provide all the following headers in
-    the request.
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
-
-    For more information about server-side encryption with CMKs
-    stored in KMS (SSE-KMS), see [Protecting Data Using Server-Side
-    Encryption with CMKs stored in
-    AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+You can optionally tell Amazon S3 to encrypt data at rest using
+server-side encryption. Server-side encryption is for data encryption at
+rest. Amazon S3 encrypts your data as it writes it to disks in its data
+centers and decrypts it when you access it. The option you use depends
+on whether you want to use AWS managed encryption keys or provide your
+own encryption key.
+\itemize{
+\item Use encryption keys managed by Amazon S3 or customer master keys
+(CMKs) stored in AWS Key Management Service (AWS KMS) -- If you want
+AWS to manage the keys used to encrypt data, specify the following
+headers in the request.
+\itemize{
+\item x-amz-server-sideâ€‹-encryption
+\item x-amz-server-side-encryption-aws-kms-key-id
+\item x-amz-server-side-encryption-context
 }
 
-Access-Control-List (ACL)-Specific Request Headers
+If you specify \code{x-amz-server-side-encryption:aws:kms}, but don\'t
+provide \code{x-amz-server-side-encryption-aws-kms-key-id}, Amazon S3
+uses the AWS managed CMK in AWS KMS to protect the data. If you want
+to use a customer managed AWS KMS CMK, you must provide the
+\code{x-amz-server-side-encryption-aws-kms-key-id} of the symmetric
+customer managed CMK. Amazon S3 only supports symmetric CMKs and not
+asymmetric CMKs. For more information, see \href{https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html}{Using Symmetric and Asymmetric Keys}
+in the \emph{AWS Key Management Service Developer Guide}.
 
-:   You also can use the following access control--related headers with
-this operation. By default, all objects are private. Only the owner
-has full access control. When adding a new object, you can grant
-permissions to individual AWS accounts or to predefined groups
-defined by Amazon S3. These permissions are then added to the Access
-Control List (ACL) on the object. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html}{Using ACLs}.
-With this operation, you can grant access permissions using one of
-the following two methods:\preformatted{-   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set
-    of predefined ACLs, known as canned ACLs. Each canned ACL has a
-    predefined set of grantees and permissions. For more
-    information, see [Canned
-    ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+All GET and PUT requests for an object protected by AWS KMS fail if
+you don\'t make them with SSL or by using SigV4.
 
--   Specify access permissions explicitly --- To explicitly grant
-    access permissions to specific AWS accounts or groups, use the
-    following headers. Each header maps to specific permissions that
-    Amazon S3 supports in an ACL. For more information, see [Access
-    Control List (ACL)
-    Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
-    In the header, you specify a list of grantees who get the
-    specific permission. To grant permissions explicitly use:
-
-    -   x-amz-grant-read
-
-    -   x-amz-grant-write
-
-    -   x-amz-grant-read-acp
-
-    -   x-amz-grant-write-acp
-
-    -   x-amz-grant-full-control
-
-    You specify each grantee as a type=value pair, where the type is
-    one of the following:
-
-    -   `emailAddress` -- if the value specified is the email
-        address of an AWS account
-
-        Using email addresses to specify a grantee is only supported
-        in the following AWS Regions:
-
-        -   US East (N. Virginia)
-
-        -   US West (N. California)
-
-        -   US West (Oregon)
-
-        -   Asia Pacific (Singapore)
-
-        -   Asia Pacific (Sydney)
-
-        -   Asia Pacific (Tokyo)
-
-        -   EU (Ireland)
-
-        -   South America (SÃ£o Paulo)
-
-        For a list of all the Amazon S3 supported Regions and
-        endpoints, see [Regions and
-        Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
-        in the AWS General Reference
-
-    -   `id` -- if the value specified is the canonical user ID of
-        an AWS account
-
-    -   `uri` -- if you are granting permissions to a predefined
-        group
-
-    For example, the following `x-amz-grant-read` header grants the
-    AWS accounts identified by email addresses permissions to read
-    object data and its metadata:
-
-    `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in AWS}.
+\item Use customer-provided encryption keys -- If you want to manage your
+own encryption keys, provide all the following headers in the
+request.
+\itemize{
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
 }
 
-Server-Side- Encryption-Specific Request Headers
+For more information about server-side encryption with CMKs stored
+in KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in AWS}.
+}
+}
 
-:   You can optionally tell Amazon S3 to encrypt data at rest using
-server-side encryption. Server-side encryption is for data
-encryption at rest. Amazon S3 encrypts your data as it writes it to
-disks in its data centers and decrypts it when you access it. The
-option you use depends on whether you want to use AWS-managed
-encryption keys or provide your own encryption key.\preformatted{-   Use encryption keys managed by Amazon S3 or customer master keys
-    (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you
-    want AWS to manage the keys used to encrypt data, specify the
-    following headers in the request.
+\subsection{Access-Control-List (ACL)-Specific Request Headers}{
 
-    -   x-amz-server-sideâ€‹-encryption
+You also can use the following access control--related headers with this
+operation. By default, all objects are private. Only the owner has full
+access control. When adding a new object, you can grant permissions to
+individual AWS accounts or to predefined groups defined by Amazon S3.
+These permissions are then added to the Access Control List (ACL) on the
+object. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html}{Using ACLs}.
+With this operation, you can grant access permissions using one of the
+following two methods:
+\itemize{
+\item Specify a canned ACL (\code{x-amz-acl}) --- Amazon S3 supports a set of
+predefined ACLs, known as canned ACLs. Each canned ACL has a
+predefined set of grantees and permissions. For more information,
+see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL}{Canned ACL}.
+\item Specify access permissions explicitly --- To explicitly grant access
+permissions to specific AWS accounts or groups, use the following
+headers. Each header maps to specific permissions that Amazon S3
+supports in an ACL. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html}{Access Control List (ACL) Overview}.
+In the header, you specify a list of grantees who get the specific
+permission. To grant permissions explicitly use:
+\itemize{
+\item x-amz-grant-read
+\item x-amz-grant-write
+\item x-amz-grant-read-acp
+\item x-amz-grant-write-acp
+\item x-amz-grant-full-control
+}
 
-    -   x-amz-server-side-encryption-aws-kms-key-id
+You specify each grantee as a type=value pair, where the type is one
+of the following:
+\itemize{
+\item \code{emailAddress} -- if the value specified is the email address of
+an AWS account
 
-    -   x-amz-server-side-encryption-context
+Using email addresses to specify a grantee is only supported in
+the following AWS Regions:
+\itemize{
+\item US East (N. Virginia)
+\item US West (N. California)
+\item US West (Oregon)
+\item Asia Pacific (Singapore)
+\item Asia Pacific (Sydney)
+\item Asia Pacific (Tokyo)
+\item EU (Ireland)
+\item South America (SÃ£o Paulo)
+}
 
-    If you specify `x-amz-server-side-encryption:aws:kms`, but
-    don\\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-    Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-    data. If you want to use a customer managed AWS KMS CMK, you
-    must provide the `x-amz-server-side-encryption-aws-kms-key-id`
-    of the symmetric customer managed CMK. Amazon S3 only supports
-    symmetric CMKs and not asymmetric CMKs. For more information,
-    see [Using Symmetric and Asymmetric
-    Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-    in the *AWS Key Management Service Developer Guide*.
+For a list of all the Amazon S3 supported Regions and endpoints,
+see \href{https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region}{Regions and Endpoints}
+in the AWS General Reference
+\item \code{id} -- if the value specified is the canonical user ID of an
+AWS account
+\item \code{uri} -- if you are granting permissions to a predefined group
+}
 
-    All GET and PUT requests for an object protected by AWS KMS fail
-    if you don\\'t make them with SSL or by using SigV4.
+For example, the following \code{x-amz-grant-read} header grants the AWS
+accounts identified by email addresses permissions to read object
+data and its metadata:
 
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in AWS
-    KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+\verb{x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" }
+}
+}
 
--   Use customer-provided encryption keys -- If you want to manage
-    your own encryption keys, provide all the following headers in
-    the request.
+\subsection{Server-Side- Encryption-Specific Request Headers}{
 
-    If you use this feature, the ETag value that Amazon S3 returns
-    in the response is not the MD5 of the object.
+You can optionally tell Amazon S3 to encrypt data at rest using
+server-side encryption. Server-side encryption is for data encryption at
+rest. Amazon S3 encrypts your data as it writes it to disks in its data
+centers and decrypts it when you access it. The option you use depends
+on whether you want to use AWS-managed encryption keys or provide your
+own encryption key.
+\itemize{
+\item Use encryption keys managed by Amazon S3 or customer master keys
+(CMKs) stored in AWS Key Management Service (AWS KMS) -- If you want
+AWS to manage the keys used to encrypt data, specify the following
+headers in the request.
+\itemize{
+\item x-amz-server-sideâ€‹-encryption
+\item x-amz-server-side-encryption-aws-kms-key-id
+\item x-amz-server-side-encryption-context
+}
 
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+If you specify \code{x-amz-server-side-encryption:aws:kms}, but don\'t
+provide \code{x-amz-server-side-encryption-aws-kms-key-id}, Amazon S3
+uses the AWS managed CMK in AWS KMS to protect the data. If you want
+to use a customer managed AWS KMS CMK, you must provide the
+\code{x-amz-server-side-encryption-aws-kms-key-id} of the symmetric
+customer managed CMK. Amazon S3 only supports symmetric CMKs and not
+asymmetric CMKs. For more information, see \href{https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html}{Using Symmetric and Asymmetric Keys}
+in the \emph{AWS Key Management Service Developer Guide}.
 
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+All GET and PUT requests for an object protected by AWS KMS fail if
+you don\'t make them with SSL or by using SigV4.
 
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in AWS KMS}.
+\item Use customer-provided encryption keys -- If you want to manage your
+own encryption keys, provide all the following headers in the
+request.
 
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in AWS
-    KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+If you use this feature, the ETag value that Amazon S3 returns in
+the response is not the MD5 of the object.
+\itemize{
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+}
+
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in AWS KMS}.
 }
 
 \strong{Storage Class Options}
@@ -404,6 +376,7 @@ for the same object simultaneously, it stores all of the objects.
 \itemize{
 \item CopyObject
 \item DeleteObject
+}
 }
 }
 \section{Request syntax}{

--- a/cran/paws/R/paws.R
+++ b/cran/paws/R/paws.R
@@ -4042,66 +4042,63 @@ elbv2 <- function(config = list()) {
 #' Global Accelerator includes components that work together to help you
 #' improve performance and availability for your applications:
 #' 
-#' Static IP address
+#' ### Static IP address
 #' 
-#' :   AWS Global Accelerator provides you with a set of static IP
-#'     addresses which are anycast from the AWS edge network and serve as
-#'     the single fixed entry points for your clients. If you already have
-#'     Elastic Load Balancing or Elastic IP address resources set up for
-#'     your applications, you can easily add those to Global Accelerator to
-#'     allow the resources to be accessed by a Global Accelerator static IP
-#'     address.
+#' AWS Global Accelerator provides you with a set of static IP addresses
+#' which are anycast from the AWS edge network and serve as the single
+#' fixed entry points for your clients. If you already have Elastic Load
+#' Balancing or Elastic IP address resources set up for your applications,
+#' you can easily add those to Global Accelerator to allow the resources to
+#' be accessed by a Global Accelerator static IP address.
 #' 
-#' Accelerator
+#' ### Accelerator
 #' 
-#' :   An accelerator directs traffic to optimal endpoints over the AWS
-#'     global network to improve availability and performance for your
-#'     internet applications that have a global audience. Each accelerator
-#'     includes one or more listeners.
+#' An accelerator directs traffic to optimal endpoints over the AWS global
+#' network to improve availability and performance for your internet
+#' applications that have a global audience. Each accelerator includes one
+#' or more listeners.
 #' 
-#' Network zone
+#' ### Network zone
 #' 
-#' :   A network zone services the static IP addresses for your accelerator
-#'     from a unique IP subnet. Similar to an AWS Availability Zone, a
-#'     network zone is an isolated unit with its own set of physical
-#'     infrastructure. When you configure an accelerator, Global
-#'     Accelerator allocates two IPv4 addresses for it. If one IP address
-#'     from a network zone becomes unavailable due to IP address blocking
-#'     by certain client networks, or network disruptions, then client
-#'     applications can retry on the healthy static IP address from the
-#'     other isolated network zone.
+#' A network zone services the static IP addresses for your accelerator
+#' from a unique IP subnet. Similar to an AWS Availability Zone, a network
+#' zone is an isolated unit with its own set of physical infrastructure.
+#' When you configure an accelerator, Global Accelerator allocates two IPv4
+#' addresses for it. If one IP address from a network zone becomes
+#' unavailable due to IP address blocking by certain client networks, or
+#' network disruptions, then client applications can retry on the healthy
+#' static IP address from the other isolated network zone.
 #' 
-#' Listener
+#' ### Listener
 #' 
-#' :   A listener processes inbound connections from clients to Global
-#'     Accelerator, based on the protocol and port that you configure. Each
-#'     listener has one or more endpoint groups associated with it, and
-#'     traffic is forwarded to endpoints in one of the groups. You
-#'     associate endpoint groups with listeners by specifying the Regions
-#'     that you want to distribute traffic to. Traffic is distributed to
-#'     optimal endpoints within the endpoint groups associated with a
-#'     listener.
+#' A listener processes inbound connections from clients to Global
+#' Accelerator, based on the protocol and port that you configure. Each
+#' listener has one or more endpoint groups associated with it, and traffic
+#' is forwarded to endpoints in one of the groups. You associate endpoint
+#' groups with listeners by specifying the Regions that you want to
+#' distribute traffic to. Traffic is distributed to optimal endpoints
+#' within the endpoint groups associated with a listener.
 #' 
-#' Endpoint group
+#' ### Endpoint group
 #' 
-#' :   Each endpoint group is associated with a specific AWS Region.
-#'     Endpoint groups include one or more endpoints in the Region. You can
-#'     increase or reduce the percentage of traffic that would be otherwise
-#'     directed to an endpoint group by adjusting a setting called a
-#'     *traffic dial*. The traffic dial lets you easily do performance
-#'     testing or blue/green deployment testing for new releases across
-#'     different AWS Regions, for example.
+#' Each endpoint group is associated with a specific AWS Region. Endpoint
+#' groups include one or more endpoints in the Region. You can increase or
+#' reduce the percentage of traffic that would be otherwise directed to an
+#' endpoint group by adjusting a setting called a *traffic dial*. The
+#' traffic dial lets you easily do performance testing or blue/green
+#' deployment testing for new releases across different AWS Regions, for
+#' example.
 #' 
-#' Endpoint
+#' ### Endpoint
 #' 
-#' :   An endpoint is an Elastic IP address, Network Load Balancer, or
-#'     Application Load Balancer. Traffic is routed to endpoints based on
-#'     several factors, including the geo-proximity to the user, the health
-#'     of the endpoint, and the configuration options that you choose, such
-#'     as endpoint weights. For each endpoint, you can configure weights,
-#'     which are numbers that you can use to specify the proportion of
-#'     traffic to route to each one. This can be useful, for example, to do
-#'     performance testing within a Region.
+#' An endpoint is an Elastic IP address, Network Load Balancer, or
+#' Application Load Balancer. Traffic is routed to endpoints based on
+#' several factors, including the geo-proximity to the user, the health of
+#' the endpoint, and the configuration options that you choose, such as
+#' endpoint weights. For each endpoint, you can configure weights, which
+#' are numbers that you can use to specify the proportion of traffic to
+#' route to each one. This can be useful, for example, to do performance
+#' testing within a Region.
 #'
 #' @param
 #' config

--- a/cran/paws/man/globalaccelerator.Rd
+++ b/cran/paws/man/globalaccelerator.Rd
@@ -38,67 +38,69 @@ to only healthy endpoints.
 
 Global Accelerator includes components that work together to help you
 improve performance and availability for your applications:
+\subsection{Static IP address}{
 
-Static IP address
+AWS Global Accelerator provides you with a set of static IP addresses
+which are anycast from the AWS edge network and serve as the single
+fixed entry points for your clients. If you already have Elastic Load
+Balancing or Elastic IP address resources set up for your applications,
+you can easily add those to Global Accelerator to allow the resources to
+be accessed by a Global Accelerator static IP address.
+}
 
-:   AWS Global Accelerator provides you with a set of static IP
-addresses which are anycast from the AWS edge network and serve as
-the single fixed entry points for your clients. If you already have
-Elastic Load Balancing or Elastic IP address resources set up for
-your applications, you can easily add those to Global Accelerator to
-allow the resources to be accessed by a Global Accelerator static IP
-address.
+\subsection{Accelerator}{
 
-Accelerator
+An accelerator directs traffic to optimal endpoints over the AWS global
+network to improve availability and performance for your internet
+applications that have a global audience. Each accelerator includes one
+or more listeners.
+}
 
-:   An accelerator directs traffic to optimal endpoints over the AWS
-global network to improve availability and performance for your
-internet applications that have a global audience. Each accelerator
-includes one or more listeners.
+\subsection{Network zone}{
 
-Network zone
+A network zone services the static IP addresses for your accelerator
+from a unique IP subnet. Similar to an AWS Availability Zone, a network
+zone is an isolated unit with its own set of physical infrastructure.
+When you configure an accelerator, Global Accelerator allocates two IPv4
+addresses for it. If one IP address from a network zone becomes
+unavailable due to IP address blocking by certain client networks, or
+network disruptions, then client applications can retry on the healthy
+static IP address from the other isolated network zone.
+}
 
-:   A network zone services the static IP addresses for your accelerator
-from a unique IP subnet. Similar to an AWS Availability Zone, a
-network zone is an isolated unit with its own set of physical
-infrastructure. When you configure an accelerator, Global
-Accelerator allocates two IPv4 addresses for it. If one IP address
-from a network zone becomes unavailable due to IP address blocking
-by certain client networks, or network disruptions, then client
-applications can retry on the healthy static IP address from the
-other isolated network zone.
+\subsection{Listener}{
 
-Listener
-
-:   A listener processes inbound connections from clients to Global
+A listener processes inbound connections from clients to Global
 Accelerator, based on the protocol and port that you configure. Each
-listener has one or more endpoint groups associated with it, and
-traffic is forwarded to endpoints in one of the groups. You
-associate endpoint groups with listeners by specifying the Regions
-that you want to distribute traffic to. Traffic is distributed to
-optimal endpoints within the endpoint groups associated with a
-listener.
+listener has one or more endpoint groups associated with it, and traffic
+is forwarded to endpoints in one of the groups. You associate endpoint
+groups with listeners by specifying the Regions that you want to
+distribute traffic to. Traffic is distributed to optimal endpoints
+within the endpoint groups associated with a listener.
+}
 
-Endpoint group
+\subsection{Endpoint group}{
 
-:   Each endpoint group is associated with a specific AWS Region.
-Endpoint groups include one or more endpoints in the Region. You can
-increase or reduce the percentage of traffic that would be otherwise
-directed to an endpoint group by adjusting a setting called a
-\emph{traffic dial}. The traffic dial lets you easily do performance
-testing or blue/green deployment testing for new releases across
-different AWS Regions, for example.
+Each endpoint group is associated with a specific AWS Region. Endpoint
+groups include one or more endpoints in the Region. You can increase or
+reduce the percentage of traffic that would be otherwise directed to an
+endpoint group by adjusting a setting called a \emph{traffic dial}. The
+traffic dial lets you easily do performance testing or blue/green
+deployment testing for new releases across different AWS Regions, for
+example.
+}
 
-Endpoint
+\subsection{Endpoint}{
 
-:   An endpoint is an Elastic IP address, Network Load Balancer, or
+An endpoint is an Elastic IP address, Network Load Balancer, or
 Application Load Balancer. Traffic is routed to endpoints based on
-several factors, including the geo-proximity to the user, the health
-of the endpoint, and the configuration options that you choose, such
-as endpoint weights. For each endpoint, you can configure weights,
-which are numbers that you can use to specify the proportion of
-traffic to route to each one. This can be useful, for example, to do
-performance testing within a Region.
+several factors, including the geo-proximity to the user, the health of
+the endpoint, and the configuration options that you choose, such as
+endpoint weights. For each endpoint, you can configure weights, which
+are numbers that you can use to specify the proportion of traffic to
+route to each one. This can be useful, for example, to do performance
+testing within a Region.
+}
 }
 \section{Service syntax}{
 \preformatted{svc <- globalaccelerator(

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -239,7 +239,9 @@ clean_html_node <- function(node) {
   switch(
     xml2::xml_name(node),
     code = clean_html_code(node),
-    a = clean_html_a(node)
+    a = clean_html_a(node),
+    dt = clean_html_dt(node),
+    dd = clean_html_dd(node)
   )
   for (child in xml2::xml_children(node)) {
     child <- clean_html_node(child)
@@ -286,6 +288,16 @@ clean_html_a <- function(node) {
   if (!url_ok(url)) {
     xml2::xml_attr(node, "href") <- NULL
   }
+}
+
+# Replace definition title nodes with header nodes.
+clean_html_dt <- function(node) {
+  xml2::xml_name(node) <- "h3"
+}
+
+# Replace definition list nodes with paragraph nodes.
+clean_html_dd <- function(node) {
+  xml2::xml_name(node) <- "p"
 }
 
 # Escape special characters % { }, and single \ not followed by another special

--- a/make.paws/R/package.R
+++ b/make.paws/R/package.R
@@ -2,7 +2,7 @@
 # Create the skeleton for category package.
 write_skeleton_category <- function(path) {
   if (!dir.exists(path)) dir.create(path)
-  else clear_files(path, keep = "cran-comments.md")
+  else clear_files(path, keep = c("cran-comments.md", "NEWS.md"))
   for (dir in c("man", "R", "tests/testthat")) {
     dir.create(file.path(path, dir), recursive = TRUE)
   }

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -499,6 +499,10 @@ test_that("convert", {
   text <- "<a href='example.com'>foo</a>"
   expected <- c("[foo](https://example.com)")
   expect_equal(convert(text), expected)
+
+  text <- "<dt>Description</dt><dd>Definition.</dd>"
+  expected <- c("### Description", "", "Definition.")
+  expect_equal(convert(text), expected)
 })
 
 test_that("first_sentence", {

--- a/paws/R/appstream_operations.R
+++ b/paws/R/appstream_operations.R
@@ -287,18 +287,18 @@ appstream_create_directory_config <- function(DirectoryName, OrganizationalUnitD
 #' -   stream.graphics-pro.16xlarge
 #' @param FleetType The fleet type.
 #' 
-#' ALWAYS\\_ON
+#' ### ALWAYS\\_ON
 #' 
-#' :   Provides users with instant-on access to their apps. You are charged
-#'     for all running instances in your fleet, even if no users are
-#'     streaming apps.
+#' Provides users with instant-on access to their apps. You are charged for
+#' all running instances in your fleet, even if no users are streaming
+#' apps.
 #' 
-#' ON\\_DEMAND
+#' ### ON\\_DEMAND
 #' 
-#' :   Provide users with access to applications after they connect, which
-#'     takes one to two minutes. You are charged for instance streaming
-#'     when users are connected and a small hourly fee for instances that
-#'     are not streaming apps.
+#' Provide users with access to applications after they connect, which
+#' takes one to two minutes. You are charged for instance streaming when
+#' users are connected and a small hourly fee for instances that are not
+#' streaming apps.
 #' @param ComputeCapacity &#91;required&#93; The desired capacity for the fleet.
 #' @param VpcConfig The VPC configuration for the fleet.
 #' @param MaxUserDurationInSeconds The maximum amount of time that a streaming session can remain active,

--- a/paws/R/athena_operations.R
+++ b/paws/R/athena_operations.R
@@ -532,8 +532,9 @@ athena_list_named_queries <- function(NextToken = NULL, MaxResults = NULL, WorkG
 #' specified workgroup. Requires you to have access to the workgroup in
 #' which the queries ran.
 #' 
-#' For code samples using the AWS SDK for Java, see Examples and Code
-#' Samples in the *Amazon Athena User Guide*.
+#' For code samples using the AWS SDK for Java, see [Examples and Code
+#' Samples](http://docs.aws.amazon.com/athena/latest/ug/code-samples.html)
+#' in the *Amazon Athena User Guide*.
 #'
 #' @usage
 #' athena_list_query_executions(NextToken, MaxResults, WorkGroup)
@@ -658,8 +659,9 @@ athena_list_work_groups <- function(NextToken = NULL, MaxResults = NULL) {
 #' Runs the SQL query statements contained in the `Query`. Requires you to
 #' have access to the workgroup in which the query ran.
 #' 
-#' For code samples using the AWS SDK for Java, see Examples and Code
-#' Samples in the *Amazon Athena User Guide*.
+#' For code samples using the AWS SDK for Java, see [Examples and Code
+#' Samples](http://docs.aws.amazon.com/athena/latest/ug/code-samples.html)
+#' in the *Amazon Athena User Guide*.
 #'
 #' @usage
 #' athena_start_query_execution(QueryString, ClientRequestToken,

--- a/paws/R/chime_service.R
+++ b/paws/R/chime_service.R
@@ -20,34 +20,33 @@ NULL
 #' CLI. Each API operation includes links to information about using it
 #' with a language-specific AWS SDK or the AWS CLI.
 #' 
-#' Using an AWS SDK
+#' ### Using an AWS SDK
 #' 
-#' :   You don\'t need to write code to calculate a signature for request
-#'     authentication. The SDK clients authenticate your requests by using
-#'     access keys that you provide. For more information about AWS SDKs,
-#'     see the [AWS Developer Center](http://aws.amazon.com/developer/).
+#' You don\'t need to write code to calculate a signature for request
+#' authentication. The SDK clients authenticate your requests by using
+#' access keys that you provide. For more information about AWS SDKs, see
+#' the [AWS Developer Center](http://aws.amazon.com/developer/).
 #' 
-#' Using the AWS CLI
+#' ### Using the AWS CLI
 #' 
-#' :   Use your access keys with the AWS CLI to make API calls. For
-#'     information about setting up the AWS CLI, see [Installing the AWS
-#'     Command Line
-#'     Interface](https://docs.aws.amazon.com/cli/latest/userguide/installing.html)
-#'     in the *AWS Command Line Interface User Guide*. For a list of
-#'     available Amazon Chime commands, see the [Amazon Chime
-#'     commands](https://docs.aws.amazon.com/cli/latest/reference/chime/index.html)
-#'     in the *AWS CLI Command Reference*.
+#' Use your access keys with the AWS CLI to make API calls. For information
+#' about setting up the AWS CLI, see [Installing the AWS Command Line
+#' Interface](https://docs.aws.amazon.com/cli/latest/userguide/installing.html)
+#' in the *AWS Command Line Interface User Guide*. For a list of available
+#' Amazon Chime commands, see the [Amazon Chime
+#' commands](https://docs.aws.amazon.com/cli/latest/reference/chime/index.html)
+#' in the *AWS CLI Command Reference*.
 #' 
-#' Using REST API
+#' ### Using REST API
 #' 
-#' :   If you use REST to make API calls, you must authenticate your
-#'     request by providing a signature. Amazon Chime supports signature
-#'     version 4. For more information, see [Signature Version 4 Signing
-#'     Process](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
-#'     in the *Amazon Web Services General Reference*.
+#' If you use REST to make API calls, you must authenticate your request by
+#' providing a signature. Amazon Chime supports signature version 4. For
+#' more information, see [Signature Version 4 Signing
+#' Process](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
+#' in the *Amazon Web Services General Reference*.
 #' 
-#'     When making REST API calls, use the service name `chime` and REST
-#'     endpoint `https://service.chime.aws.amazon.com`.
+#' When making REST API calls, use the service name `chime` and REST
+#' endpoint `https://service.chime.aws.amazon.com`.
 #' 
 #' Administrative permissions are controlled using AWS Identity and Access
 #' Management (IAM). For more information, see [Identity and Access

--- a/paws/R/connect_operations.R
+++ b/paws/R/connect_operations.R
@@ -310,57 +310,57 @@ connect_get_contact_attributes <- function(InstanceId, InitialContactId) {
 #' @param CurrentMetrics &#91;required&#93; The metrics to retrieve. Specify the name and unit for each metric. The
 #' following metrics are available:
 #' 
-#' AGENTS\\_AFTER\\_CONTACT\\_WORK
+#' ### AGENTS\\_AFTER\\_CONTACT\\_WORK
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_AVAILABLE
+#' ### AGENTS\\_AVAILABLE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_ERROR
+#' ### AGENTS\\_ERROR
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_NON\\_PRODUCTIVE
+#' ### AGENTS\\_NON\\_PRODUCTIVE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_ON\\_CALL
+#' ### AGENTS\\_ON\\_CALL
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_ON\\_CONTACT
+#' ### AGENTS\\_ON\\_CONTACT
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_ONLINE
+#' ### AGENTS\\_ONLINE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' AGENTS\\_STAFFED
+#' ### AGENTS\\_STAFFED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' CONTACTS\\_IN\\_QUEUE
+#' ### CONTACTS\\_IN\\_QUEUE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' CONTACTS\\_SCHEDULED
+#' ### CONTACTS\\_SCHEDULED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' OLDEST\\_CONTACT\\_AGE
+#' ### OLDEST\\_CONTACT\\_AGE
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#' SLOTS\\_ACTIVE
+#' ### SLOTS\\_ACTIVE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#' SLOTS\\_AVAILABLE
+#' ### SLOTS\\_AVAILABLE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' @param NextToken The token for the next set of results. Use the value returned in the
 #' previous response in the next request to retrieve the next set of
 #' results.
@@ -496,159 +496,159 @@ connect_get_federation_token <- function(InstanceId) {
 #' @param HistoricalMetrics &#91;required&#93; The metrics to retrieve. Specify the name, unit, and statistic for each
 #' metric. The following historical metrics are available:
 #' 
-#' ABANDON\\_TIME
+#' ### ABANDON\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' AFTER\\_CONTACT\\_WORK\\_TIME
+#' ### AFTER\\_CONTACT\\_WORK\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' API\\_CONTACTS\\_HANDLED
+#' ### API\\_CONTACTS\\_HANDLED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CALLBACK\\_CONTACTS\\_HANDLED
+#' ### CALLBACK\\_CONTACTS\\_HANDLED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_ABANDONED
+#' ### CONTACTS\\_ABANDONED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_AGENT\\_HUNG\\_UP\\_FIRST
+#' ### CONTACTS\\_AGENT\\_HUNG\\_UP\\_FIRST
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_CONSULTED
+#' ### CONTACTS\\_CONSULTED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_HANDLED
+#' ### CONTACTS\\_HANDLED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_HANDLED\\_INCOMING
+#' ### CONTACTS\\_HANDLED\\_INCOMING
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_HANDLED\\_OUTBOUND
+#' ### CONTACTS\\_HANDLED\\_OUTBOUND
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_HOLD\\_ABANDONS
+#' ### CONTACTS\\_HOLD\\_ABANDONS
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_MISSED
+#' ### CONTACTS\\_MISSED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_QUEUED
+#' ### CONTACTS\\_QUEUED
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_TRANSFERRED\\_IN
+#' ### CONTACTS\\_TRANSFERRED\\_IN
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_TRANSFERRED\\_IN\\_FROM\\_QUEUE
+#' ### CONTACTS\\_TRANSFERRED\\_IN\\_FROM\\_QUEUE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_TRANSFERRED\\_OUT
+#' ### CONTACTS\\_TRANSFERRED\\_OUT
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' CONTACTS\\_TRANSFERRED\\_OUT\\_FROM\\_QUEUE
+#' ### CONTACTS\\_TRANSFERRED\\_OUT\\_FROM\\_QUEUE
 #' 
-#' :   Unit: COUNT
+#' Unit: COUNT
 #' 
-#'     Statistic: SUM
+#' Statistic: SUM
 #' 
-#' HANDLE\\_TIME
+#' ### HANDLE\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' HOLD\\_TIME
+#' ### HOLD\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' INTERACTION\\_AND\\_HOLD\\_TIME
+#' ### INTERACTION\\_AND\\_HOLD\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' INTERACTION\\_TIME
+#' ### INTERACTION\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' OCCUPANCY
+#' ### OCCUPANCY
 #' 
-#' :   Unit: PERCENT
+#' Unit: PERCENT
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' QUEUE\\_ANSWER\\_TIME
+#' ### QUEUE\\_ANSWER\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#' QUEUED\\_TIME
+#' ### QUEUED\\_TIME
 #' 
-#' :   Unit: SECONDS
+#' Unit: SECONDS
 #' 
-#'     Statistic: MAX
+#' Statistic: MAX
 #' 
-#' SERVICE\\_LEVEL
+#' ### SERVICE\\_LEVEL
 #' 
-#' :   Unit: PERCENT
+#' Unit: PERCENT
 #' 
-#'     Statistic: AVG
+#' Statistic: AVG
 #' 
-#'     Threshold: Only \"Less than\" comparisons are supported, with the
-#'     following service level thresholds: 15, 20, 25, 30, 45, 60, 90, 120,
-#'     180, 240, 300, 600
+#' Threshold: Only \"Less than\" comparisons are supported, with the
+#' following service level thresholds: 15, 20, 25, 30, 45, 60, 90, 120,
+#' 180, 240, 300, 600
 #' @param NextToken The token for the next set of results. Use the value returned in the
 #' previous response in the next request to retrieve the next set of
 #' results.

--- a/paws/R/ec2_operations.R
+++ b/paws/R/ec2_operations.R
@@ -18003,8 +18003,9 @@ ec2_describe_transit_gateways <- function(TransitGatewayIds = NULL, Filters = NU
 #' Describes the specified attribute of the specified volume. You can
 #' specify only one attribute at a time.
 #' 
-#' For more information about EBS volumes, see Amazon EBS Volumes in the
-#' *Amazon Elastic Compute Cloud User Guide*.
+#' For more information about EBS volumes, see [Amazon EBS
+#' Volumes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumes.html)
+#' in the *Amazon Elastic Compute Cloud User Guide*.
 #'
 #' @usage
 #' ec2_describe_volume_attribute(Attribute, VolumeId, DryRun)

--- a/paws/R/elasticbeanstalk_operations.R
+++ b/paws/R/elasticbeanstalk_operations.R
@@ -2762,15 +2762,15 @@ elasticbeanstalk_update_environment <- function(ApplicationName = NULL, Environm
 #' operation, specify one of the following two virtual actions (or both)
 #' instead of the API operation name:
 #' 
-#' elasticbeanstalk:AddTags
+#' ### elasticbeanstalk:AddTags
 #' 
-#' :   Controls permission to call `UpdateTagsForResource` and pass a list
-#'     of tags to add in the `TagsToAdd` parameter.
+#' Controls permission to call `UpdateTagsForResource` and pass a list of
+#' tags to add in the `TagsToAdd` parameter.
 #' 
-#' elasticbeanstalk:RemoveTags
+#' ### elasticbeanstalk:RemoveTags
 #' 
-#' :   Controls permission to call `UpdateTagsForResource` and pass a list
-#'     of tag keys to remove in the `TagsToRemove` parameter.
+#' Controls permission to call `UpdateTagsForResource` and pass a list of
+#' tag keys to remove in the `TagsToRemove` parameter.
 #' 
 #' For details about creating a custom user policy, see [Creating a Custom
 #' User

--- a/paws/R/globalaccelerator_service.R
+++ b/paws/R/globalaccelerator_service.R
@@ -35,66 +35,63 @@ NULL
 #' Global Accelerator includes components that work together to help you
 #' improve performance and availability for your applications:
 #' 
-#' Static IP address
+#' ### Static IP address
 #' 
-#' :   AWS Global Accelerator provides you with a set of static IP
-#'     addresses which are anycast from the AWS edge network and serve as
-#'     the single fixed entry points for your clients. If you already have
-#'     Elastic Load Balancing or Elastic IP address resources set up for
-#'     your applications, you can easily add those to Global Accelerator to
-#'     allow the resources to be accessed by a Global Accelerator static IP
-#'     address.
+#' AWS Global Accelerator provides you with a set of static IP addresses
+#' which are anycast from the AWS edge network and serve as the single
+#' fixed entry points for your clients. If you already have Elastic Load
+#' Balancing or Elastic IP address resources set up for your applications,
+#' you can easily add those to Global Accelerator to allow the resources to
+#' be accessed by a Global Accelerator static IP address.
 #' 
-#' Accelerator
+#' ### Accelerator
 #' 
-#' :   An accelerator directs traffic to optimal endpoints over the AWS
-#'     global network to improve availability and performance for your
-#'     internet applications that have a global audience. Each accelerator
-#'     includes one or more listeners.
+#' An accelerator directs traffic to optimal endpoints over the AWS global
+#' network to improve availability and performance for your internet
+#' applications that have a global audience. Each accelerator includes one
+#' or more listeners.
 #' 
-#' Network zone
+#' ### Network zone
 #' 
-#' :   A network zone services the static IP addresses for your accelerator
-#'     from a unique IP subnet. Similar to an AWS Availability Zone, a
-#'     network zone is an isolated unit with its own set of physical
-#'     infrastructure. When you configure an accelerator, Global
-#'     Accelerator allocates two IPv4 addresses for it. If one IP address
-#'     from a network zone becomes unavailable due to IP address blocking
-#'     by certain client networks, or network disruptions, then client
-#'     applications can retry on the healthy static IP address from the
-#'     other isolated network zone.
+#' A network zone services the static IP addresses for your accelerator
+#' from a unique IP subnet. Similar to an AWS Availability Zone, a network
+#' zone is an isolated unit with its own set of physical infrastructure.
+#' When you configure an accelerator, Global Accelerator allocates two IPv4
+#' addresses for it. If one IP address from a network zone becomes
+#' unavailable due to IP address blocking by certain client networks, or
+#' network disruptions, then client applications can retry on the healthy
+#' static IP address from the other isolated network zone.
 #' 
-#' Listener
+#' ### Listener
 #' 
-#' :   A listener processes inbound connections from clients to Global
-#'     Accelerator, based on the protocol and port that you configure. Each
-#'     listener has one or more endpoint groups associated with it, and
-#'     traffic is forwarded to endpoints in one of the groups. You
-#'     associate endpoint groups with listeners by specifying the Regions
-#'     that you want to distribute traffic to. Traffic is distributed to
-#'     optimal endpoints within the endpoint groups associated with a
-#'     listener.
+#' A listener processes inbound connections from clients to Global
+#' Accelerator, based on the protocol and port that you configure. Each
+#' listener has one or more endpoint groups associated with it, and traffic
+#' is forwarded to endpoints in one of the groups. You associate endpoint
+#' groups with listeners by specifying the Regions that you want to
+#' distribute traffic to. Traffic is distributed to optimal endpoints
+#' within the endpoint groups associated with a listener.
 #' 
-#' Endpoint group
+#' ### Endpoint group
 #' 
-#' :   Each endpoint group is associated with a specific AWS Region.
-#'     Endpoint groups include one or more endpoints in the Region. You can
-#'     increase or reduce the percentage of traffic that would be otherwise
-#'     directed to an endpoint group by adjusting a setting called a
-#'     *traffic dial*. The traffic dial lets you easily do performance
-#'     testing or blue/green deployment testing for new releases across
-#'     different AWS Regions, for example.
+#' Each endpoint group is associated with a specific AWS Region. Endpoint
+#' groups include one or more endpoints in the Region. You can increase or
+#' reduce the percentage of traffic that would be otherwise directed to an
+#' endpoint group by adjusting a setting called a *traffic dial*. The
+#' traffic dial lets you easily do performance testing or blue/green
+#' deployment testing for new releases across different AWS Regions, for
+#' example.
 #' 
-#' Endpoint
+#' ### Endpoint
 #' 
-#' :   An endpoint is an Elastic IP address, Network Load Balancer, or
-#'     Application Load Balancer. Traffic is routed to endpoints based on
-#'     several factors, including the geo-proximity to the user, the health
-#'     of the endpoint, and the configuration options that you choose, such
-#'     as endpoint weights. For each endpoint, you can configure weights,
-#'     which are numbers that you can use to specify the proportion of
-#'     traffic to route to each one. This can be useful, for example, to do
-#'     performance testing within a Region.
+#' An endpoint is an Elastic IP address, Network Load Balancer, or
+#' Application Load Balancer. Traffic is routed to endpoints based on
+#' several factors, including the geo-proximity to the user, the health of
+#' the endpoint, and the configuration options that you choose, such as
+#' endpoint weights. For each endpoint, you can configure weights, which
+#' are numbers that you can use to specify the proportion of traffic to
+#' route to each one. This can be useful, for example, to do performance
+#' testing within a Region.
 #'
 #' @param
 #' config

--- a/paws/R/glue_operations.R
+++ b/paws/R/glue_operations.R
@@ -3682,55 +3682,53 @@ glue_get_partition <- function(CatalogId = NULL, DatabaseName, TableName, Partit
 #' *Operators*: The following are the operators that you can use in the
 #' `Expression` API call:
 #' 
-#' =
+#' ### =
 #' 
-#' :   Checks whether the values of the two operands are equal; if yes,
-#'     then the condition becomes true.
+#' Checks whether the values of the two operands are equal; if yes, then
+#' the condition becomes true.
 #' 
-#'     Example: Assume \'variable a\' holds 10 and \'variable b\' holds 20.
+#' Example: Assume \'variable a\' holds 10 and \'variable b\' holds 20.
 #' 
-#'     (a = b) is not true.
+#' (a = b) is not true.
 #' 
-#' \\< \\>
+#' ### \\< \\>
 #' 
-#' :   Checks whether the values of two operands are equal; if the values
-#'     are not equal, then the condition becomes true.
+#' Checks whether the values of two operands are equal; if the values are
+#' not equal, then the condition becomes true.
 #' 
-#'     Example: (a \\< \\> b) is true.
+#' Example: (a \\< \\> b) is true.
 #' 
-#' \\>
+#' ### \\>
 #' 
-#' :   Checks whether the value of the left operand is greater than the
-#'     value of the right operand; if yes, then the condition becomes true.
+#' Checks whether the value of the left operand is greater than the value
+#' of the right operand; if yes, then the condition becomes true.
 #' 
-#'     Example: (a \\> b) is not true.
+#' Example: (a \\> b) is not true.
 #' 
-#' \\<
+#' ### \\<
 #' 
-#' :   Checks whether the value of the left operand is less than the value
-#'     of the right operand; if yes, then the condition becomes true.
+#' Checks whether the value of the left operand is less than the value of
+#' the right operand; if yes, then the condition becomes true.
 #' 
-#'     Example: (a \\< b) is true.
+#' Example: (a \\< b) is true.
 #' 
-#' \\>=
+#' ### \\>=
 #' 
-#' :   Checks whether the value of the left operand is greater than or
-#'     equal to the value of the right operand; if yes, then the condition
-#'     becomes true.
+#' Checks whether the value of the left operand is greater than or equal to
+#' the value of the right operand; if yes, then the condition becomes true.
 #' 
-#'     Example: (a \\>= b) is not true.
+#' Example: (a \\>= b) is not true.
 #' 
-#' \\<=
+#' ### \\<=
 #' 
-#' :   Checks whether the value of the left operand is less than or equal
-#'     to the value of the right operand; if yes, then the condition
-#'     becomes true.
+#' Checks whether the value of the left operand is less than or equal to
+#' the value of the right operand; if yes, then the condition becomes true.
 #' 
-#'     Example: (a \\<= b) is true.
+#' Example: (a \\<= b) is true.
 #' 
-#' AND, OR, IN, BETWEEN, LIKE, NOT, IS NULL
+#' ### AND, OR, IN, BETWEEN, LIKE, NOT, IS NULL
 #' 
-#' :   Logical operators.
+#' Logical operators.
 #' 
 #' *Supported Partition Key Types*: The following are the supported
 #' partition keys.

--- a/paws/R/iot_operations.R
+++ b/paws/R/iot_operations.R
@@ -9657,34 +9657,33 @@ iot_update_thing_groups_for_thing <- function(thingName = NULL, thingGroupsToAdd
 #' @param arn &#91;required&#93; The ARN of the topic rule destination.
 #' @param status &#91;required&#93; The status of the topic rule destination. Valid values are:
 #' 
-#' IN\\_PROGRESS
+#' ### IN\\_PROGRESS
 #' 
-#' :   A topic rule destination was created but has not been confirmed. You
-#'     can set `status` to `IN_PROGRESS` by calling
-#'     `UpdateTopicRuleDestination`. Calling `UpdateTopicRuleDestination`
-#'     causes a new confirmation challenge to be sent to your confirmation
-#'     endpoint.
+#' A topic rule destination was created but has not been confirmed. You can
+#' set `status` to `IN_PROGRESS` by calling `UpdateTopicRuleDestination`.
+#' Calling `UpdateTopicRuleDestination` causes a new confirmation challenge
+#' to be sent to your confirmation endpoint.
 #' 
-#' ENABLED
+#' ### ENABLED
 #' 
-#' :   Confirmation was completed, and traffic to this destination is
-#'     allowed. You can set `status` to `DISABLED` by calling
-#'     `UpdateTopicRuleDestination`.
+#' Confirmation was completed, and traffic to this destination is allowed.
+#' You can set `status` to `DISABLED` by calling
+#' `UpdateTopicRuleDestination`.
 #' 
-#' DISABLED
+#' ### DISABLED
 #' 
-#' :   Confirmation was completed, and traffic to this destination is not
-#'     allowed. You can set `status` to `ENABLED` by calling
-#'     `UpdateTopicRuleDestination`.
+#' Confirmation was completed, and traffic to this destination is not
+#' allowed. You can set `status` to `ENABLED` by calling
+#' `UpdateTopicRuleDestination`.
 #' 
-#' ERROR
+#' ### ERROR
 #' 
-#' :   Confirmation could not be completed, for example if the confirmation
-#'     timed out. You can call `GetTopicRuleDestination` for details about
-#'     the error. You can set `status` to `IN_PROGRESS` by calling
-#'     `UpdateTopicRuleDestination`. Calling `UpdateTopicRuleDestination`
-#'     causes a new confirmation challenge to be sent to your confirmation
-#'     endpoint.
+#' Confirmation could not be completed, for example if the confirmation
+#' timed out. You can call `GetTopicRuleDestination` for details about the
+#' error. You can set `status` to `IN_PROGRESS` by calling
+#' `UpdateTopicRuleDestination`. Calling `UpdateTopicRuleDestination`
+#' causes a new confirmation challenge to be sent to your confirmation
+#' endpoint.
 #'
 #' @section Request syntax:
 #' ```

--- a/paws/R/kinesisvideoarchivedmedia_operations.R
+++ b/paws/R/kinesisvideoarchivedmedia_operations.R
@@ -27,14 +27,14 @@ NULL
 #' 
 #' -   The video track of each fragment must contain codec private data in
 #'     the Advanced Video Coding (AVC) for H.264 format and HEVC for H.265
-#'     format. For more information, see MPEG-4 specification ISO/IEC
-#'     14496-15. For information about adapting stream data to a given
-#'     format, see [NAL Adaptation
+#'     format. For more information, see [MPEG-4 specification ISO/IEC
+#'     14496-15](https://www.iso.org/standard/55980.html). For information
+#'     about adapting stream data to a given format, see [NAL Adaptation
 #'     Flags](http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html).
 #' 
 #' -   The audio track (if present) of each fragment must contain codec
-#'     private data in the AAC format (AAC specification ISO/IEC 13818-7)
-#'     or the [MS Wave
+#'     private data in the AAC format ([AAC specification ISO/IEC
+#'     13818-7](https://www.iso.org/standard/43345.html)) or the [MS Wave
 #'     format](http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html).
 #' 
 #' The following procedure shows how to use MPEG-DASH with Kinesis Video

--- a/paws/R/kms_operations.R
+++ b/paws/R/kms_operations.R
@@ -579,49 +579,49 @@ kms_create_grant <- function(KeyId, GranteePrincipal, RetiringPrincipal = NULL, 
 #' 
 #' To create different types of CMKs, use the following guidance:
 #' 
-#' Asymmetric CMKs
+#' ### Asymmetric CMKs
 #' 
-#' :   To create an asymmetric CMK, use the `CustomerMasterKeySpec`
-#'     parameter to specify the type of key material in the CMK. Then, use
-#'     the `KeyUsage` parameter to determine whether the CMK will be used
-#'     to encrypt and decrypt or sign and verify. You can\'t change these
-#'     properties after the CMK is created.
+#' To create an asymmetric CMK, use the `CustomerMasterKeySpec` parameter
+#' to specify the type of key material in the CMK. Then, use the `KeyUsage`
+#' parameter to determine whether the CMK will be used to encrypt and
+#' decrypt or sign and verify. You can\'t change these properties after the
+#' CMK is created.
 #' 
-#' Symmetric CMKs
+#' ### Symmetric CMKs
 #' 
-#' :   When creating a symmetric CMK, you don\'t need to specify the
-#'     `CustomerMasterKeySpec` or `KeyUsage` parameters. The default value
-#'     for `CustomerMasterKeySpec`, `SYMMETRIC_DEFAULT`, and the default
-#'     value for `KeyUsage`, `ENCRYPT_DECRYPT`, are the only valid values
-#'     for symmetric CMKs.
+#' When creating a symmetric CMK, you don\'t need to specify the
+#' `CustomerMasterKeySpec` or `KeyUsage` parameters. The default value for
+#' `CustomerMasterKeySpec`, `SYMMETRIC_DEFAULT`, and the default value for
+#' `KeyUsage`, `ENCRYPT_DECRYPT`, are the only valid values for symmetric
+#' CMKs.
 #' 
-#' Imported Key Material
+#' ### Imported Key Material
 #' 
-#' :   To import your own key material, begin by creating a symmetric CMK
-#'     with no key material. To do this, use the `Origin` parameter of
-#'     `CreateKey` with a value of `EXTERNAL`. Next, use
-#'     GetParametersForImport operation to get a public key and import
-#'     token, and use the public key to encrypt your key material. Then,
-#'     use ImportKeyMaterial with your import token to import the key
-#'     material. For step-by-step instructions, see [Importing Key
-#'     Material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
-#'     in the **AWS Key Management Service Developer Guide** . You cannot
-#'     import the key material into an asymmetric CMK.
+#' To import your own key material, begin by creating a symmetric CMK with
+#' no key material. To do this, use the `Origin` parameter of `CreateKey`
+#' with a value of `EXTERNAL`. Next, use GetParametersForImport operation
+#' to get a public key and import token, and use the public key to encrypt
+#' your key material. Then, use ImportKeyMaterial with your import token to
+#' import the key material. For step-by-step instructions, see [Importing
+#' Key
+#' Material](https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html)
+#' in the **AWS Key Management Service Developer Guide** . You cannot
+#' import the key material into an asymmetric CMK.
 #' 
-#' Custom Key Stores
+#' ### Custom Key Stores
 #' 
-#' :   To create a symmetric CMK in a [custom key
-#'     store](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
-#'     use the `CustomKeyStoreId` parameter to specify the custom key
-#'     store. You must also use the `Origin` parameter with a value of
-#'     `AWS_CLOUDHSM`. The AWS CloudHSM cluster that is associated with the
-#'     custom key store must have at least two active HSMs in different
-#'     Availability Zones in the AWS Region.
+#' To create a symmetric CMK in a [custom key
+#' store](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html),
+#' use the `CustomKeyStoreId` parameter to specify the custom key store.
+#' You must also use the `Origin` parameter with a value of `AWS_CLOUDHSM`.
+#' The AWS CloudHSM cluster that is associated with the custom key store
+#' must have at least two active HSMs in different Availability Zones in
+#' the AWS Region.
 #' 
-#'     You cannot create an asymmetric CMK in a custom key store. For
-#'     information about custom key stores in AWS KMS see [Using Custom Key
-#'     Stores](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-#'     in the **AWS Key Management Service Developer Guide** .
+#' You cannot create an asymmetric CMK in a custom key store. For
+#' information about custom key stores in AWS KMS see [Using Custom Key
+#' Stores](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
+#' in the **AWS Key Management Service Developer Guide** .
 #'
 #' @usage
 #' kms_create_key(Policy, Description, KeyUsage, CustomerMasterKeySpec,

--- a/paws/R/robomaker_operations.R
+++ b/paws/R/robomaker_operations.R
@@ -507,13 +507,13 @@ robomaker_create_simulation_application_version <- function(application, current
 #' is how credentials are passed in to your simulation job.
 #' @param failureBehavior The failure behavior the simulation job.
 #' 
-#' Continue
+#' ### Continue
 #' 
-#' :   Restart the simulation job in the same host instance.
+#' Restart the simulation job in the same host instance.
 #' 
-#' Fail
+#' ### Fail
 #' 
-#' :   Stop the simulation job and terminate the instance.
+#' Stop the simulation job and terminate the instance.
 #' @param robotApplications The robot application to use in the simulation job.
 #' @param simulationApplications The simulation application to use in the simulation job.
 #' @param dataSources The data sources for the simulation job.

--- a/paws/R/route53_operations.R
+++ b/paws/R/route53_operations.R
@@ -1049,109 +1049,107 @@ route53_create_hosted_zone <- function(Name, VPC = NULL, CallerReference, Hosted
 #' 
 #' -   DNS response code, such as `NoError` or `ServFail`
 #' 
-#' Log Group and Resource Policy
+#' ### Log Group and Resource Policy
 #' 
-#' :   Before you create a query logging configuration, perform the
-#'     following operations.
+#' Before you create a query logging configuration, perform the following
+#' operations.
 #' 
-#'     If you create a query logging configuration using the Route 53
-#'     console, Route 53 performs these operations automatically.
+#' If you create a query logging configuration using the Route 53 console,
+#' Route 53 performs these operations automatically.
 #' 
-#'     1.  Create a CloudWatch Logs log group, and make note of the ARN,
-#'         which you specify when you create a query logging configuration.
-#'         Note the following:
+#' 1.  Create a CloudWatch Logs log group, and make note of the ARN, which
+#'     you specify when you create a query logging configuration. Note the
+#'     following:
 #' 
-#'         -   You must create the log group in the us-east-1 region.
+#'     -   You must create the log group in the us-east-1 region.
 #' 
-#'         -   You must use the same AWS account to create the log group
-#'             and the hosted zone that you want to configure query logging
-#'             for.
+#'     -   You must use the same AWS account to create the log group and
+#'         the hosted zone that you want to configure query logging for.
 #' 
-#'         -   When you create log groups for query logging, we recommend
-#'             that you use a consistent prefix, for example:
+#'     -   When you create log groups for query logging, we recommend that
+#'         you use a consistent prefix, for example:
 #' 
-#'             `/aws/route53/<i>hosted zone name</i> `
+#'         `/aws/route53/<i>hosted zone name</i> `
 #' 
-#'             In the next step, you\'ll create a resource policy, which
-#'             controls access to one or more log groups and the associated
-#'             AWS resources, such as Route 53 hosted zones. There\'s a
-#'             limit on the number of resource policies that you can
-#'             create, so we recommend that you use a consistent prefix so
-#'             you can use the same resource policy for all the log groups
-#'             that you create for query logging.
+#'         In the next step, you\'ll create a resource policy, which
+#'         controls access to one or more log groups and the associated AWS
+#'         resources, such as Route 53 hosted zones. There\'s a limit on
+#'         the number of resource policies that you can create, so we
+#'         recommend that you use a consistent prefix so you can use the
+#'         same resource policy for all the log groups that you create for
+#'         query logging.
 #' 
-#'     2.  Create a CloudWatch Logs resource policy, and give it the
-#'         permissions that Route 53 needs to create log streams and to
-#'         send query logs to log streams. For the value of `Resource`,
-#'         specify the ARN for the log group that you created in the
-#'         previous step. To use the same resource policy for all the
-#'         CloudWatch Logs log groups that you created for query logging
-#'         configurations, replace the hosted zone name with `*`, for
-#'         example:
+#' 2.  Create a CloudWatch Logs resource policy, and give it the
+#'     permissions that Route 53 needs to create log streams and to send
+#'     query logs to log streams. For the value of `Resource`, specify the
+#'     ARN for the log group that you created in the previous step. To use
+#'     the same resource policy for all the CloudWatch Logs log groups that
+#'     you created for query logging configurations, replace the hosted
+#'     zone name with `*`, for example:
 #' 
-#'         `arn:aws:logs:us-east-1:123412341234:log-group:/aws/route53/*`
+#'     `arn:aws:logs:us-east-1:123412341234:log-group:/aws/route53/*`
 #' 
-#'         You can\'t use the CloudWatch console to create or edit a
-#'         resource policy. You must use the CloudWatch API, one of the AWS
-#'         SDKs, or the AWS CLI.
+#'     You can\'t use the CloudWatch console to create or edit a resource
+#'     policy. You must use the CloudWatch API, one of the AWS SDKs, or the
+#'     AWS CLI.
 #' 
-#' Log Streams and Edge Locations
+#' ### Log Streams and Edge Locations
 #' 
-#' :   When Route 53 finishes creating the configuration for DNS query
-#'     logging, it does the following:
+#' When Route 53 finishes creating the configuration for DNS query logging,
+#' it does the following:
 #' 
-#'     -   Creates a log stream for an edge location the first time that
-#'         the edge location responds to DNS queries for the specified
-#'         hosted zone. That log stream is used to log all queries that
-#'         Route 53 responds to for that edge location.
+#' -   Creates a log stream for an edge location the first time that the
+#'     edge location responds to DNS queries for the specified hosted zone.
+#'     That log stream is used to log all queries that Route 53 responds to
+#'     for that edge location.
 #' 
-#'     -   Begins to send query logs to the applicable log stream.
+#' -   Begins to send query logs to the applicable log stream.
 #' 
-#'     The name of each log stream is in the following format:
+#' The name of each log stream is in the following format:
 #' 
-#'     ` <i>hosted zone ID</i>/<i>edge location code</i> `
+#' ` <i>hosted zone ID</i>/<i>edge location code</i> `
 #' 
-#'     The edge location code is a three-letter code and an arbitrarily
-#'     assigned number, for example, DFW3. The three-letter code typically
-#'     corresponds with the International Air Transport Association airport
-#'     code for an airport near the edge location. (These abbreviations
-#'     might change in the future.) For a list of edge locations, see \"The
-#'     Route 53 Global Network\" on the [Route 53 Product
-#'     Details](http://aws.amazon.com/route53/details/) page.
+#' The edge location code is a three-letter code and an arbitrarily
+#' assigned number, for example, DFW3. The three-letter code typically
+#' corresponds with the International Air Transport Association airport
+#' code for an airport near the edge location. (These abbreviations might
+#' change in the future.) For a list of edge locations, see \"The Route 53
+#' Global Network\" on the [Route 53 Product
+#' Details](http://aws.amazon.com/route53/details/) page.
 #' 
-#' Queries That Are Logged
+#' ### Queries That Are Logged
 #' 
-#' :   Query logs contain only the queries that DNS resolvers forward to
-#'     Route 53. If a DNS resolver has already cached the response to a
-#'     query (such as the IP address for a load balancer for example.com),
-#'     the resolver will continue to return the cached response. It
-#'     doesn\'t forward another query to Route 53 until the TTL for the
-#'     corresponding resource record set expires. Depending on how many DNS
-#'     queries are submitted for a resource record set, and depending on
-#'     the TTL for that resource record set, query logs might contain
-#'     information about only one query out of every several thousand
-#'     queries that are submitted to DNS. For more information about how
-#'     DNS works, see [Routing Internet Traffic to Your Website or Web
-#'     Application](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/welcome-dns-service.html)
-#'     in the *Amazon Route 53 Developer Guide*.
+#' Query logs contain only the queries that DNS resolvers forward to Route
+#' 53. If a DNS resolver has already cached the response to a query (such
+#' as the IP address for a load balancer for example.com), the resolver
+#' will continue to return the cached response. It doesn\'t forward another
+#' query to Route 53 until the TTL for the corresponding resource record
+#' set expires. Depending on how many DNS queries are submitted for a
+#' resource record set, and depending on the TTL for that resource record
+#' set, query logs might contain information about only one query out of
+#' every several thousand queries that are submitted to DNS. For more
+#' information about how DNS works, see [Routing Internet Traffic to Your
+#' Website or Web
+#' Application](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/welcome-dns-service.html)
+#' in the *Amazon Route 53 Developer Guide*.
 #' 
-#' Log File Format
+#' ### Log File Format
 #' 
-#' :   For a list of the values in each query log and the format of each
-#'     value, see [Logging DNS
-#'     Queries](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html)
-#'     in the *Amazon Route 53 Developer Guide*.
+#' For a list of the values in each query log and the format of each value,
+#' see [Logging DNS
+#' Queries](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html)
+#' in the *Amazon Route 53 Developer Guide*.
 #' 
-#' Pricing
+#' ### Pricing
 #' 
-#' :   For information about charges for query logs, see [Amazon CloudWatch
-#'     Pricing](http://aws.amazon.com/cloudwatch/pricing/).
+#' For information about charges for query logs, see [Amazon CloudWatch
+#' Pricing](http://aws.amazon.com/cloudwatch/pricing/).
 #' 
-#' How to Stop Logging
+#' ### How to Stop Logging
 #' 
-#' :   If you want Route 53 to stop sending query logs to CloudWatch Logs,
-#'     delete the query logging configuration. For more information, see
-#'     [DeleteQueryLoggingConfig](https://docs.aws.amazon.com/Route53/latest/APIReference/API_DeleteQueryLoggingConfig.html).
+#' If you want Route 53 to stop sending query logs to CloudWatch Logs,
+#' delete the query logging configuration. For more information, see
+#' [DeleteQueryLoggingConfig](https://docs.aws.amazon.com/Route53/latest/APIReference/API_DeleteQueryLoggingConfig.html).
 #'
 #' @usage
 #' route53_create_query_logging_config(HostedZoneId,
@@ -3080,25 +3078,25 @@ route53_list_query_logging_configs <- function(HostedZoneId = NULL, NextToken = 
 #' You can use the name and type elements to specify the resource record
 #' set that the list begins with:
 #' 
-#' If you do not specify Name or Type
+#' ### If you do not specify Name or Type
 #' 
-#' :   The results begin with the first resource record set that the hosted
-#'     zone contains.
+#' The results begin with the first resource record set that the hosted
+#' zone contains.
 #' 
-#' If you specify Name but not Type
+#' ### If you specify Name but not Type
 #' 
-#' :   The results begin with the first resource record set in the list
-#'     whose name is greater than or equal to `Name`.
+#' The results begin with the first resource record set in the list whose
+#' name is greater than or equal to `Name`.
 #' 
-#' If you specify Type but not Name
+#' ### If you specify Type but not Name
 #' 
-#' :   Amazon Route 53 returns the `InvalidInput` error.
+#' Amazon Route 53 returns the `InvalidInput` error.
 #' 
-#' If you specify both Name and Type
+#' ### If you specify both Name and Type
 #' 
-#' :   The results begin with the first resource record set in the list
-#'     whose name is greater than or equal to `Name`, and whose type is
-#'     greater than or equal to `Type`.
+#' The results begin with the first resource record set in the list whose
+#' name is greater than or equal to `Name`, and whose type is greater than
+#' or equal to `Type`.
 #' 
 #' **Resource record sets that are PENDING**
 #' 

--- a/paws/R/s3_operations.R
+++ b/paws/R/s3_operations.R
@@ -340,162 +340,159 @@ s3_complete_multipart_upload <- function(Bucket, Key, MultipartUpload = NULL, Up
 #' 
 #' Following are other considerations when using `CopyObject`:
 #' 
-#' Versioning
+#' ### Versioning
 #' 
-#' :   By default, `x-amz-copy-source` identifies the current version of an
-#'     object to copy. (If the current version is a delete marker, Amazon
-#'     S3 behaves as if the object was deleted.) To copy a different
-#'     version, use the `versionId` subresource.
+#' By default, `x-amz-copy-source` identifies the current version of an
+#' object to copy. (If the current version is a delete marker, Amazon S3
+#' behaves as if the object was deleted.) To copy a different version, use
+#' the `versionId` subresource.
 #' 
-#'     If you enable versioning on the target bucket, Amazon S3 generates a
-#'     unique version ID for the object being copied. This version ID is
-#'     different from the version ID of the source object. Amazon S3
-#'     returns the version ID of the copied object in the
-#'     `x-amz-version-id` response header in the response.
+#' If you enable versioning on the target bucket, Amazon S3 generates a
+#' unique version ID for the object being copied. This version ID is
+#' different from the version ID of the source object. Amazon S3 returns
+#' the version ID of the copied object in the `x-amz-version-id` response
+#' header in the response.
 #' 
-#'     If you do not enable versioning or suspend it on the target bucket,
-#'     the version ID that Amazon S3 generates is always null.
+#' If you do not enable versioning or suspend it on the target bucket, the
+#' version ID that Amazon S3 generates is always null.
 #' 
-#'     If the source object\'s storage class is GLACIER, you must restore a
-#'     copy of this object before you can use it as a source object for the
-#'     copy operation. For more information, see .
+#' If the source object\'s storage class is GLACIER, you must restore a
+#' copy of this object before you can use it as a source object for the
+#' copy operation. For more information, see .
 #' 
-#' Access Permissions
+#' ### Access Permissions
 #' 
-#' :   When copying an object, you can optionally specify the accounts or
-#'     groups that should be granted specific permissions on the new
-#'     object. There are two ways to grant the permissions using the
-#'     request headers:
+#' When copying an object, you can optionally specify the accounts or
+#' groups that should be granted specific permissions on the new object.
+#' There are two ways to grant the permissions using the request headers:
 #' 
-#'     -   Specify a canned ACL with the `x-amz-acl` request header. For
-#'         more information, see [Canned
-#'         ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+#' -   Specify a canned ACL with the `x-amz-acl` request header. For more
+#'     information, see [Canned
+#'     ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
 #' 
-#'     -   Specify access permissions explicitly with the
-#'         `x-amz-grant-read`, `x-amz-grant-read-acp`,
-#'         `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers.
-#'         These parameters map to the set of permissions that Amazon S3
-#'         supports in an ACL. For more information, see [Access Control
-#'         List (ACL)
-#'         Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+#' -   Specify access permissions explicitly with the `x-amz-grant-read`,
+#'     `x-amz-grant-read-acp`, `x-amz-grant-write-acp`, and
+#'     `x-amz-grant-full-control` headers. These parameters map to the set
+#'     of permissions that Amazon S3 supports in an ACL. For more
+#'     information, see [Access Control List (ACL)
+#'     Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
 #' 
-#'     You can use either a canned ACL or specify access permissions
-#'     explicitly. You cannot do both.
+#' You can use either a canned ACL or specify access permissions
+#' explicitly. You cannot do both.
 #' 
-#' Server-Side- Encryption-Specific Request Headers
+#' ### Server-Side- Encryption-Specific Request Headers
 #' 
-#' :   To encrypt the target object, you must provide the appropriate
-#'     encryption-related request headers. The one you use depends on
-#'     whether you want to use AWS managed encryption keys or provide your
-#'     own encryption key.
+#' To encrypt the target object, you must provide the appropriate
+#' encryption-related request headers. The one you use depends on whether
+#' you want to use AWS managed encryption keys or provide your own
+#' encryption key.
 #' 
-#'     -   To encrypt the target object using server-side encryption with
-#'         an AWS managed encryption key, provide the following request
-#'         headers, as appropriate.
+#' -   To encrypt the target object using server-side encryption with an
+#'     AWS managed encryption key, provide the following request headers,
+#'     as appropriate.
 #' 
-#'         -   `x-amz-server-sideâ€‹-encryption`
+#'     -   `x-amz-server-sideâ€‹-encryption`
 #' 
-#'         -   `x-amz-server-side-encryption-aws-kms-key-id`
+#'     -   `x-amz-server-side-encryption-aws-kms-key-id`
 #' 
-#'         -   `x-amz-server-side-encryption-context`
+#'     -   `x-amz-server-side-encryption-context`
 #' 
-#'         If you specify `x-amz-server-side-encryption:aws:kms`, but
-#'         don\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-#'         Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-#'         data. If you want to use a customer managed AWS KMS CMK, you
-#'         must provide the `x-amz-server-side-encryption-aws-kms-key-id`
-#'         of the symmetric customer managed CMK. Amazon S3 only supports
-#'         symmetric CMKs and not asymmetric CMKs. For more information,
-#'         see [Using Symmetric and Asymmetric
-#'         Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-#'         in the *AWS Key Management Service Developer Guide*.
+#'     If you specify `x-amz-server-side-encryption:aws:kms`, but don\'t
+#'     provide `x-amz-server-side-encryption-aws-kms-key-id`, Amazon S3
+#'     uses the AWS managed CMK in AWS KMS to protect the data. If you want
+#'     to use a customer managed AWS KMS CMK, you must provide the
+#'     `x-amz-server-side-encryption-aws-kms-key-id` of the symmetric
+#'     customer managed CMK. Amazon S3 only supports symmetric CMKs and not
+#'     asymmetric CMKs. For more information, see [Using Symmetric and
+#'     Asymmetric
+#'     Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+#'     in the *AWS Key Management Service Developer Guide*.
 #' 
-#'         All GET and PUT requests for an object protected by AWS KMS fail
-#'         if you don\'t make them with SSL or by using SigV4.
+#'     All GET and PUT requests for an object protected by AWS KMS fail if
+#'     you don\'t make them with SSL or by using SigV4.
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in
-#'         KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in
+#'     KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#'     -   To encrypt the target object using server-side encryption with
-#'         an encryption key that you provide, use the following headers.
+#' -   To encrypt the target object using server-side encryption with an
+#'     encryption key that you provide, use the following headers.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
 #' 
-#'     -   If the source object is encrypted using server-side encryption
-#'         with customer-provided encryption keys, you must use the
-#'         following headers.
+#' -   If the source object is encrypted using server-side encryption with
+#'     customer-provided encryption keys, you must use the following
+#'     headers.
 #' 
-#'         -   x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+#'     -   x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-algorithm
 #' 
-#'         -   x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-key
+#'     -   x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-key
 #' 
-#'         -   x-amz-copy-source-â€‹server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+#'     -   x-amz-copy-source-â€‹server-sideâ€‹-encryptionâ€‹-customer-key-MD5
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in Amazon
-#'         KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in Amazon
+#'     KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#' Access-Control-List (ACL)-Specific Request Headers
+#' ### Access-Control-List (ACL)-Specific Request Headers
 #' 
-#' :   You also can use the following access control--related headers with
-#'     this operation. By default, all objects are private. Only the owner
-#'     has full access control. When adding a new object, you can grant
-#'     permissions to individual AWS accounts or to predefined groups
-#'     defined by Amazon S3. These permissions are then added to the access
-#'     control list (ACL) on the object. For more information, see [Using
-#'     ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
-#'     With this operation, you can grant access permissions using one of
-#'     the following two methods:
+#' You also can use the following access control--related headers with this
+#' operation. By default, all objects are private. Only the owner has full
+#' access control. When adding a new object, you can grant permissions to
+#' individual AWS accounts or to predefined groups defined by Amazon S3.
+#' These permissions are then added to the access control list (ACL) on the
+#' object. For more information, see [Using
+#' ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
+#' With this operation, you can grant access permissions using one of the
+#' following two methods:
 #' 
-#'     -   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set
-#'         of predefined ACLs, known as *canned ACLs*. Each canned ACL has
-#'         a predefined set of grantees and permissions. For more
-#'         information, see [Canned
-#'         ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+#' -   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set of
+#'     predefined ACLs, known as *canned ACLs*. Each canned ACL has a
+#'     predefined set of grantees and permissions. For more information,
+#'     see [Canned
+#'     ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
 #' 
-#'     -   Specify access permissions explicitly --- To explicitly grant
-#'         access permissions to specific AWS accounts or groups, use the
-#'         following headers. Each header maps to specific permissions that
-#'         Amazon S3 supports in an ACL. For more information, see [Access
-#'         Control List (ACL)
-#'         Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
-#'         In the header, you specify a list of grantees who get the
-#'         specific permission. To grant permissions explicitly, use:
+#' -   Specify access permissions explicitly --- To explicitly grant access
+#'     permissions to specific AWS accounts or groups, use the following
+#'     headers. Each header maps to specific permissions that Amazon S3
+#'     supports in an ACL. For more information, see [Access Control List
+#'     (ACL)
+#'     Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+#'     In the header, you specify a list of grantees who get the specific
+#'     permission. To grant permissions explicitly, use:
 #' 
-#'         -   x-amz-grant-read
+#'     -   x-amz-grant-read
 #' 
-#'         -   x-amz-grant-write
+#'     -   x-amz-grant-write
 #' 
-#'         -   x-amz-grant-read-acp
+#'     -   x-amz-grant-read-acp
 #' 
-#'         -   x-amz-grant-write-acp
+#'     -   x-amz-grant-write-acp
 #' 
-#'         -   x-amz-grant-full-control
+#'     -   x-amz-grant-full-control
 #' 
-#'         You specify each grantee as a type=value pair, where the type is
-#'         one of the following:
+#'     You specify each grantee as a type=value pair, where the type is one
+#'     of the following:
 #' 
-#'         -   `emailAddress` -- if the value specified is the email
-#'             address of an AWS account
+#'     -   `emailAddress` -- if the value specified is the email address of
+#'         an AWS account
 #' 
-#'         -   `id` -- if the value specified is the canonical user ID of
-#'             an AWS account
+#'     -   `id` -- if the value specified is the canonical user ID of an
+#'         AWS account
 #' 
-#'         -   `uri` -- if you are granting permissions to a predefined
-#'             group
+#'     -   `uri` -- if you are granting permissions to a predefined group
 #' 
-#'         For example, the following `x-amz-grant-read` header grants the
-#'         AWS accounts identified by email addresses permissions to read
-#'         object data and its metadata:
+#'     For example, the following `x-amz-grant-read` header grants the AWS
+#'     accounts identified by email addresses permissions to read object
+#'     data and its metadata:
 #' 
-#'         `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
+#'     `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
 #' 
 #' The following operations are related to `CopyObject`:
 #' 
@@ -876,130 +873,126 @@ s3_create_bucket <- function(ACL = NULL, Bucket, CreateBucketConfiguration = NUL
 #' For more information, see [Protecting Data Using Server-Side
 #' Encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html).
 #' 
-#' Access Permissions
+#' ### Access Permissions
 #' 
-#' :   When copying an object, you can optionally specify the accounts or
-#'     groups that should be granted specific permissions on the new
-#'     object. There are two ways to grant the permissions using the
-#'     request headers:
+#' When copying an object, you can optionally specify the accounts or
+#' groups that should be granted specific permissions on the new object.
+#' There are two ways to grant the permissions using the request headers:
 #' 
-#'     -   Specify a canned ACL with the `x-amz-acl` request header. For
-#'         more information, see [Canned
-#'         ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+#' -   Specify a canned ACL with the `x-amz-acl` request header. For more
+#'     information, see [Canned
+#'     ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
 #' 
-#'     -   Specify access permissions explicitly with the
-#'         `x-amz-grant-read`, `x-amz-grant-read-acp`,
-#'         `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers.
-#'         These parameters map to the set of permissions that Amazon S3
-#'         supports in an ACL. For more information, see [Access Control
-#'         List (ACL)
-#'         Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+#' -   Specify access permissions explicitly with the `x-amz-grant-read`,
+#'     `x-amz-grant-read-acp`, `x-amz-grant-write-acp`, and
+#'     `x-amz-grant-full-control` headers. These parameters map to the set
+#'     of permissions that Amazon S3 supports in an ACL. For more
+#'     information, see [Access Control List (ACL)
+#'     Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
 #' 
-#'     You can use either a canned ACL or specify access permissions
-#'     explicitly. You cannot do both.
+#' You can use either a canned ACL or specify access permissions
+#' explicitly. You cannot do both.
 #' 
-#' Server-Side- Encryption-Specific Request Headers
+#' ### Server-Side- Encryption-Specific Request Headers
 #' 
-#' :   You can optionally tell Amazon S3 to encrypt data at rest using
-#'     server-side encryption. Server-side encryption is for data
-#'     encryption at rest. Amazon S3 encrypts your data as it writes it to
-#'     disks in its data centers and decrypts it when you access it. The
-#'     option you use depends on whether you want to use AWS managed
-#'     encryption keys or provide your own encryption key.
+#' You can optionally tell Amazon S3 to encrypt data at rest using
+#' server-side encryption. Server-side encryption is for data encryption at
+#' rest. Amazon S3 encrypts your data as it writes it to disks in its data
+#' centers and decrypts it when you access it. The option you use depends
+#' on whether you want to use AWS managed encryption keys or provide your
+#' own encryption key.
 #' 
-#'     -   Use encryption keys managed by Amazon S3 or customer master keys
-#'         (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you
-#'         want AWS to manage the keys used to encrypt data, specify the
-#'         following headers in the request.
+#' -   Use encryption keys managed by Amazon S3 or customer master keys
+#'     (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you want
+#'     AWS to manage the keys used to encrypt data, specify the following
+#'     headers in the request.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryption
+#'     -   x-amz-server-sideâ€‹-encryption
 #' 
-#'         -   x-amz-server-side-encryption-aws-kms-key-id
+#'     -   x-amz-server-side-encryption-aws-kms-key-id
 #' 
-#'         -   x-amz-server-side-encryption-context
+#'     -   x-amz-server-side-encryption-context
 #' 
-#'         If you specify `x-amz-server-side-encryption:aws:kms`, but
-#'         don\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-#'         Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-#'         data.
+#'     If you specify `x-amz-server-side-encryption:aws:kms`, but don\'t
+#'     provide `x-amz-server-side-encryption-aws-kms-key-id`, Amazon S3
+#'     uses the AWS managed CMK in AWS KMS to protect the data.
 #' 
-#'         All GET and PUT requests for an object protected by AWS KMS fail
-#'         if you don\'t make them with SSL or by using SigV4.
+#'     All GET and PUT requests for an object protected by AWS KMS fail if
+#'     you don\'t make them with SSL or by using SigV4.
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in AWS
-#'         KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in AWS
+#'     KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#'     -   Use customer-provided encryption keys -- If you want to manage
-#'         your own encryption keys, provide all the following headers in
-#'         the request.
+#' -   Use customer-provided encryption keys -- If you want to manage your
+#'     own encryption keys, provide all the following headers in the
+#'     request.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in AWS
-#'         KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in AWS
+#'     KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#' Access-Control-List (ACL)-Specific Request Headers
+#' ### Access-Control-List (ACL)-Specific Request Headers
 #' 
-#' :   You also can use the following access control--related headers with
-#'     this operation. By default, all objects are private. Only the owner
-#'     has full access control. When adding a new object, you can grant
-#'     permissions to individual AWS accounts or to predefined groups
-#'     defined by Amazon S3. These permissions are then added to the access
-#'     control list (ACL) on the object. For more information, see [Using
-#'     ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
-#'     With this operation, you can grant access permissions using one of
-#'     the following two methods:
+#' You also can use the following access control--related headers with this
+#' operation. By default, all objects are private. Only the owner has full
+#' access control. When adding a new object, you can grant permissions to
+#' individual AWS accounts or to predefined groups defined by Amazon S3.
+#' These permissions are then added to the access control list (ACL) on the
+#' object. For more information, see [Using
+#' ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
+#' With this operation, you can grant access permissions using one of the
+#' following two methods:
 #' 
-#'     -   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set
-#'         of predefined ACLs, known as *canned ACLs*. Each canned ACL has
-#'         a predefined set of grantees and permissions. For more
-#'         information, see [Canned
-#'         ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+#' -   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set of
+#'     predefined ACLs, known as *canned ACLs*. Each canned ACL has a
+#'     predefined set of grantees and permissions. For more information,
+#'     see [Canned
+#'     ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
 #' 
-#'     -   Specify access permissions explicitly --- To explicitly grant
-#'         access permissions to specific AWS accounts or groups, use the
-#'         following headers. Each header maps to specific permissions that
-#'         Amazon S3 supports in an ACL. For more information, see [Access
-#'         Control List (ACL)
-#'         Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
-#'         In the header, you specify a list of grantees who get the
-#'         specific permission. To grant permissions explicitly, use:
+#' -   Specify access permissions explicitly --- To explicitly grant access
+#'     permissions to specific AWS accounts or groups, use the following
+#'     headers. Each header maps to specific permissions that Amazon S3
+#'     supports in an ACL. For more information, see [Access Control List
+#'     (ACL)
+#'     Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+#'     In the header, you specify a list of grantees who get the specific
+#'     permission. To grant permissions explicitly, use:
 #' 
-#'         -   x-amz-grant-read
+#'     -   x-amz-grant-read
 #' 
-#'         -   x-amz-grant-write
+#'     -   x-amz-grant-write
 #' 
-#'         -   x-amz-grant-read-acp
+#'     -   x-amz-grant-read-acp
 #' 
-#'         -   x-amz-grant-write-acp
+#'     -   x-amz-grant-write-acp
 #' 
-#'         -   x-amz-grant-full-control
+#'     -   x-amz-grant-full-control
 #' 
-#'         You specify each grantee as a type=value pair, where the type is
-#'         one of the following:
+#'     You specify each grantee as a type=value pair, where the type is one
+#'     of the following:
 #' 
-#'         -   `emailAddress` -- if the value specified is the email
-#'             address of an AWS account
+#'     -   `emailAddress` -- if the value specified is the email address of
+#'         an AWS account
 #' 
-#'         -   `id` -- if the value specified is the canonical user ID of
-#'             an AWS account
+#'     -   `id` -- if the value specified is the canonical user ID of an
+#'         AWS account
 #' 
-#'         -   `uri` -- if you are granting permissions to a predefined
-#'             group
+#'     -   `uri` -- if you are granting permissions to a predefined group
 #' 
-#'         For example, the following `x-amz-grant-read` header grants the
-#'         AWS accounts identified by email addresses permissions to read
-#'         object data and its metadata:
+#'     For example, the following `x-amz-grant-read` header grants the AWS
+#'     accounts identified by email addresses permissions to read object
+#'     data and its metadata:
 #' 
-#'         `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
+#'     `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
 #' 
 #' The following operations are related to `CreateMultipartUpload`:
 #' 
@@ -7315,216 +7308,214 @@ s3_put_bucket_website <- function(Bucket, ContentMD5 = NULL, WebsiteConfiguratio
 #' keys. For more information, see [Using Server-Side
 #' Encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html).
 #' 
-#' Access Permissions
+#' ### Access Permissions
 #' 
-#' :   You can optionally specify the accounts or groups that should be
-#'     granted specific permissions on the new object. There are two ways
-#'     to grant the permissions using the request headers:
+#' You can optionally specify the accounts or groups that should be granted
+#' specific permissions on the new object. There are two ways to grant the
+#' permissions using the request headers:
 #' 
-#'     -   Specify a canned ACL with the `x-amz-acl` request header. For
-#'         more information, see [Canned
-#'         ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+#' -   Specify a canned ACL with the `x-amz-acl` request header. For more
+#'     information, see [Canned
+#'     ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
 #' 
-#'     -   Specify access permissions explicitly with the
-#'         `x-amz-grant-read`, `x-amz-grant-read-acp`,
-#'         `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers.
-#'         These parameters map to the set of permissions that Amazon S3
-#'         supports in an ACL. For more information, see [Access Control
-#'         List (ACL)
-#'         Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+#' -   Specify access permissions explicitly with the `x-amz-grant-read`,
+#'     `x-amz-grant-read-acp`, `x-amz-grant-write-acp`, and
+#'     `x-amz-grant-full-control` headers. These parameters map to the set
+#'     of permissions that Amazon S3 supports in an ACL. For more
+#'     information, see [Access Control List (ACL)
+#'     Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
 #' 
-#'     You can use either a canned ACL or specify access permissions
-#'     explicitly. You cannot do both.
+#' You can use either a canned ACL or specify access permissions
+#' explicitly. You cannot do both.
 #' 
-#' Server-Side- Encryption-Specific Request Headers
+#' ### Server-Side- Encryption-Specific Request Headers
 #' 
-#' :   You can optionally tell Amazon S3 to encrypt data at rest using
-#'     server-side encryption. Server-side encryption is for data
-#'     encryption at rest. Amazon S3 encrypts your data as it writes it to
-#'     disks in its data centers and decrypts it when you access it. The
-#'     option you use depends on whether you want to use AWS managed
-#'     encryption keys or provide your own encryption key.
+#' You can optionally tell Amazon S3 to encrypt data at rest using
+#' server-side encryption. Server-side encryption is for data encryption at
+#' rest. Amazon S3 encrypts your data as it writes it to disks in its data
+#' centers and decrypts it when you access it. The option you use depends
+#' on whether you want to use AWS managed encryption keys or provide your
+#' own encryption key.
 #' 
-#'     -   Use encryption keys managed by Amazon S3 or customer master keys
-#'         (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you
-#'         want AWS to manage the keys used to encrypt data, specify the
-#'         following headers in the request.
+#' -   Use encryption keys managed by Amazon S3 or customer master keys
+#'     (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you want
+#'     AWS to manage the keys used to encrypt data, specify the following
+#'     headers in the request.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryption
+#'     -   x-amz-server-sideâ€‹-encryption
 #' 
-#'         -   x-amz-server-side-encryption-aws-kms-key-id
+#'     -   x-amz-server-side-encryption-aws-kms-key-id
 #' 
-#'         -   x-amz-server-side-encryption-context
+#'     -   x-amz-server-side-encryption-context
 #' 
-#'         If you specify `x-amz-server-side-encryption:aws:kms`, but
-#'         don\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-#'         Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-#'         data. If you want to use a customer managed AWS KMS CMK, you
-#'         must provide the `x-amz-server-side-encryption-aws-kms-key-id`
-#'         of the symmetric customer managed CMK. Amazon S3 only supports
-#'         symmetric CMKs and not asymmetric CMKs. For more information,
-#'         see [Using Symmetric and Asymmetric
-#'         Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-#'         in the *AWS Key Management Service Developer Guide*.
+#'     If you specify `x-amz-server-side-encryption:aws:kms`, but don\'t
+#'     provide `x-amz-server-side-encryption-aws-kms-key-id`, Amazon S3
+#'     uses the AWS managed CMK in AWS KMS to protect the data. If you want
+#'     to use a customer managed AWS KMS CMK, you must provide the
+#'     `x-amz-server-side-encryption-aws-kms-key-id` of the symmetric
+#'     customer managed CMK. Amazon S3 only supports symmetric CMKs and not
+#'     asymmetric CMKs. For more information, see [Using Symmetric and
+#'     Asymmetric
+#'     Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+#'     in the *AWS Key Management Service Developer Guide*.
 #' 
-#'         All GET and PUT requests for an object protected by AWS KMS fail
-#'         if you don\'t make them with SSL or by using SigV4.
+#'     All GET and PUT requests for an object protected by AWS KMS fail if
+#'     you don\'t make them with SSL or by using SigV4.
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in
-#'         AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in
+#'     AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#'     -   Use customer-provided encryption keys -- If you want to manage
-#'         your own encryption keys, provide all the following headers in
-#'         the request.
+#' -   Use customer-provided encryption keys -- If you want to manage your
+#'     own encryption keys, provide all the following headers in the
+#'     request.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in KMS (SSE-KMS), see [Protecting Data Using Server-Side
-#'         Encryption with CMKs stored in
-#'         AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in KMS (SSE-KMS), see [Protecting Data Using Server-Side Encryption
+#'     with CMKs stored in
+#'     AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#' Access-Control-List (ACL)-Specific Request Headers
+#' ### Access-Control-List (ACL)-Specific Request Headers
 #' 
-#' :   You also can use the following access control--related headers with
-#'     this operation. By default, all objects are private. Only the owner
-#'     has full access control. When adding a new object, you can grant
-#'     permissions to individual AWS accounts or to predefined groups
-#'     defined by Amazon S3. These permissions are then added to the Access
-#'     Control List (ACL) on the object. For more information, see [Using
-#'     ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
-#'     With this operation, you can grant access permissions using one of
-#'     the following two methods:
+#' You also can use the following access control--related headers with this
+#' operation. By default, all objects are private. Only the owner has full
+#' access control. When adding a new object, you can grant permissions to
+#' individual AWS accounts or to predefined groups defined by Amazon S3.
+#' These permissions are then added to the Access Control List (ACL) on the
+#' object. For more information, see [Using
+#' ACLs](https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html).
+#' With this operation, you can grant access permissions using one of the
+#' following two methods:
 #' 
-#'     -   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set
-#'         of predefined ACLs, known as canned ACLs. Each canned ACL has a
-#'         predefined set of grantees and permissions. For more
-#'         information, see [Canned
-#'         ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+#' -   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set of
+#'     predefined ACLs, known as canned ACLs. Each canned ACL has a
+#'     predefined set of grantees and permissions. For more information,
+#'     see [Canned
+#'     ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
 #' 
-#'     -   Specify access permissions explicitly --- To explicitly grant
-#'         access permissions to specific AWS accounts or groups, use the
-#'         following headers. Each header maps to specific permissions that
-#'         Amazon S3 supports in an ACL. For more information, see [Access
-#'         Control List (ACL)
-#'         Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
-#'         In the header, you specify a list of grantees who get the
-#'         specific permission. To grant permissions explicitly use:
+#' -   Specify access permissions explicitly --- To explicitly grant access
+#'     permissions to specific AWS accounts or groups, use the following
+#'     headers. Each header maps to specific permissions that Amazon S3
+#'     supports in an ACL. For more information, see [Access Control List
+#'     (ACL)
+#'     Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+#'     In the header, you specify a list of grantees who get the specific
+#'     permission. To grant permissions explicitly use:
 #' 
-#'         -   x-amz-grant-read
+#'     -   x-amz-grant-read
 #' 
-#'         -   x-amz-grant-write
+#'     -   x-amz-grant-write
 #' 
-#'         -   x-amz-grant-read-acp
+#'     -   x-amz-grant-read-acp
 #' 
-#'         -   x-amz-grant-write-acp
+#'     -   x-amz-grant-write-acp
 #' 
-#'         -   x-amz-grant-full-control
+#'     -   x-amz-grant-full-control
 #' 
-#'         You specify each grantee as a type=value pair, where the type is
-#'         one of the following:
+#'     You specify each grantee as a type=value pair, where the type is one
+#'     of the following:
 #' 
-#'         -   `emailAddress` -- if the value specified is the email
-#'             address of an AWS account
+#'     -   `emailAddress` -- if the value specified is the email address of
+#'         an AWS account
 #' 
-#'             Using email addresses to specify a grantee is only supported
-#'             in the following AWS Regions:
+#'         Using email addresses to specify a grantee is only supported in
+#'         the following AWS Regions:
 #' 
-#'             -   US East (N. Virginia)
+#'         -   US East (N. Virginia)
 #' 
-#'             -   US West (N. California)
+#'         -   US West (N. California)
 #' 
-#'             -   US West (Oregon)
+#'         -   US West (Oregon)
 #' 
-#'             -   Asia Pacific (Singapore)
+#'         -   Asia Pacific (Singapore)
 #' 
-#'             -   Asia Pacific (Sydney)
+#'         -   Asia Pacific (Sydney)
 #' 
-#'             -   Asia Pacific (Tokyo)
+#'         -   Asia Pacific (Tokyo)
 #' 
-#'             -   EU (Ireland)
+#'         -   EU (Ireland)
 #' 
-#'             -   South America (SÃ£o Paulo)
+#'         -   South America (SÃ£o Paulo)
 #' 
-#'             For a list of all the Amazon S3 supported Regions and
-#'             endpoints, see [Regions and
-#'             Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
-#'             in the AWS General Reference
+#'         For a list of all the Amazon S3 supported Regions and endpoints,
+#'         see [Regions and
+#'         Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
+#'         in the AWS General Reference
 #' 
-#'         -   `id` -- if the value specified is the canonical user ID of
-#'             an AWS account
+#'     -   `id` -- if the value specified is the canonical user ID of an
+#'         AWS account
 #' 
-#'         -   `uri` -- if you are granting permissions to a predefined
-#'             group
+#'     -   `uri` -- if you are granting permissions to a predefined group
 #' 
-#'         For example, the following `x-amz-grant-read` header grants the
-#'         AWS accounts identified by email addresses permissions to read
-#'         object data and its metadata:
+#'     For example, the following `x-amz-grant-read` header grants the AWS
+#'     accounts identified by email addresses permissions to read object
+#'     data and its metadata:
 #' 
-#'         `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
+#'     `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
 #' 
-#' Server-Side- Encryption-Specific Request Headers
+#' ### Server-Side- Encryption-Specific Request Headers
 #' 
-#' :   You can optionally tell Amazon S3 to encrypt data at rest using
-#'     server-side encryption. Server-side encryption is for data
-#'     encryption at rest. Amazon S3 encrypts your data as it writes it to
-#'     disks in its data centers and decrypts it when you access it. The
-#'     option you use depends on whether you want to use AWS-managed
-#'     encryption keys or provide your own encryption key.
+#' You can optionally tell Amazon S3 to encrypt data at rest using
+#' server-side encryption. Server-side encryption is for data encryption at
+#' rest. Amazon S3 encrypts your data as it writes it to disks in its data
+#' centers and decrypts it when you access it. The option you use depends
+#' on whether you want to use AWS-managed encryption keys or provide your
+#' own encryption key.
 #' 
-#'     -   Use encryption keys managed by Amazon S3 or customer master keys
-#'         (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you
-#'         want AWS to manage the keys used to encrypt data, specify the
-#'         following headers in the request.
+#' -   Use encryption keys managed by Amazon S3 or customer master keys
+#'     (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you want
+#'     AWS to manage the keys used to encrypt data, specify the following
+#'     headers in the request.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryption
+#'     -   x-amz-server-sideâ€‹-encryption
 #' 
-#'         -   x-amz-server-side-encryption-aws-kms-key-id
+#'     -   x-amz-server-side-encryption-aws-kms-key-id
 #' 
-#'         -   x-amz-server-side-encryption-context
+#'     -   x-amz-server-side-encryption-context
 #' 
-#'         If you specify `x-amz-server-side-encryption:aws:kms`, but
-#'         don\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-#'         Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-#'         data. If you want to use a customer managed AWS KMS CMK, you
-#'         must provide the `x-amz-server-side-encryption-aws-kms-key-id`
-#'         of the symmetric customer managed CMK. Amazon S3 only supports
-#'         symmetric CMKs and not asymmetric CMKs. For more information,
-#'         see [Using Symmetric and Asymmetric
-#'         Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-#'         in the *AWS Key Management Service Developer Guide*.
+#'     If you specify `x-amz-server-side-encryption:aws:kms`, but don\'t
+#'     provide `x-amz-server-side-encryption-aws-kms-key-id`, Amazon S3
+#'     uses the AWS managed CMK in AWS KMS to protect the data. If you want
+#'     to use a customer managed AWS KMS CMK, you must provide the
+#'     `x-amz-server-side-encryption-aws-kms-key-id` of the symmetric
+#'     customer managed CMK. Amazon S3 only supports symmetric CMKs and not
+#'     asymmetric CMKs. For more information, see [Using Symmetric and
+#'     Asymmetric
+#'     Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
+#'     in the *AWS Key Management Service Developer Guide*.
 #' 
-#'         All GET and PUT requests for an object protected by AWS KMS fail
-#'         if you don\'t make them with SSL or by using SigV4.
+#'     All GET and PUT requests for an object protected by AWS KMS fail if
+#'     you don\'t make them with SSL or by using SigV4.
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in AWS
-#'         KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in AWS
+#'     KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
-#'     -   Use customer-provided encryption keys -- If you want to manage
-#'         your own encryption keys, provide all the following headers in
-#'         the request.
+#' -   Use customer-provided encryption keys -- If you want to manage your
+#'     own encryption keys, provide all the following headers in the
+#'     request.
 #' 
-#'         If you use this feature, the ETag value that Amazon S3 returns
-#'         in the response is not the MD5 of the object.
+#'     If you use this feature, the ETag value that Amazon S3 returns in
+#'     the response is not the MD5 of the object.
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
 #' 
-#'         -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+#'     -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
 #' 
-#'         For more information about server-side encryption with CMKs
-#'         stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-#'         Server-Side Encryption with CMKs stored in AWS
-#'         KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+#'     For more information about server-side encryption with CMKs stored
+#'     in AWS KMS (SSE-KMS), see [Protecting Data Using Server-Side
+#'     Encryption with CMKs stored in AWS
+#'     KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
 #' 
 #' **Storage Class Options**
 #' 

--- a/paws/R/servicecatalog_operations.R
+++ b/paws/R/servicecatalog_operations.R
@@ -492,51 +492,51 @@ servicecatalog_copy_product <- function(AcceptLanguage = NULL, SourceProductArn,
 #' @param Parameters &#91;required&#93; The constraint parameters, in JSON format. The syntax depends on the
 #' constraint type as follows:
 #' 
-#' LAUNCH
+#' ### LAUNCH
 #' 
-#' :   Specify the `RoleArn` property as follows:
+#' Specify the `RoleArn` property as follows:
 #' 
-#'     `\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\}`
+#' `\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\}`
 #' 
-#'     You cannot have both a `LAUNCH` and a `STACKSET` constraint.
+#' You cannot have both a `LAUNCH` and a `STACKSET` constraint.
 #' 
-#'     You also cannot have more than one `LAUNCH` constraint on a product
-#'     and portfolio.
+#' You also cannot have more than one `LAUNCH` constraint on a product and
+#' portfolio.
 #' 
-#' NOTIFICATION
+#' ### NOTIFICATION
 #' 
-#' :   Specify the `NotificationArns` property as follows:
+#' Specify the `NotificationArns` property as follows:
 #' 
-#'     `\{"NotificationArns" : \\["arn:aws:sns:us-east-1:123456789012:Topic"\\]\}`
+#' `\{"NotificationArns" : \\["arn:aws:sns:us-east-1:123456789012:Topic"\\]\}`
 #' 
-#' RESOURCE\\_UPDATE
+#' ### RESOURCE\\_UPDATE
 #' 
-#' :   Specify the `TagUpdatesOnProvisionedProduct` property as follows:
+#' Specify the `TagUpdatesOnProvisionedProduct` property as follows:
 #' 
-#'     `\{"Version":"2.0","Properties":\{"TagUpdateOnProvisionedProduct":"String"\}\}`
+#' `\{"Version":"2.0","Properties":\{"TagUpdateOnProvisionedProduct":"String"\}\}`
 #' 
-#'     The `TagUpdatesOnProvisionedProduct` property accepts a string value
-#'     of `ALLOWED` or `NOT_ALLOWED`.
+#' The `TagUpdatesOnProvisionedProduct` property accepts a string value of
+#' `ALLOWED` or `NOT_ALLOWED`.
 #' 
-#' STACKSET
+#' ### STACKSET
 #' 
-#' :   Specify the `Parameters` property as follows:
+#' Specify the `Parameters` property as follows:
 #' 
-#'     `\{"Version": "String", "Properties": \{"AccountList": \\[ "String" \\], "RegionList": \\[ "String" \\], "AdminRole": "String", "ExecutionRole": "String"\}\}`
+#' `\{"Version": "String", "Properties": \{"AccountList": \\[ "String" \\], "RegionList": \\[ "String" \\], "AdminRole": "String", "ExecutionRole": "String"\}\}`
 #' 
-#'     You cannot have both a `LAUNCH` and a `STACKSET` constraint.
+#' You cannot have both a `LAUNCH` and a `STACKSET` constraint.
 #' 
-#'     You also cannot have more than one `STACKSET` constraint on a
-#'     product and portfolio.
+#' You also cannot have more than one `STACKSET` constraint on a product
+#' and portfolio.
 #' 
-#'     Products with a `STACKSET` constraint will launch an AWS
-#'     CloudFormation stack set.
+#' Products with a `STACKSET` constraint will launch an AWS CloudFormation
+#' stack set.
 #' 
-#' TEMPLATE
+#' ### TEMPLATE
 #' 
-#' :   Specify the `Rules` property. For more information, see [Template
-#'     Constraint
-#'     Rules](http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html).
+#' Specify the `Rules` property. For more information, see [Template
+#' Constraint
+#' Rules](http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html).
 #' @param Type &#91;required&#93; The type of constraint.
 #' 
 #' -   `LAUNCH`
@@ -962,30 +962,30 @@ servicecatalog_create_provisioning_artifact <- function(AcceptLanguage = NULL, P
 #' @param DefinitionType &#91;required&#93; The service action definition type. For example, `SSM_AUTOMATION`.
 #' @param Definition &#91;required&#93; The self-service action definition. Can be one of the following:
 #' 
-#' Name
+#' ### Name
 #' 
-#' :   The name of the AWS Systems Manager Document. For example,
-#'     `AWS-RestartEC2Instance`.
+#' The name of the AWS Systems Manager Document. For example,
+#' `AWS-RestartEC2Instance`.
 #' 
-#' Version
+#' ### Version
 #' 
-#' :   The AWS Systems Manager automation document version. For example,
-#'     `"Version": "1"`
+#' The AWS Systems Manager automation document version. For example,
+#' `"Version": "1"`
 #' 
-#' AssumeRole
+#' ### AssumeRole
 #' 
-#' :   The Amazon Resource Name (ARN) of the role that performs the
-#'     self-service actions on your behalf. For example,
-#'     `"AssumeRole": "arn:aws:iam::12345678910:role/ActionRole"`.
+#' The Amazon Resource Name (ARN) of the role that performs the
+#' self-service actions on your behalf. For example,
+#' `"AssumeRole": "arn:aws:iam::12345678910:role/ActionRole"`.
 #' 
-#'     To reuse the provisioned product launch role, set to
-#'     `"AssumeRole": "LAUNCH_ROLE"`.
+#' To reuse the provisioned product launch role, set to
+#' `"AssumeRole": "LAUNCH_ROLE"`.
 #' 
-#' Parameters
+#' ### Parameters
 #' 
-#' :   The list of parameters in JSON format.
+#' The list of parameters in JSON format.
 #' 
-#'     For example: `\\[\{\"Name\":\"InstanceId\",\"Type\":\"TARGET\"\}\\]`.
+#' For example: `\\[\{\"Name\":\"InstanceId\",\"Type\":\"TARGET\"\}\\]`.
 #' @param Description The self-service action description.
 #' @param AcceptLanguage The language code.
 #' 
@@ -4007,51 +4007,51 @@ servicecatalog_terminate_provisioned_product <- function(ProvisionedProductName 
 #' @param Parameters The constraint parameters, in JSON format. The syntax depends on the
 #' constraint type as follows:
 #' 
-#' LAUNCH
+#' ### LAUNCH
 #' 
-#' :   Specify the `RoleArn` property as follows:
+#' Specify the `RoleArn` property as follows:
 #' 
-#'     `\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\}`
+#' `\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\}`
 #' 
-#'     You cannot have both a `LAUNCH` and a `STACKSET` constraint.
+#' You cannot have both a `LAUNCH` and a `STACKSET` constraint.
 #' 
-#'     You also cannot have more than one `LAUNCH` constraint on a product
-#'     and portfolio.
+#' You also cannot have more than one `LAUNCH` constraint on a product and
+#' portfolio.
 #' 
-#' NOTIFICATION
+#' ### NOTIFICATION
 #' 
-#' :   Specify the `NotificationArns` property as follows:
+#' Specify the `NotificationArns` property as follows:
 #' 
-#'     `\{"NotificationArns" : \\["arn:aws:sns:us-east-1:123456789012:Topic"\\]\}`
+#' `\{"NotificationArns" : \\["arn:aws:sns:us-east-1:123456789012:Topic"\\]\}`
 #' 
-#' RESOURCE\\_UPDATE
+#' ### RESOURCE\\_UPDATE
 #' 
-#' :   Specify the `TagUpdatesOnProvisionedProduct` property as follows:
+#' Specify the `TagUpdatesOnProvisionedProduct` property as follows:
 #' 
-#'     `\{"Version":"2.0","Properties":\{"TagUpdateOnProvisionedProduct":"String"\}\}`
+#' `\{"Version":"2.0","Properties":\{"TagUpdateOnProvisionedProduct":"String"\}\}`
 #' 
-#'     The `TagUpdatesOnProvisionedProduct` property accepts a string value
-#'     of `ALLOWED` or `NOT_ALLOWED`.
+#' The `TagUpdatesOnProvisionedProduct` property accepts a string value of
+#' `ALLOWED` or `NOT_ALLOWED`.
 #' 
-#' STACKSET
+#' ### STACKSET
 #' 
-#' :   Specify the `Parameters` property as follows:
+#' Specify the `Parameters` property as follows:
 #' 
-#'     `\{"Version": "String", "Properties": \{"AccountList": \\[ "String" \\], "RegionList": \\[ "String" \\], "AdminRole": "String", "ExecutionRole": "String"\}\}`
+#' `\{"Version": "String", "Properties": \{"AccountList": \\[ "String" \\], "RegionList": \\[ "String" \\], "AdminRole": "String", "ExecutionRole": "String"\}\}`
 #' 
-#'     You cannot have both a `LAUNCH` and a `STACKSET` constraint.
+#' You cannot have both a `LAUNCH` and a `STACKSET` constraint.
 #' 
-#'     You also cannot have more than one `STACKSET` constraint on a
-#'     product and portfolio.
+#' You also cannot have more than one `STACKSET` constraint on a product
+#' and portfolio.
 #' 
-#'     Products with a `STACKSET` constraint will launch an AWS
-#'     CloudFormation stack set.
+#' Products with a `STACKSET` constraint will launch an AWS CloudFormation
+#' stack set.
 #' 
-#' TEMPLATE
+#' ### TEMPLATE
 #' 
-#' :   Specify the `Rules` property. For more information, see [Template
-#'     Constraint
-#'     Rules](http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html).
+#' Specify the `Rules` property. For more information, see [Template
+#' Constraint
+#' Rules](http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html).
 #'
 #' @section Request syntax:
 #' ```

--- a/paws/R/ssm_operations.R
+++ b/paws/R/ssm_operations.R
@@ -3315,34 +3315,34 @@ ssm_describe_patch_groups <- function(MaxResults = NULL, Filters = NULL, NextTok
 #' The following section lists the properties that can be used in filters
 #' for each major operating system type:
 #' 
-#' WINDOWS
+#' ### WINDOWS
 #' 
-#' :   Valid properties: PRODUCT, PRODUCT\\_FAMILY, CLASSIFICATION,
-#'     MSRC\\_SEVERITY
+#' Valid properties: PRODUCT, PRODUCT\\_FAMILY, CLASSIFICATION,
+#' MSRC\\_SEVERITY
 #' 
-#' AMAZON\\_LINUX
+#' ### AMAZON\\_LINUX
 #' 
-#' :   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+#' Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
 #' 
-#' AMAZON\\_LINUX\\_2
+#' ### AMAZON\\_LINUX\\_2
 #' 
-#' :   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+#' Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
 #' 
-#' UBUNTU
+#' ### UBUNTU
 #' 
-#' :   Valid properties: PRODUCT, PRIORITY
+#' Valid properties: PRODUCT, PRIORITY
 #' 
-#' REDHAT\\_ENTERPRISE\\_LINUX
+#' ### REDHAT\\_ENTERPRISE\\_LINUX
 #' 
-#' :   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+#' Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
 #' 
-#' SUSE
+#' ### SUSE
 #' 
-#' :   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+#' Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
 #' 
-#' CENTOS
+#' ### CENTOS
 #' 
-#' :   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+#' Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
 #'
 #' @usage
 #' ssm_describe_patch_properties(OperatingSystem, Property, PatchSet,

--- a/paws/man/appstream_create_fleet.Rd
+++ b/paws/man/appstream_create_fleet.Rd
@@ -43,19 +43,20 @@ instance types are available:
 }}
 
 \item{FleetType}{The fleet type.
+\subsection{ALWAYS\\_ON}{
 
-ALWAYS\\_ON
+Provides users with instant-on access to their apps. You are charged for
+all running instances in your fleet, even if no users are streaming
+apps.
+}
 
-:   Provides users with instant-on access to their apps. You are charged
-for all running instances in your fleet, even if no users are
+\subsection{ON\\_DEMAND}{
+
+Provide users with access to applications after they connect, which
+takes one to two minutes. You are charged for instance streaming when
+users are connected and a small hourly fee for instances that are not
 streaming apps.
-
-ON\\_DEMAND
-
-:   Provide users with access to applications after they connect, which
-takes one to two minutes. You are charged for instance streaming
-when users are connected and a small hourly fee for instances that
-are not streaming apps.}
+}}
 
 \item{ComputeCapacity}{[required] The desired capacity for the fleet.}
 

--- a/paws/man/athena_list_query_executions.Rd
+++ b/paws/man/athena_list_query_executions.Rd
@@ -21,8 +21,8 @@ specified workgroup. Requires you to have access to the workgroup in
 which the queries ran.
 }
 \details{
-For code samples using the AWS SDK for Java, see Examples and Code
-Samples in the \emph{Amazon Athena User Guide}.
+For code samples using the AWS SDK for Java, see \href{http://docs.aws.amazon.com/athena/latest/ug/code-samples.html}{Examples and Code Samples}
+in the \emph{Amazon Athena User Guide}.
 }
 \section{Request syntax}{
 \preformatted{svc$list_query_executions(

--- a/paws/man/athena_start_query_execution.Rd
+++ b/paws/man/athena_start_query_execution.Rd
@@ -38,8 +38,8 @@ Runs the SQL query statements contained in the \code{Query}. Requires you to
 have access to the workgroup in which the query ran.
 }
 \details{
-For code samples using the AWS SDK for Java, see Examples and Code
-Samples in the \emph{Amazon Athena User Guide}.
+For code samples using the AWS SDK for Java, see \href{http://docs.aws.amazon.com/athena/latest/ug/code-samples.html}{Examples and Code Samples}
+in the \emph{Amazon Athena User Guide}.
 }
 \section{Request syntax}{
 \preformatted{svc$start_query_execution(

--- a/paws/man/chime.Rd
+++ b/paws/man/chime.Rd
@@ -23,34 +23,37 @@ You can use an AWS SDK, the AWS Command Line Interface (AWS CLI), or the
 REST API to make API calls. We recommend using an AWS SDK or the AWS
 CLI. Each API operation includes links to information about using it
 with a language-specific AWS SDK or the AWS CLI.
+\subsection{Using an AWS SDK}{
 
-Using an AWS SDK
-
-:   You don\'t need to write code to calculate a signature for request
+You don\'t need to write code to calculate a signature for request
 authentication. The SDK clients authenticate your requests by using
-access keys that you provide. For more information about AWS SDKs,
-see the \href{http://aws.amazon.com/developer/}{AWS Developer Center}.
-
-Using the AWS CLI
-
-:   Use your access keys with the AWS CLI to make API calls. For
-information about setting up the AWS CLI, see \href{https://docs.aws.amazon.com/cli/latest/userguide/installing.html}{Installing the AWS Command Line Interface}
-in the \emph{AWS Command Line Interface User Guide}. For a list of
-available Amazon Chime commands, see the \href{https://docs.aws.amazon.com/cli/latest/reference/chime/index.html}{Amazon Chime commands}
-in the \emph{AWS CLI Command Reference}.
-
-Using REST API
-
-:   If you use REST to make API calls, you must authenticate your
-request by providing a signature. Amazon Chime supports signature
-version 4. For more information, see \href{https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html}{Signature Version 4 Signing Process}
-in the \emph{Amazon Web Services General Reference}.\preformatted{When making REST API calls, use the service name `chime` and REST
-endpoint `https://service.chime.aws.amazon.com`.
+access keys that you provide. For more information about AWS SDKs, see
+the \href{http://aws.amazon.com/developer/}{AWS Developer Center}.
 }
+
+\subsection{Using the AWS CLI}{
+
+Use your access keys with the AWS CLI to make API calls. For information
+about setting up the AWS CLI, see \href{https://docs.aws.amazon.com/cli/latest/userguide/installing.html}{Installing the AWS Command Line Interface}
+in the \emph{AWS Command Line Interface User Guide}. For a list of available
+Amazon Chime commands, see the \href{https://docs.aws.amazon.com/cli/latest/reference/chime/index.html}{Amazon Chime commands}
+in the \emph{AWS CLI Command Reference}.
+}
+
+\subsection{Using REST API}{
+
+If you use REST to make API calls, you must authenticate your request by
+providing a signature. Amazon Chime supports signature version 4. For
+more information, see \href{https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html}{Signature Version 4 Signing Process}
+in the \emph{Amazon Web Services General Reference}.
+
+When making REST API calls, use the service name \code{chime} and REST
+endpoint \verb{https://service.chime.aws.amazon.com}.
 
 Administrative permissions are controlled using AWS Identity and Access
 Management (IAM). For more information, see \href{https://docs.aws.amazon.com/chime/latest/ag/security-iam.html}{Identity and Access Management for Amazon Chime} in
 the \emph{Amazon Chime Administration Guide}.
+}
 }
 \section{Service syntax}{
 \preformatted{svc <- chime(

--- a/paws/man/connect_get_current_metric_data.Rd
+++ b/paws/man/connect_get_current_metric_data.Rd
@@ -27,58 +27,70 @@ returned.}
 
 \item{CurrentMetrics}{[required] The metrics to retrieve. Specify the name and unit for each metric. The
 following metrics are available:
+\subsection{AGENTS\\_AFTER\\_CONTACT\\_WORK}{
 
-AGENTS\\_AFTER\\_CONTACT\\_WORK
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_AVAILABLE}{
 
-AGENTS\\_AVAILABLE
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_ERROR}{
 
-AGENTS\\_ERROR
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_NON\\_PRODUCTIVE}{
 
-AGENTS\\_NON\\_PRODUCTIVE
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_ON\\_CALL}{
 
-AGENTS\\_ON\\_CALL
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_ON\\_CONTACT}{
 
-AGENTS\\_ON\\_CONTACT
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_ONLINE}{
 
-AGENTS\\_ONLINE
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{AGENTS\\_STAFFED}{
 
-AGENTS\\_STAFFED
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{CONTACTS\\_IN\\_QUEUE}{
 
-CONTACTS\\_IN\\_QUEUE
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{CONTACTS\\_SCHEDULED}{
 
-CONTACTS\\_SCHEDULED
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{OLDEST\\_CONTACT\\_AGE}{
 
-OLDEST\\_CONTACT\\_AGE
+Unit: SECONDS
+}
 
-:   Unit: SECONDS
+\subsection{SLOTS\\_ACTIVE}{
 
-SLOTS\\_ACTIVE
+Unit: COUNT
+}
 
-:   Unit: COUNT
+\subsection{SLOTS\\_AVAILABLE}{
 
-SLOTS\\_AVAILABLE
-
-:   Unit: COUNT}
+Unit: COUNT
+}}
 
 \item{NextToken}{The token for the next set of results. Use the value returned in the
 previous response in the next request to retrieve the next set of

--- a/paws/man/connect_get_metric_data.Rd
+++ b/paws/man/connect_get_metric_data.Rd
@@ -44,132 +44,181 @@ returned.}
 
 \item{HistoricalMetrics}{[required] The metrics to retrieve. Specify the name, unit, and statistic for each
 metric. The following historical metrics are available:
+\subsection{ABANDON\\_TIME}{
 
-ABANDON\\_TIME
+Unit: SECONDS
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Statistic: AVG
 }
 
-AFTER\\_CONTACT\\_WORK\\_TIME
+\subsection{AFTER\\_CONTACT\\_WORK\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Unit: SECONDS
+
+Statistic: AVG
 }
 
-API\\_CONTACTS\\_HANDLED
+\subsection{API\\_CONTACTS\\_HANDLED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CALLBACK\\_CONTACTS\\_HANDLED
+\subsection{CALLBACK\\_CONTACTS\\_HANDLED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_ABANDONED
+\subsection{CONTACTS\\_ABANDONED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_AGENT\\_HUNG\\_UP\\_FIRST
+\subsection{CONTACTS\\_AGENT\\_HUNG\\_UP\\_FIRST}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_CONSULTED
+\subsection{CONTACTS\\_CONSULTED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_HANDLED
+\subsection{CONTACTS\\_HANDLED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_HANDLED\\_INCOMING
+\subsection{CONTACTS\\_HANDLED\\_INCOMING}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_HANDLED\\_OUTBOUND
+\subsection{CONTACTS\\_HANDLED\\_OUTBOUND}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_HOLD\\_ABANDONS
+\subsection{CONTACTS\\_HOLD\\_ABANDONS}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_MISSED
+\subsection{CONTACTS\\_MISSED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_QUEUED
+\subsection{CONTACTS\\_QUEUED}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_TRANSFERRED\\_IN
+\subsection{CONTACTS\\_TRANSFERRED\\_IN}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_TRANSFERRED\\_IN\\_FROM\\_QUEUE
+\subsection{CONTACTS\\_TRANSFERRED\\_IN\\_FROM\\_QUEUE}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_TRANSFERRED\\_OUT
+\subsection{CONTACTS\\_TRANSFERRED\\_OUT}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-CONTACTS\\_TRANSFERRED\\_OUT\\_FROM\\_QUEUE
+\subsection{CONTACTS\\_TRANSFERRED\\_OUT\\_FROM\\_QUEUE}{
 
-:   Unit: COUNT\preformatted{Statistic: SUM
+Unit: COUNT
+
+Statistic: SUM
 }
 
-HANDLE\\_TIME
+\subsection{HANDLE\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Unit: SECONDS
+
+Statistic: AVG
 }
 
-HOLD\\_TIME
+\subsection{HOLD\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Unit: SECONDS
+
+Statistic: AVG
 }
 
-INTERACTION\\_AND\\_HOLD\\_TIME
+\subsection{INTERACTION\\_AND\\_HOLD\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Unit: SECONDS
+
+Statistic: AVG
 }
 
-INTERACTION\\_TIME
+\subsection{INTERACTION\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Unit: SECONDS
+
+Statistic: AVG
 }
 
-OCCUPANCY
+\subsection{OCCUPANCY}{
 
-:   Unit: PERCENT\preformatted{Statistic: AVG
+Unit: PERCENT
+
+Statistic: AVG
 }
 
-QUEUE\\_ANSWER\\_TIME
+\subsection{QUEUE\\_ANSWER\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: AVG
+Unit: SECONDS
+
+Statistic: AVG
 }
 
-QUEUED\\_TIME
+\subsection{QUEUED\\_TIME}{
 
-:   Unit: SECONDS\preformatted{Statistic: MAX
+Unit: SECONDS
+
+Statistic: MAX
 }
 
-SERVICE\\_LEVEL
+\subsection{SERVICE\\_LEVEL}{
 
-:   Unit: PERCENT\preformatted{Statistic: AVG
+Unit: PERCENT
 
-Threshold: Only \\"Less than\\" comparisons are supported, with the
+Statistic: AVG
+
+Threshold: Only \"Less than\" comparisons are supported, with the
 following service level thresholds: 15, 20, 25, 30, 45, 60, 90, 120,
 180, 240, 300, 600
 }}

--- a/paws/man/ec2_describe_volume_attribute.Rd
+++ b/paws/man/ec2_describe_volume_attribute.Rd
@@ -21,8 +21,8 @@ Describes the specified attribute of the specified volume. You can
 specify only one attribute at a time.
 }
 \details{
-For more information about EBS volumes, see Amazon EBS Volumes in the
-\emph{Amazon Elastic Compute Cloud User Guide}.
+For more information about EBS volumes, see \href{https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumes.html}{Amazon EBS Volumes}
+in the \emph{Amazon Elastic Compute Cloud User Guide}.
 }
 \section{Request syntax}{
 \preformatted{svc$describe_volume_attribute(

--- a/paws/man/elasticbeanstalk_update_tags_for_resource.Rd
+++ b/paws/man/elasticbeanstalk_update_tags_for_resource.Rd
@@ -32,18 +32,19 @@ environments. For details about environment tagging, see \href{https://docs.aws.
 If you create a custom IAM user policy to control permission to this
 operation, specify one of the following two virtual actions (or both)
 instead of the API operation name:
+\subsection{elasticbeanstalk:AddTags}{
 
-elasticbeanstalk:AddTags
+Controls permission to call \code{UpdateTagsForResource} and pass a list of
+tags to add in the \code{TagsToAdd} parameter.
+}
 
-:   Controls permission to call \code{UpdateTagsForResource} and pass a list
-of tags to add in the \code{TagsToAdd} parameter.
+\subsection{elasticbeanstalk:RemoveTags}{
 
-elasticbeanstalk:RemoveTags
-
-:   Controls permission to call \code{UpdateTagsForResource} and pass a list
-of tag keys to remove in the \code{TagsToRemove} parameter.
+Controls permission to call \code{UpdateTagsForResource} and pass a list of
+tag keys to remove in the \code{TagsToRemove} parameter.
 
 For details about creating a custom user policy, see \href{https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.iam.managed-policies.html#AWSHowTo.iam.policies}{Creating a Custom User Policy}.
+}
 }
 \section{Request syntax}{
 \preformatted{svc$update_tags_for_resource(

--- a/paws/man/globalaccelerator.Rd
+++ b/paws/man/globalaccelerator.Rd
@@ -38,67 +38,69 @@ to only healthy endpoints.
 
 Global Accelerator includes components that work together to help you
 improve performance and availability for your applications:
+\subsection{Static IP address}{
 
-Static IP address
+AWS Global Accelerator provides you with a set of static IP addresses
+which are anycast from the AWS edge network and serve as the single
+fixed entry points for your clients. If you already have Elastic Load
+Balancing or Elastic IP address resources set up for your applications,
+you can easily add those to Global Accelerator to allow the resources to
+be accessed by a Global Accelerator static IP address.
+}
 
-:   AWS Global Accelerator provides you with a set of static IP
-addresses which are anycast from the AWS edge network and serve as
-the single fixed entry points for your clients. If you already have
-Elastic Load Balancing or Elastic IP address resources set up for
-your applications, you can easily add those to Global Accelerator to
-allow the resources to be accessed by a Global Accelerator static IP
-address.
+\subsection{Accelerator}{
 
-Accelerator
+An accelerator directs traffic to optimal endpoints over the AWS global
+network to improve availability and performance for your internet
+applications that have a global audience. Each accelerator includes one
+or more listeners.
+}
 
-:   An accelerator directs traffic to optimal endpoints over the AWS
-global network to improve availability and performance for your
-internet applications that have a global audience. Each accelerator
-includes one or more listeners.
+\subsection{Network zone}{
 
-Network zone
+A network zone services the static IP addresses for your accelerator
+from a unique IP subnet. Similar to an AWS Availability Zone, a network
+zone is an isolated unit with its own set of physical infrastructure.
+When you configure an accelerator, Global Accelerator allocates two IPv4
+addresses for it. If one IP address from a network zone becomes
+unavailable due to IP address blocking by certain client networks, or
+network disruptions, then client applications can retry on the healthy
+static IP address from the other isolated network zone.
+}
 
-:   A network zone services the static IP addresses for your accelerator
-from a unique IP subnet. Similar to an AWS Availability Zone, a
-network zone is an isolated unit with its own set of physical
-infrastructure. When you configure an accelerator, Global
-Accelerator allocates two IPv4 addresses for it. If one IP address
-from a network zone becomes unavailable due to IP address blocking
-by certain client networks, or network disruptions, then client
-applications can retry on the healthy static IP address from the
-other isolated network zone.
+\subsection{Listener}{
 
-Listener
-
-:   A listener processes inbound connections from clients to Global
+A listener processes inbound connections from clients to Global
 Accelerator, based on the protocol and port that you configure. Each
-listener has one or more endpoint groups associated with it, and
-traffic is forwarded to endpoints in one of the groups. You
-associate endpoint groups with listeners by specifying the Regions
-that you want to distribute traffic to. Traffic is distributed to
-optimal endpoints within the endpoint groups associated with a
-listener.
+listener has one or more endpoint groups associated with it, and traffic
+is forwarded to endpoints in one of the groups. You associate endpoint
+groups with listeners by specifying the Regions that you want to
+distribute traffic to. Traffic is distributed to optimal endpoints
+within the endpoint groups associated with a listener.
+}
 
-Endpoint group
+\subsection{Endpoint group}{
 
-:   Each endpoint group is associated with a specific AWS Region.
-Endpoint groups include one or more endpoints in the Region. You can
-increase or reduce the percentage of traffic that would be otherwise
-directed to an endpoint group by adjusting a setting called a
-\emph{traffic dial}. The traffic dial lets you easily do performance
-testing or blue/green deployment testing for new releases across
-different AWS Regions, for example.
+Each endpoint group is associated with a specific AWS Region. Endpoint
+groups include one or more endpoints in the Region. You can increase or
+reduce the percentage of traffic that would be otherwise directed to an
+endpoint group by adjusting a setting called a \emph{traffic dial}. The
+traffic dial lets you easily do performance testing or blue/green
+deployment testing for new releases across different AWS Regions, for
+example.
+}
 
-Endpoint
+\subsection{Endpoint}{
 
-:   An endpoint is an Elastic IP address, Network Load Balancer, or
+An endpoint is an Elastic IP address, Network Load Balancer, or
 Application Load Balancer. Traffic is routed to endpoints based on
-several factors, including the geo-proximity to the user, the health
-of the endpoint, and the configuration options that you choose, such
-as endpoint weights. For each endpoint, you can configure weights,
-which are numbers that you can use to specify the proportion of
-traffic to route to each one. This can be useful, for example, to do
-performance testing within a Region.
+several factors, including the geo-proximity to the user, the health of
+the endpoint, and the configuration options that you choose, such as
+endpoint weights. For each endpoint, you can configure weights, which
+are numbers that you can use to specify the proportion of traffic to
+route to each one. This can be useful, for example, to do performance
+testing within a Region.
+}
 }
 \section{Service syntax}{
 \preformatted{svc <- globalaccelerator(

--- a/paws/man/glue_get_partitions.Rd
+++ b/paws/man/glue_get_partitions.Rd
@@ -24,50 +24,59 @@ expression.
 
 \emph{Operators}: The following are the operators that you can use in the
 \code{Expression} API call:
+\subsection{=}{
 
-=
+Checks whether the values of the two operands are equal; if yes, then
+the condition becomes true.
 
-:   Checks whether the values of the two operands are equal; if yes,
-then the condition becomes true.\preformatted{Example: Assume \\'variable a\\' holds 10 and \\'variable b\\' holds 20.
+Example: Assume \'variable a\' holds 10 and \'variable b\' holds 20.
 
 (a = b) is not true.
 }
 
-\\< \\>
+\subsection{\\< \\>}{
 
-:   Checks whether the values of two operands are equal; if the values
-are not equal, then the condition becomes true.\preformatted{Example: (a \\\\< \\\\> b) is true.
+Checks whether the values of two operands are equal; if the values are
+not equal, then the condition becomes true.
+
+Example: (a \\< \\> b) is true.
 }
 
-\\>
+\subsection{\\>}{
 
-:   Checks whether the value of the left operand is greater than the
-value of the right operand; if yes, then the condition becomes true.\preformatted{Example: (a \\\\> b) is not true.
+Checks whether the value of the left operand is greater than the value
+of the right operand; if yes, then the condition becomes true.
+
+Example: (a \\> b) is not true.
 }
 
-\\<
+\subsection{\\<}{
 
-:   Checks whether the value of the left operand is less than the value
-of the right operand; if yes, then the condition becomes true.\preformatted{Example: (a \\\\< b) is true.
+Checks whether the value of the left operand is less than the value of
+the right operand; if yes, then the condition becomes true.
+
+Example: (a \\< b) is true.
 }
 
-\\>=
+\subsection{\\>=}{
 
-:   Checks whether the value of the left operand is greater than or
-equal to the value of the right operand; if yes, then the condition
-becomes true.\preformatted{Example: (a \\\\>= b) is not true.
+Checks whether the value of the left operand is greater than or equal to
+the value of the right operand; if yes, then the condition becomes true.
+
+Example: (a \\>= b) is not true.
 }
 
-\\<=
+\subsection{\\<=}{
 
-:   Checks whether the value of the left operand is less than or equal
-to the value of the right operand; if yes, then the condition
-becomes true.\preformatted{Example: (a \\\\<= b) is true.
+Checks whether the value of the left operand is less than or equal to
+the value of the right operand; if yes, then the condition becomes true.
+
+Example: (a \\<= b) is true.
 }
 
-AND, OR, IN, BETWEEN, LIKE, NOT, IS NULL
+\subsection{AND, OR, IN, BETWEEN, LIKE, NOT, IS NULL}{
 
-:   Logical operators.
+Logical operators.
 
 \emph{Supported Partition Key Types}: The following are the supported
 partition keys.
@@ -89,7 +98,8 @@ The following list shows the valid operators on each type. When you
 define a crawler, the \code{partitionKey} type is created as a \code{STRING}, to
 be compatible with the catalog partitions.
 
-\emph{Sample API Call}:}
+\emph{Sample API Call}:
+}}
 
 \item{NextToken}{A continuation token, if this is not the first call to retrieve these
 partitions.}

--- a/paws/man/iot_update_topic_rule_destination.Rd
+++ b/paws/man/iot_update_topic_rule_destination.Rd
@@ -10,35 +10,37 @@ iot_update_topic_rule_destination(arn, status)
 \item{arn}{[required] The ARN of the topic rule destination.}
 
 \item{status}{[required] The status of the topic rule destination. Valid values are:
+\subsection{IN\\_PROGRESS}{
 
-IN\\_PROGRESS
+A topic rule destination was created but has not been confirmed. You can
+set \code{status} to \code{IN_PROGRESS} by calling \code{UpdateTopicRuleDestination}.
+Calling \code{UpdateTopicRuleDestination} causes a new confirmation challenge
+to be sent to your confirmation endpoint.
+}
 
-:   A topic rule destination was created but has not been confirmed. You
-can set \code{status} to \code{IN_PROGRESS} by calling
+\subsection{ENABLED}{
+
+Confirmation was completed, and traffic to this destination is allowed.
+You can set \code{status} to \code{DISABLED} by calling
+\code{UpdateTopicRuleDestination}.
+}
+
+\subsection{DISABLED}{
+
+Confirmation was completed, and traffic to this destination is not
+allowed. You can set \code{status} to \code{ENABLED} by calling
+\code{UpdateTopicRuleDestination}.
+}
+
+\subsection{ERROR}{
+
+Confirmation could not be completed, for example if the confirmation
+timed out. You can call \code{GetTopicRuleDestination} for details about the
+error. You can set \code{status} to \code{IN_PROGRESS} by calling
 \code{UpdateTopicRuleDestination}. Calling \code{UpdateTopicRuleDestination}
 causes a new confirmation challenge to be sent to your confirmation
 endpoint.
-
-ENABLED
-
-:   Confirmation was completed, and traffic to this destination is
-allowed. You can set \code{status} to \code{DISABLED} by calling
-\code{UpdateTopicRuleDestination}.
-
-DISABLED
-
-:   Confirmation was completed, and traffic to this destination is not
-allowed. You can set \code{status} to \code{ENABLED} by calling
-\code{UpdateTopicRuleDestination}.
-
-ERROR
-
-:   Confirmation could not be completed, for example if the confirmation
-timed out. You can call \code{GetTopicRuleDestination} for details about
-the error. You can set \code{status} to \code{IN_PROGRESS} by calling
-\code{UpdateTopicRuleDestination}. Calling \code{UpdateTopicRuleDestination}
-causes a new confirmation challenge to be sent to your confirmation
-endpoint.}
+}}
 }
 \description{
 Updates a topic rule destination. You use this to change the status,

--- a/paws/man/kinesisvideoarchivedmedia_get_dash_streaming_session_url.Rd
+++ b/paws/man/kinesisvideoarchivedmedia_get_dash_streaming_session_url.Rd
@@ -158,12 +158,10 @@ AAC) or A\\_MS/ACM (for G.711).
 \item Data retention must be greater than 0.
 \item The video track of each fragment must contain codec private data in
 the Advanced Video Coding (AVC) for H.264 format and HEVC for H.265
-format. For more information, see MPEG-4 specification ISO/IEC
-14496-15. For information about adapting stream data to a given
-format, see \href{http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html}{NAL Adaptation Flags}.
+format. For more information, see \href{https://www.iso.org/standard/55980.html}{MPEG-4 specification ISO/IEC 14496-15}. For information
+about adapting stream data to a given format, see \href{http://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html}{NAL Adaptation Flags}.
 \item The audio track (if present) of each fragment must contain codec
-private data in the AAC format (AAC specification ISO/IEC 13818-7)
-or the \href{http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html}{MS Wave format}.
+private data in the AAC format (\href{https://www.iso.org/standard/43345.html}{AAC specification ISO/IEC 13818-7}) or the \href{http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html}{MS Wave format}.
 }
 
 The following procedure shows how to use MPEG-DASH with Kinesis Video

--- a/paws/man/kms_create_key.Rd
+++ b/paws/man/kms_create_key.Rd
@@ -183,46 +183,48 @@ For information about symmetric and asymmetric CMKs, see \href{https://docs.aws.
 in the \emph{AWS Key Management Service Developer Guide}.
 
 To create different types of CMKs, use the following guidance:
+\subsection{Asymmetric CMKs}{
 
-Asymmetric CMKs
+To create an asymmetric CMK, use the \code{CustomerMasterKeySpec} parameter
+to specify the type of key material in the CMK. Then, use the \code{KeyUsage}
+parameter to determine whether the CMK will be used to encrypt and
+decrypt or sign and verify. You can\'t change these properties after the
+CMK is created.
+}
 
-:   To create an asymmetric CMK, use the \code{CustomerMasterKeySpec}
-parameter to specify the type of key material in the CMK. Then, use
-the \code{KeyUsage} parameter to determine whether the CMK will be used
-to encrypt and decrypt or sign and verify. You can\'t change these
-properties after the CMK is created.
+\subsection{Symmetric CMKs}{
 
-Symmetric CMKs
+When creating a symmetric CMK, you don\'t need to specify the
+\code{CustomerMasterKeySpec} or \code{KeyUsage} parameters. The default value for
+\code{CustomerMasterKeySpec}, \code{SYMMETRIC_DEFAULT}, and the default value for
+\code{KeyUsage}, \code{ENCRYPT_DECRYPT}, are the only valid values for symmetric
+CMKs.
+}
 
-:   When creating a symmetric CMK, you don\'t need to specify the
-\code{CustomerMasterKeySpec} or \code{KeyUsage} parameters. The default value
-for \code{CustomerMasterKeySpec}, \code{SYMMETRIC_DEFAULT}, and the default
-value for \code{KeyUsage}, \code{ENCRYPT_DECRYPT}, are the only valid values
-for symmetric CMKs.
+\subsection{Imported Key Material}{
 
-Imported Key Material
-
-:   To import your own key material, begin by creating a symmetric CMK
-with no key material. To do this, use the \code{Origin} parameter of
-\code{CreateKey} with a value of \code{EXTERNAL}. Next, use
-GetParametersForImport operation to get a public key and import
-token, and use the public key to encrypt your key material. Then,
-use ImportKeyMaterial with your import token to import the key
-material. For step-by-step instructions, see \href{https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html}{Importing Key Material}
+To import your own key material, begin by creating a symmetric CMK with
+no key material. To do this, use the \code{Origin} parameter of \code{CreateKey}
+with a value of \code{EXTERNAL}. Next, use GetParametersForImport operation
+to get a public key and import token, and use the public key to encrypt
+your key material. Then, use ImportKeyMaterial with your import token to
+import the key material. For step-by-step instructions, see \href{https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html}{Importing Key Material}
 in the \strong{AWS Key Management Service Developer Guide} . You cannot
 import the key material into an asymmetric CMK.
+}
 
-Custom Key Stores
+\subsection{Custom Key Stores}{
 
-:   To create a symmetric CMK in a \href{https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html}{custom key store},
-use the \code{CustomKeyStoreId} parameter to specify the custom key
-store. You must also use the \code{Origin} parameter with a value of
-\code{AWS_CLOUDHSM}. The AWS CloudHSM cluster that is associated with the
-custom key store must have at least two active HSMs in different
-Availability Zones in the AWS Region.\preformatted{You cannot create an asymmetric CMK in a custom key store. For
-information about custom key stores in AWS KMS see [Using Custom Key
-Stores](https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html)
-in the **AWS Key Management Service Developer Guide** .
+To create a symmetric CMK in a \href{https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html}{custom key store},
+use the \code{CustomKeyStoreId} parameter to specify the custom key store.
+You must also use the \code{Origin} parameter with a value of \code{AWS_CLOUDHSM}.
+The AWS CloudHSM cluster that is associated with the custom key store
+must have at least two active HSMs in different Availability Zones in
+the AWS Region.
+
+You cannot create an asymmetric CMK in a custom key store. For
+information about custom key stores in AWS KMS see \href{https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html}{Using Custom Key Stores}
+in the \strong{AWS Key Management Service Developer Guide} .
 }
 }
 \section{Request syntax}{

--- a/paws/man/robomaker_create_simulation_job.Rd
+++ b/paws/man/robomaker_create_simulation_job.Rd
@@ -25,14 +25,15 @@ APIs that are specified in its associated policies on your behalf. This
 is how credentials are passed in to your simulation job.}
 
 \item{failureBehavior}{The failure behavior the simulation job.
+\subsection{Continue}{
 
-Continue
+Restart the simulation job in the same host instance.
+}
 
-:   Restart the simulation job in the same host instance.
+\subsection{Fail}{
 
-Fail
-
-:   Stop the simulation job and terminate the instance.}
+Stop the simulation job and terminate the instance.
+}}
 
 \item{robotApplications}{The robot application to use in the simulation job.}
 

--- a/paws/man/route53_create_query_logging_config.Rd
+++ b/paws/man/route53_create_query_logging_config.Rd
@@ -36,105 +36,107 @@ receives for a specified public hosted zone, such as the following:
 \item DNS record type, such as A or AAAA
 \item DNS response code, such as \code{NoError} or \code{ServFail}
 }
+\subsection{Log Group and Resource Policy}{
 
-Log Group and Resource Policy
+Before you create a query logging configuration, perform the following
+operations.
 
-:   Before you create a query logging configuration, perform the
-following operations.\preformatted{If you create a query logging configuration using the Route 53
-console, Route 53 performs these operations automatically.
+If you create a query logging configuration using the Route 53 console,
+Route 53 performs these operations automatically.
+\enumerate{
+\item Create a CloudWatch Logs log group, and make note of the ARN, which
+you specify when you create a query logging configuration. Note the
+following:
+\itemize{
+\item You must create the log group in the us-east-1 region.
+\item You must use the same AWS account to create the log group and
+the hosted zone that you want to configure query logging for.
+\item When you create log groups for query logging, we recommend that
+you use a consistent prefix, for example:
 
-1.  Create a CloudWatch Logs log group, and make note of the ARN,
-    which you specify when you create a query logging configuration.
-    Note the following:
+\verb{/aws/route53/<i>hosted zone name</i> }
 
-    -   You must create the log group in the us-east-1 region.
+In the next step, you\'ll create a resource policy, which
+controls access to one or more log groups and the associated AWS
+resources, such as Route 53 hosted zones. There\'s a limit on
+the number of resource policies that you can create, so we
+recommend that you use a consistent prefix so you can use the
+same resource policy for all the log groups that you create for
+query logging.
+}
+\item Create a CloudWatch Logs resource policy, and give it the
+permissions that Route 53 needs to create log streams and to send
+query logs to log streams. For the value of \code{Resource}, specify the
+ARN for the log group that you created in the previous step. To use
+the same resource policy for all the CloudWatch Logs log groups that
+you created for query logging configurations, replace the hosted
+zone name with \code{*}, for example:
 
-    -   You must use the same AWS account to create the log group
-        and the hosted zone that you want to configure query logging
-        for.
+\verb{arn:aws:logs:us-east-1:123412341234:log-group:/aws/route53/*}
 
-    -   When you create log groups for query logging, we recommend
-        that you use a consistent prefix, for example:
-
-        `/aws/route53/<i>hosted zone name</i> `
-
-        In the next step, you\\'ll create a resource policy, which
-        controls access to one or more log groups and the associated
-        AWS resources, such as Route 53 hosted zones. There\\'s a
-        limit on the number of resource policies that you can
-        create, so we recommend that you use a consistent prefix so
-        you can use the same resource policy for all the log groups
-        that you create for query logging.
-
-2.  Create a CloudWatch Logs resource policy, and give it the
-    permissions that Route 53 needs to create log streams and to
-    send query logs to log streams. For the value of `Resource`,
-    specify the ARN for the log group that you created in the
-    previous step. To use the same resource policy for all the
-    CloudWatch Logs log groups that you created for query logging
-    configurations, replace the hosted zone name with `*`, for
-    example:
-
-    `arn:aws:logs:us-east-1:123412341234:log-group:/aws/route53/*`
-
-    You can\\'t use the CloudWatch console to create or edit a
-    resource policy. You must use the CloudWatch API, one of the AWS
-    SDKs, or the AWS CLI.
+You can\'t use the CloudWatch console to create or edit a resource
+policy. You must use the CloudWatch API, one of the AWS SDKs, or the
+AWS CLI.
+}
 }
 
-Log Streams and Edge Locations
+\subsection{Log Streams and Edge Locations}{
 
-:   When Route 53 finishes creating the configuration for DNS query
-logging, it does the following:\preformatted{-   Creates a log stream for an edge location the first time that
-    the edge location responds to DNS queries for the specified
-    hosted zone. That log stream is used to log all queries that
-    Route 53 responds to for that edge location.
-
--   Begins to send query logs to the applicable log stream.
+When Route 53 finishes creating the configuration for DNS query logging,
+it does the following:
+\itemize{
+\item Creates a log stream for an edge location the first time that the
+edge location responds to DNS queries for the specified hosted zone.
+That log stream is used to log all queries that Route 53 responds to
+for that edge location.
+\item Begins to send query logs to the applicable log stream.
+}
 
 The name of each log stream is in the following format:
 
-` <i>hosted zone ID</i>/<i>edge location code</i> `
+\verb{<i>hosted zone ID</i>/<i>edge location code</i>}
 
 The edge location code is a three-letter code and an arbitrarily
 assigned number, for example, DFW3. The three-letter code typically
 corresponds with the International Air Transport Association airport
-code for an airport near the edge location. (These abbreviations
-might change in the future.) For a list of edge locations, see \\"The
-Route 53 Global Network\\" on the [Route 53 Product
-Details](http://aws.amazon.com/route53/details/) page.
+code for an airport near the edge location. (These abbreviations might
+change in the future.) For a list of edge locations, see \"The Route 53
+Global Network\" on the \href{http://aws.amazon.com/route53/details/}{Route 53 Product Details} page.
 }
 
-Queries That Are Logged
+\subsection{Queries That Are Logged}{
 
-:   Query logs contain only the queries that DNS resolvers forward to
-Route 53. If a DNS resolver has already cached the response to a
-query (such as the IP address for a load balancer for example.com),
-the resolver will continue to return the cached response. It
-doesn\'t forward another query to Route 53 until the TTL for the
-corresponding resource record set expires. Depending on how many DNS
-queries are submitted for a resource record set, and depending on
-the TTL for that resource record set, query logs might contain
-information about only one query out of every several thousand
-queries that are submitted to DNS. For more information about how
-DNS works, see \href{https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/welcome-dns-service.html}{Routing Internet Traffic to Your Website or Web Application}
+Query logs contain only the queries that DNS resolvers forward to Route
+53. If a DNS resolver has already cached the response to a query (such
+as the IP address for a load balancer for example.com), the resolver
+will continue to return the cached response. It doesn\'t forward another
+query to Route 53 until the TTL for the corresponding resource record
+set expires. Depending on how many DNS queries are submitted for a
+resource record set, and depending on the TTL for that resource record
+set, query logs might contain information about only one query out of
+every several thousand queries that are submitted to DNS. For more
+information about how DNS works, see \href{https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/welcome-dns-service.html}{Routing Internet Traffic to Your Website or Web Application}
 in the \emph{Amazon Route 53 Developer Guide}.
+}
 
-Log File Format
+\subsection{Log File Format}{
 
-:   For a list of the values in each query log and the format of each
-value, see \href{https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html}{Logging DNS Queries}
+For a list of the values in each query log and the format of each value,
+see \href{https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/query-logs.html}{Logging DNS Queries}
 in the \emph{Amazon Route 53 Developer Guide}.
+}
 
-Pricing
+\subsection{Pricing}{
 
-:   For information about charges for query logs, see \href{http://aws.amazon.com/cloudwatch/pricing/}{Amazon CloudWatch Pricing}.
+For information about charges for query logs, see \href{http://aws.amazon.com/cloudwatch/pricing/}{Amazon CloudWatch Pricing}.
+}
 
-How to Stop Logging
+\subsection{How to Stop Logging}{
 
-:   If you want Route 53 to stop sending query logs to CloudWatch Logs,
+If you want Route 53 to stop sending query logs to CloudWatch Logs,
 delete the query logging configuration. For more information, see
 \href{https://docs.aws.amazon.com/Route53/latest/APIReference/API_DeleteQueryLoggingConfig.html}{DeleteQueryLoggingConfig}.
+}
 }
 \section{Request syntax}{
 \preformatted{svc$create_query_logging_config(

--- a/paws/man/route53_list_resource_record_sets.Rd
+++ b/paws/man/route53_list_resource_record_sets.Rd
@@ -79,26 +79,28 @@ sorts results by the record type.
 
 You can use the name and type elements to specify the resource record
 set that the list begins with:
+\subsection{If you do not specify Name or Type}{
 
-If you do not specify Name or Type
-
-:   The results begin with the first resource record set that the hosted
+The results begin with the first resource record set that the hosted
 zone contains.
+}
 
-If you specify Name but not Type
+\subsection{If you specify Name but not Type}{
 
-:   The results begin with the first resource record set in the list
-whose name is greater than or equal to \code{Name}.
+The results begin with the first resource record set in the list whose
+name is greater than or equal to \code{Name}.
+}
 
-If you specify Type but not Name
+\subsection{If you specify Type but not Name}{
 
-:   Amazon Route 53 returns the \code{InvalidInput} error.
+Amazon Route 53 returns the \code{InvalidInput} error.
+}
 
-If you specify both Name and Type
+\subsection{If you specify both Name and Type}{
 
-:   The results begin with the first resource record set in the list
-whose name is greater than or equal to \code{Name}, and whose type is
-greater than or equal to \code{Type}.
+The results begin with the first resource record set in the list whose
+name is greater than or equal to \code{Name}, and whose type is greater than
+or equal to \code{Type}.
 
 \strong{Resource record sets that are PENDING}
 
@@ -123,6 +125,7 @@ of results, get the values of \code{NextRecordName}, \code{NextRecordType}, and
 \code{NextRecordIdentifier} (if any) from the response. Then submit another
 \code{ListResourceRecordSets} request, and specify those values for
 \code{StartRecordName}, \code{StartRecordType}, and \code{StartRecordIdentifier}.
+}
 }
 \section{Request syntax}{
 \preformatted{svc$list_resource_record_sets(

--- a/paws/man/s3_copy_object.Rd
+++ b/paws/man/s3_copy_object.Rd
@@ -215,157 +215,141 @@ The copy request charge is based on the storage class and Region you
 specify for the destination object. For pricing information, see \href{https://aws.amazon.com/s3/pricing/}{Amazon S3 Pricing}.
 
 Following are other considerations when using \code{CopyObject}:
+\subsection{Versioning}{
 
-Versioning
+By default, \code{x-amz-copy-source} identifies the current version of an
+object to copy. (If the current version is a delete marker, Amazon S3
+behaves as if the object was deleted.) To copy a different version, use
+the \code{versionId} subresource.
 
-:   By default, \code{x-amz-copy-source} identifies the current version of an
-object to copy. (If the current version is a delete marker, Amazon
-S3 behaves as if the object was deleted.) To copy a different
-version, use the \code{versionId} subresource.\preformatted{If you enable versioning on the target bucket, Amazon S3 generates a
+If you enable versioning on the target bucket, Amazon S3 generates a
 unique version ID for the object being copied. This version ID is
-different from the version ID of the source object. Amazon S3
-returns the version ID of the copied object in the
-`x-amz-version-id` response header in the response.
+different from the version ID of the source object. Amazon S3 returns
+the version ID of the copied object in the \code{x-amz-version-id} response
+header in the response.
 
-If you do not enable versioning or suspend it on the target bucket,
-the version ID that Amazon S3 generates is always null.
+If you do not enable versioning or suspend it on the target bucket, the
+version ID that Amazon S3 generates is always null.
 
-If the source object\\'s storage class is GLACIER, you must restore a
+If the source object\'s storage class is GLACIER, you must restore a
 copy of this object before you can use it as a source object for the
 copy operation. For more information, see .
 }
 
-Access Permissions
+\subsection{Access Permissions}{
 
-:   When copying an object, you can optionally specify the accounts or
-groups that should be granted specific permissions on the new
-object. There are two ways to grant the permissions using the
-request headers:\preformatted{-   Specify a canned ACL with the `x-amz-acl` request header. For
-    more information, see [Canned
-    ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
-
--   Specify access permissions explicitly with the
-    `x-amz-grant-read`, `x-amz-grant-read-acp`,
-    `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers.
-    These parameters map to the set of permissions that Amazon S3
-    supports in an ACL. For more information, see [Access Control
-    List (ACL)
-    Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+When copying an object, you can optionally specify the accounts or
+groups that should be granted specific permissions on the new object.
+There are two ways to grant the permissions using the request headers:
+\itemize{
+\item Specify a canned ACL with the \code{x-amz-acl} request header. For more
+information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL}{Canned ACL}.
+\item Specify access permissions explicitly with the \code{x-amz-grant-read},
+\code{x-amz-grant-read-acp}, \code{x-amz-grant-write-acp}, and
+\code{x-amz-grant-full-control} headers. These parameters map to the set
+of permissions that Amazon S3 supports in an ACL. For more
+information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html}{Access Control List (ACL) Overview}.
+}
 
 You can use either a canned ACL or specify access permissions
 explicitly. You cannot do both.
 }
 
-Server-Side- Encryption-Specific Request Headers
+\subsection{Server-Side- Encryption-Specific Request Headers}{
 
-:   To encrypt the target object, you must provide the appropriate
-encryption-related request headers. The one you use depends on
-whether you want to use AWS managed encryption keys or provide your
-own encryption key.\preformatted{-   To encrypt the target object using server-side encryption with
-    an AWS managed encryption key, provide the following request
-    headers, as appropriate.
-
-    -   `x-amz-server-sideâ€‹-encryption`
-
-    -   `x-amz-server-side-encryption-aws-kms-key-id`
-
-    -   `x-amz-server-side-encryption-context`
-
-    If you specify `x-amz-server-side-encryption:aws:kms`, but
-    don\\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-    Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-    data. If you want to use a customer managed AWS KMS CMK, you
-    must provide the `x-amz-server-side-encryption-aws-kms-key-id`
-    of the symmetric customer managed CMK. Amazon S3 only supports
-    symmetric CMKs and not asymmetric CMKs. For more information,
-    see [Using Symmetric and Asymmetric
-    Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-    in the *AWS Key Management Service Developer Guide*.
-
-    All GET and PUT requests for an object protected by AWS KMS fail
-    if you don\\'t make them with SSL or by using SigV4.
-
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in
-    KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
-
--   To encrypt the target object using server-side encryption with
-    an encryption key that you provide, use the following headers.
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
-
--   If the source object is encrypted using server-side encryption
-    with customer-provided encryption keys, you must use the
-    following headers.
-
-    -   x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-algorithm
-
-    -   x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-key
-
-    -   x-amz-copy-source-â€‹server-sideâ€‹-encryptionâ€‹-customer-key-MD5
-
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in Amazon
-    KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+To encrypt the target object, you must provide the appropriate
+encryption-related request headers. The one you use depends on whether
+you want to use AWS managed encryption keys or provide your own
+encryption key.
+\itemize{
+\item To encrypt the target object using server-side encryption with an
+AWS managed encryption key, provide the following request headers,
+as appropriate.
+\itemize{
+\item \verb{x-amz-server-sideâ€‹-encryption}
+\item \code{x-amz-server-side-encryption-aws-kms-key-id}
+\item \code{x-amz-server-side-encryption-context}
 }
 
-Access-Control-List (ACL)-Specific Request Headers
+If you specify \code{x-amz-server-side-encryption:aws:kms}, but don\'t
+provide \code{x-amz-server-side-encryption-aws-kms-key-id}, Amazon S3
+uses the AWS managed CMK in AWS KMS to protect the data. If you want
+to use a customer managed AWS KMS CMK, you must provide the
+\code{x-amz-server-side-encryption-aws-kms-key-id} of the symmetric
+customer managed CMK. Amazon S3 only supports symmetric CMKs and not
+asymmetric CMKs. For more information, see \href{https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html}{Using Symmetric and Asymmetric Keys}
+in the \emph{AWS Key Management Service Developer Guide}.
 
-:   You also can use the following access control--related headers with
-this operation. By default, all objects are private. Only the owner
-has full access control. When adding a new object, you can grant
-permissions to individual AWS accounts or to predefined groups
-defined by Amazon S3. These permissions are then added to the access
-control list (ACL) on the object. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html}{Using ACLs}.
-With this operation, you can grant access permissions using one of
-the following two methods:\preformatted{-   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set
-    of predefined ACLs, known as *canned ACLs*. Each canned ACL has
-    a predefined set of grantees and permissions. For more
-    information, see [Canned
-    ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+All GET and PUT requests for an object protected by AWS KMS fail if
+you don\'t make them with SSL or by using SigV4.
 
--   Specify access permissions explicitly --- To explicitly grant
-    access permissions to specific AWS accounts or groups, use the
-    following headers. Each header maps to specific permissions that
-    Amazon S3 supports in an ACL. For more information, see [Access
-    Control List (ACL)
-    Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
-    In the header, you specify a list of grantees who get the
-    specific permission. To grant permissions explicitly, use:
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in KMS}.
+\item To encrypt the target object using server-side encryption with an
+encryption key that you provide, use the following headers.
+\itemize{
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+}
+\item If the source object is encrypted using server-side encryption with
+customer-provided encryption keys, you must use the following
+headers.
+\itemize{
+\item x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+\item x-amz-copy-sourceâ€‹-server-sideâ€‹-encryptionâ€‹-customer-key
+\item x-amz-copy-source-â€‹server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+}
 
-    -   x-amz-grant-read
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in Amazon KMS}.
+}
+}
 
-    -   x-amz-grant-write
+\subsection{Access-Control-List (ACL)-Specific Request Headers}{
 
-    -   x-amz-grant-read-acp
+You also can use the following access control--related headers with this
+operation. By default, all objects are private. Only the owner has full
+access control. When adding a new object, you can grant permissions to
+individual AWS accounts or to predefined groups defined by Amazon S3.
+These permissions are then added to the access control list (ACL) on the
+object. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html}{Using ACLs}.
+With this operation, you can grant access permissions using one of the
+following two methods:
+\itemize{
+\item Specify a canned ACL (\code{x-amz-acl}) --- Amazon S3 supports a set of
+predefined ACLs, known as \emph{canned ACLs}. Each canned ACL has a
+predefined set of grantees and permissions. For more information,
+see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL}{Canned ACL}.
+\item Specify access permissions explicitly --- To explicitly grant access
+permissions to specific AWS accounts or groups, use the following
+headers. Each header maps to specific permissions that Amazon S3
+supports in an ACL. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html}{Access Control List (ACL) Overview}.
+In the header, you specify a list of grantees who get the specific
+permission. To grant permissions explicitly, use:
+\itemize{
+\item x-amz-grant-read
+\item x-amz-grant-write
+\item x-amz-grant-read-acp
+\item x-amz-grant-write-acp
+\item x-amz-grant-full-control
+}
 
-    -   x-amz-grant-write-acp
+You specify each grantee as a type=value pair, where the type is one
+of the following:
+\itemize{
+\item \code{emailAddress} -- if the value specified is the email address of
+an AWS account
+\item \code{id} -- if the value specified is the canonical user ID of an
+AWS account
+\item \code{uri} -- if you are granting permissions to a predefined group
+}
 
-    -   x-amz-grant-full-control
+For example, the following \code{x-amz-grant-read} header grants the AWS
+accounts identified by email addresses permissions to read object
+data and its metadata:
 
-    You specify each grantee as a type=value pair, where the type is
-    one of the following:
-
-    -   `emailAddress` -- if the value specified is the email
-        address of an AWS account
-
-    -   `id` -- if the value specified is the canonical user ID of
-        an AWS account
-
-    -   `uri` -- if you are granting permissions to a predefined
-        group
-
-    For example, the following `x-amz-grant-read` header grants the
-    AWS accounts identified by email addresses permissions to read
-    object data and its metadata:
-
-    `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
+\verb{x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" }
 }
 
 The following operations are related to \code{CopyObject}:
@@ -375,6 +359,7 @@ The following operations are related to \code{CopyObject}:
 }
 
 For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html}{Copying Objects}.
+}
 }
 \section{Request syntax}{
 \preformatted{svc$copy_object(

--- a/paws/man/s3_create_multipart_upload.Rd
+++ b/paws/man/s3_create_multipart_upload.Rd
@@ -145,126 +145,111 @@ different account than the key, then you must have the permissions on
 both the key policy and your IAM user or role.
 
 For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html}{Protecting Data Using Server-Side Encryption}.
+\subsection{Access Permissions}{
 
-Access Permissions
-
-:   When copying an object, you can optionally specify the accounts or
-groups that should be granted specific permissions on the new
-object. There are two ways to grant the permissions using the
-request headers:\preformatted{-   Specify a canned ACL with the `x-amz-acl` request header. For
-    more information, see [Canned
-    ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
-
--   Specify access permissions explicitly with the
-    `x-amz-grant-read`, `x-amz-grant-read-acp`,
-    `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers.
-    These parameters map to the set of permissions that Amazon S3
-    supports in an ACL. For more information, see [Access Control
-    List (ACL)
-    Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+When copying an object, you can optionally specify the accounts or
+groups that should be granted specific permissions on the new object.
+There are two ways to grant the permissions using the request headers:
+\itemize{
+\item Specify a canned ACL with the \code{x-amz-acl} request header. For more
+information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL}{Canned ACL}.
+\item Specify access permissions explicitly with the \code{x-amz-grant-read},
+\code{x-amz-grant-read-acp}, \code{x-amz-grant-write-acp}, and
+\code{x-amz-grant-full-control} headers. These parameters map to the set
+of permissions that Amazon S3 supports in an ACL. For more
+information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html}{Access Control List (ACL) Overview}.
+}
 
 You can use either a canned ACL or specify access permissions
 explicitly. You cannot do both.
 }
 
-Server-Side- Encryption-Specific Request Headers
+\subsection{Server-Side- Encryption-Specific Request Headers}{
 
-:   You can optionally tell Amazon S3 to encrypt data at rest using
-server-side encryption. Server-side encryption is for data
-encryption at rest. Amazon S3 encrypts your data as it writes it to
-disks in its data centers and decrypts it when you access it. The
-option you use depends on whether you want to use AWS managed
-encryption keys or provide your own encryption key.\preformatted{-   Use encryption keys managed by Amazon S3 or customer master keys
-    (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you
-    want AWS to manage the keys used to encrypt data, specify the
-    following headers in the request.
-
-    -   x-amz-server-sideâ€‹-encryption
-
-    -   x-amz-server-side-encryption-aws-kms-key-id
-
-    -   x-amz-server-side-encryption-context
-
-    If you specify `x-amz-server-side-encryption:aws:kms`, but
-    don\\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-    Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-    data.
-
-    All GET and PUT requests for an object protected by AWS KMS fail
-    if you don\\'t make them with SSL or by using SigV4.
-
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in AWS
-    KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
-
--   Use customer-provided encryption keys -- If you want to manage
-    your own encryption keys, provide all the following headers in
-    the request.
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
-
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in AWS
-    KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+You can optionally tell Amazon S3 to encrypt data at rest using
+server-side encryption. Server-side encryption is for data encryption at
+rest. Amazon S3 encrypts your data as it writes it to disks in its data
+centers and decrypts it when you access it. The option you use depends
+on whether you want to use AWS managed encryption keys or provide your
+own encryption key.
+\itemize{
+\item Use encryption keys managed by Amazon S3 or customer master keys
+(CMKs) stored in AWS Key Management Service (AWS KMS) -- If you want
+AWS to manage the keys used to encrypt data, specify the following
+headers in the request.
+\itemize{
+\item x-amz-server-sideâ€‹-encryption
+\item x-amz-server-side-encryption-aws-kms-key-id
+\item x-amz-server-side-encryption-context
 }
 
-Access-Control-List (ACL)-Specific Request Headers
+If you specify \code{x-amz-server-side-encryption:aws:kms}, but don\'t
+provide \code{x-amz-server-side-encryption-aws-kms-key-id}, Amazon S3
+uses the AWS managed CMK in AWS KMS to protect the data.
 
-:   You also can use the following access control--related headers with
-this operation. By default, all objects are private. Only the owner
-has full access control. When adding a new object, you can grant
-permissions to individual AWS accounts or to predefined groups
-defined by Amazon S3. These permissions are then added to the access
-control list (ACL) on the object. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html}{Using ACLs}.
-With this operation, you can grant access permissions using one of
-the following two methods:\preformatted{-   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set
-    of predefined ACLs, known as *canned ACLs*. Each canned ACL has
-    a predefined set of grantees and permissions. For more
-    information, see [Canned
-    ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+All GET and PUT requests for an object protected by AWS KMS fail if
+you don\'t make them with SSL or by using SigV4.
 
--   Specify access permissions explicitly --- To explicitly grant
-    access permissions to specific AWS accounts or groups, use the
-    following headers. Each header maps to specific permissions that
-    Amazon S3 supports in an ACL. For more information, see [Access
-    Control List (ACL)
-    Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
-    In the header, you specify a list of grantees who get the
-    specific permission. To grant permissions explicitly, use:
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in AWS KMS}.
+\item Use customer-provided encryption keys -- If you want to manage your
+own encryption keys, provide all the following headers in the
+request.
+\itemize{
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+}
 
-    -   x-amz-grant-read
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in AWS KMS}.
+}
+}
 
-    -   x-amz-grant-write
+\subsection{Access-Control-List (ACL)-Specific Request Headers}{
 
-    -   x-amz-grant-read-acp
+You also can use the following access control--related headers with this
+operation. By default, all objects are private. Only the owner has full
+access control. When adding a new object, you can grant permissions to
+individual AWS accounts or to predefined groups defined by Amazon S3.
+These permissions are then added to the access control list (ACL) on the
+object. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html}{Using ACLs}.
+With this operation, you can grant access permissions using one of the
+following two methods:
+\itemize{
+\item Specify a canned ACL (\code{x-amz-acl}) --- Amazon S3 supports a set of
+predefined ACLs, known as \emph{canned ACLs}. Each canned ACL has a
+predefined set of grantees and permissions. For more information,
+see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL}{Canned ACL}.
+\item Specify access permissions explicitly --- To explicitly grant access
+permissions to specific AWS accounts or groups, use the following
+headers. Each header maps to specific permissions that Amazon S3
+supports in an ACL. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html}{Access Control List (ACL) Overview}.
+In the header, you specify a list of grantees who get the specific
+permission. To grant permissions explicitly, use:
+\itemize{
+\item x-amz-grant-read
+\item x-amz-grant-write
+\item x-amz-grant-read-acp
+\item x-amz-grant-write-acp
+\item x-amz-grant-full-control
+}
 
-    -   x-amz-grant-write-acp
+You specify each grantee as a type=value pair, where the type is one
+of the following:
+\itemize{
+\item \code{emailAddress} -- if the value specified is the email address of
+an AWS account
+\item \code{id} -- if the value specified is the canonical user ID of an
+AWS account
+\item \code{uri} -- if you are granting permissions to a predefined group
+}
 
-    -   x-amz-grant-full-control
+For example, the following \code{x-amz-grant-read} header grants the AWS
+accounts identified by email addresses permissions to read object
+data and its metadata:
 
-    You specify each grantee as a type=value pair, where the type is
-    one of the following:
-
-    -   `emailAddress` -- if the value specified is the email
-        address of an AWS account
-
-    -   `id` -- if the value specified is the canonical user ID of
-        an AWS account
-
-    -   `uri` -- if you are granting permissions to a predefined
-        group
-
-    For example, the following `x-amz-grant-read` header grants the
-    AWS accounts identified by email addresses permissions to read
-    object data and its metadata:
-
-    `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
+\verb{x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" }
 }
 
 The following operations are related to \code{CreateMultipartUpload}:
@@ -274,6 +259,7 @@ The following operations are related to \code{CreateMultipartUpload}:
 \item AbortMultipartUpload
 \item ListParts
 \item ListMultipartUploads
+}
 }
 }
 \section{Request syntax}{

--- a/paws/man/s3_put_object.Rd
+++ b/paws/man/s3_put_object.Rd
@@ -174,211 +174,183 @@ encryption, Amazon S3 encrypts your data as it writes it to disks in its
 data centers and decrypts the data when you access it. You have the
 option to provide your own encryption key or use AWS managed encryption
 keys. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html}{Using Server-Side Encryption}.
+\subsection{Access Permissions}{
 
-Access Permissions
-
-:   You can optionally specify the accounts or groups that should be
-granted specific permissions on the new object. There are two ways
-to grant the permissions using the request headers:\preformatted{-   Specify a canned ACL with the `x-amz-acl` request header. For
-    more information, see [Canned
-    ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
-
--   Specify access permissions explicitly with the
-    `x-amz-grant-read`, `x-amz-grant-read-acp`,
-    `x-amz-grant-write-acp`, and `x-amz-grant-full-control` headers.
-    These parameters map to the set of permissions that Amazon S3
-    supports in an ACL. For more information, see [Access Control
-    List (ACL)
-    Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
+You can optionally specify the accounts or groups that should be granted
+specific permissions on the new object. There are two ways to grant the
+permissions using the request headers:
+\itemize{
+\item Specify a canned ACL with the \code{x-amz-acl} request header. For more
+information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL}{Canned ACL}.
+\item Specify access permissions explicitly with the \code{x-amz-grant-read},
+\code{x-amz-grant-read-acp}, \code{x-amz-grant-write-acp}, and
+\code{x-amz-grant-full-control} headers. These parameters map to the set
+of permissions that Amazon S3 supports in an ACL. For more
+information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html}{Access Control List (ACL) Overview}.
+}
 
 You can use either a canned ACL or specify access permissions
 explicitly. You cannot do both.
 }
 
-Server-Side- Encryption-Specific Request Headers
+\subsection{Server-Side- Encryption-Specific Request Headers}{
 
-:   You can optionally tell Amazon S3 to encrypt data at rest using
-server-side encryption. Server-side encryption is for data
-encryption at rest. Amazon S3 encrypts your data as it writes it to
-disks in its data centers and decrypts it when you access it. The
-option you use depends on whether you want to use AWS managed
-encryption keys or provide your own encryption key.\preformatted{-   Use encryption keys managed by Amazon S3 or customer master keys
-    (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you
-    want AWS to manage the keys used to encrypt data, specify the
-    following headers in the request.
-
-    -   x-amz-server-sideâ€‹-encryption
-
-    -   x-amz-server-side-encryption-aws-kms-key-id
-
-    -   x-amz-server-side-encryption-context
-
-    If you specify `x-amz-server-side-encryption:aws:kms`, but
-    don\\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-    Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-    data. If you want to use a customer managed AWS KMS CMK, you
-    must provide the `x-amz-server-side-encryption-aws-kms-key-id`
-    of the symmetric customer managed CMK. Amazon S3 only supports
-    symmetric CMKs and not asymmetric CMKs. For more information,
-    see [Using Symmetric and Asymmetric
-    Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-    in the *AWS Key Management Service Developer Guide*.
-
-    All GET and PUT requests for an object protected by AWS KMS fail
-    if you don\\'t make them with SSL or by using SigV4.
-
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in
-    AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
-
--   Use customer-provided encryption keys -- If you want to manage
-    your own encryption keys, provide all the following headers in
-    the request.
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
-
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
-
-    For more information about server-side encryption with CMKs
-    stored in KMS (SSE-KMS), see [Protecting Data Using Server-Side
-    Encryption with CMKs stored in
-    AWS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+You can optionally tell Amazon S3 to encrypt data at rest using
+server-side encryption. Server-side encryption is for data encryption at
+rest. Amazon S3 encrypts your data as it writes it to disks in its data
+centers and decrypts it when you access it. The option you use depends
+on whether you want to use AWS managed encryption keys or provide your
+own encryption key.
+\itemize{
+\item Use encryption keys managed by Amazon S3 or customer master keys
+(CMKs) stored in AWS Key Management Service (AWS KMS) -- If you want
+AWS to manage the keys used to encrypt data, specify the following
+headers in the request.
+\itemize{
+\item x-amz-server-sideâ€‹-encryption
+\item x-amz-server-side-encryption-aws-kms-key-id
+\item x-amz-server-side-encryption-context
 }
 
-Access-Control-List (ACL)-Specific Request Headers
+If you specify \code{x-amz-server-side-encryption:aws:kms}, but don\'t
+provide \code{x-amz-server-side-encryption-aws-kms-key-id}, Amazon S3
+uses the AWS managed CMK in AWS KMS to protect the data. If you want
+to use a customer managed AWS KMS CMK, you must provide the
+\code{x-amz-server-side-encryption-aws-kms-key-id} of the symmetric
+customer managed CMK. Amazon S3 only supports symmetric CMKs and not
+asymmetric CMKs. For more information, see \href{https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html}{Using Symmetric and Asymmetric Keys}
+in the \emph{AWS Key Management Service Developer Guide}.
 
-:   You also can use the following access control--related headers with
-this operation. By default, all objects are private. Only the owner
-has full access control. When adding a new object, you can grant
-permissions to individual AWS accounts or to predefined groups
-defined by Amazon S3. These permissions are then added to the Access
-Control List (ACL) on the object. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html}{Using ACLs}.
-With this operation, you can grant access permissions using one of
-the following two methods:\preformatted{-   Specify a canned ACL (`x-amz-acl`) --- Amazon S3 supports a set
-    of predefined ACLs, known as canned ACLs. Each canned ACL has a
-    predefined set of grantees and permissions. For more
-    information, see [Canned
-    ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL).
+All GET and PUT requests for an object protected by AWS KMS fail if
+you don\'t make them with SSL or by using SigV4.
 
--   Specify access permissions explicitly --- To explicitly grant
-    access permissions to specific AWS accounts or groups, use the
-    following headers. Each header maps to specific permissions that
-    Amazon S3 supports in an ACL. For more information, see [Access
-    Control List (ACL)
-    Overview](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html).
-    In the header, you specify a list of grantees who get the
-    specific permission. To grant permissions explicitly use:
-
-    -   x-amz-grant-read
-
-    -   x-amz-grant-write
-
-    -   x-amz-grant-read-acp
-
-    -   x-amz-grant-write-acp
-
-    -   x-amz-grant-full-control
-
-    You specify each grantee as a type=value pair, where the type is
-    one of the following:
-
-    -   `emailAddress` -- if the value specified is the email
-        address of an AWS account
-
-        Using email addresses to specify a grantee is only supported
-        in the following AWS Regions:
-
-        -   US East (N. Virginia)
-
-        -   US West (N. California)
-
-        -   US West (Oregon)
-
-        -   Asia Pacific (Singapore)
-
-        -   Asia Pacific (Sydney)
-
-        -   Asia Pacific (Tokyo)
-
-        -   EU (Ireland)
-
-        -   South America (SÃ£o Paulo)
-
-        For a list of all the Amazon S3 supported Regions and
-        endpoints, see [Regions and
-        Endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region)
-        in the AWS General Reference
-
-    -   `id` -- if the value specified is the canonical user ID of
-        an AWS account
-
-    -   `uri` -- if you are granting permissions to a predefined
-        group
-
-    For example, the following `x-amz-grant-read` header grants the
-    AWS accounts identified by email addresses permissions to read
-    object data and its metadata:
-
-    `x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" `
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in AWS}.
+\item Use customer-provided encryption keys -- If you want to manage your
+own encryption keys, provide all the following headers in the
+request.
+\itemize{
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
 }
 
-Server-Side- Encryption-Specific Request Headers
+For more information about server-side encryption with CMKs stored
+in KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in AWS}.
+}
+}
 
-:   You can optionally tell Amazon S3 to encrypt data at rest using
-server-side encryption. Server-side encryption is for data
-encryption at rest. Amazon S3 encrypts your data as it writes it to
-disks in its data centers and decrypts it when you access it. The
-option you use depends on whether you want to use AWS-managed
-encryption keys or provide your own encryption key.\preformatted{-   Use encryption keys managed by Amazon S3 or customer master keys
-    (CMKs) stored in AWS Key Management Service (AWS KMS) -- If you
-    want AWS to manage the keys used to encrypt data, specify the
-    following headers in the request.
+\subsection{Access-Control-List (ACL)-Specific Request Headers}{
 
-    -   x-amz-server-sideâ€‹-encryption
+You also can use the following access control--related headers with this
+operation. By default, all objects are private. Only the owner has full
+access control. When adding a new object, you can grant permissions to
+individual AWS accounts or to predefined groups defined by Amazon S3.
+These permissions are then added to the Access Control List (ACL) on the
+object. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/S3_ACLs_UsingACLs.html}{Using ACLs}.
+With this operation, you can grant access permissions using one of the
+following two methods:
+\itemize{
+\item Specify a canned ACL (\code{x-amz-acl}) --- Amazon S3 supports a set of
+predefined ACLs, known as canned ACLs. Each canned ACL has a
+predefined set of grantees and permissions. For more information,
+see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL}{Canned ACL}.
+\item Specify access permissions explicitly --- To explicitly grant access
+permissions to specific AWS accounts or groups, use the following
+headers. Each header maps to specific permissions that Amazon S3
+supports in an ACL. For more information, see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html}{Access Control List (ACL) Overview}.
+In the header, you specify a list of grantees who get the specific
+permission. To grant permissions explicitly use:
+\itemize{
+\item x-amz-grant-read
+\item x-amz-grant-write
+\item x-amz-grant-read-acp
+\item x-amz-grant-write-acp
+\item x-amz-grant-full-control
+}
 
-    -   x-amz-server-side-encryption-aws-kms-key-id
+You specify each grantee as a type=value pair, where the type is one
+of the following:
+\itemize{
+\item \code{emailAddress} -- if the value specified is the email address of
+an AWS account
 
-    -   x-amz-server-side-encryption-context
+Using email addresses to specify a grantee is only supported in
+the following AWS Regions:
+\itemize{
+\item US East (N. Virginia)
+\item US West (N. California)
+\item US West (Oregon)
+\item Asia Pacific (Singapore)
+\item Asia Pacific (Sydney)
+\item Asia Pacific (Tokyo)
+\item EU (Ireland)
+\item South America (SÃ£o Paulo)
+}
 
-    If you specify `x-amz-server-side-encryption:aws:kms`, but
-    don\\'t provide `x-amz-server-side-encryption-aws-kms-key-id`,
-    Amazon S3 uses the AWS managed CMK in AWS KMS to protect the
-    data. If you want to use a customer managed AWS KMS CMK, you
-    must provide the `x-amz-server-side-encryption-aws-kms-key-id`
-    of the symmetric customer managed CMK. Amazon S3 only supports
-    symmetric CMKs and not asymmetric CMKs. For more information,
-    see [Using Symmetric and Asymmetric
-    Keys](https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html)
-    in the *AWS Key Management Service Developer Guide*.
+For a list of all the Amazon S3 supported Regions and endpoints,
+see \href{https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region}{Regions and Endpoints}
+in the AWS General Reference
+\item \code{id} -- if the value specified is the canonical user ID of an
+AWS account
+\item \code{uri} -- if you are granting permissions to a predefined group
+}
 
-    All GET and PUT requests for an object protected by AWS KMS fail
-    if you don\\'t make them with SSL or by using SigV4.
+For example, the following \code{x-amz-grant-read} header grants the AWS
+accounts identified by email addresses permissions to read object
+data and its metadata:
 
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in AWS
-    KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+\verb{x-amz-grant-read: emailAddress="xyz@amazon.com", emailAddress="abc@amazon.com" }
+}
+}
 
--   Use customer-provided encryption keys -- If you want to manage
-    your own encryption keys, provide all the following headers in
-    the request.
+\subsection{Server-Side- Encryption-Specific Request Headers}{
 
-    If you use this feature, the ETag value that Amazon S3 returns
-    in the response is not the MD5 of the object.
+You can optionally tell Amazon S3 to encrypt data at rest using
+server-side encryption. Server-side encryption is for data encryption at
+rest. Amazon S3 encrypts your data as it writes it to disks in its data
+centers and decrypts it when you access it. The option you use depends
+on whether you want to use AWS-managed encryption keys or provide your
+own encryption key.
+\itemize{
+\item Use encryption keys managed by Amazon S3 or customer master keys
+(CMKs) stored in AWS Key Management Service (AWS KMS) -- If you want
+AWS to manage the keys used to encrypt data, specify the following
+headers in the request.
+\itemize{
+\item x-amz-server-sideâ€‹-encryption
+\item x-amz-server-side-encryption-aws-kms-key-id
+\item x-amz-server-side-encryption-context
+}
 
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+If you specify \code{x-amz-server-side-encryption:aws:kms}, but don\'t
+provide \code{x-amz-server-side-encryption-aws-kms-key-id}, Amazon S3
+uses the AWS managed CMK in AWS KMS to protect the data. If you want
+to use a customer managed AWS KMS CMK, you must provide the
+\code{x-amz-server-side-encryption-aws-kms-key-id} of the symmetric
+customer managed CMK. Amazon S3 only supports symmetric CMKs and not
+asymmetric CMKs. For more information, see \href{https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html}{Using Symmetric and Asymmetric Keys}
+in the \emph{AWS Key Management Service Developer Guide}.
 
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+All GET and PUT requests for an object protected by AWS KMS fail if
+you don\'t make them with SSL or by using SigV4.
 
-    -   x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in AWS KMS}.
+\item Use customer-provided encryption keys -- If you want to manage your
+own encryption keys, provide all the following headers in the
+request.
 
-    For more information about server-side encryption with CMKs
-    stored in AWS KMS (SSE-KMS), see [Protecting Data Using
-    Server-Side Encryption with CMKs stored in AWS
-    KMS](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html).
+If you use this feature, the ETag value that Amazon S3 returns in
+the response is not the MD5 of the object.
+\itemize{
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-algorithm
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key
+\item x-amz-server-sideâ€‹-encryptionâ€‹-customer-key-MD5
+}
+
+For more information about server-side encryption with CMKs stored
+in AWS KMS (SSE-KMS), see \href{https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html}{Protecting Data Using Server-Side Encryption with CMKs stored in AWS KMS}.
 }
 
 \strong{Storage Class Options}
@@ -404,6 +376,7 @@ for the same object simultaneously, it stores all of the objects.
 \itemize{
 \item CopyObject
 \item DeleteObject
+}
 }
 }
 \section{Request syntax}{

--- a/paws/man/servicecatalog_create_constraint.Rd
+++ b/paws/man/servicecatalog_create_constraint.Rd
@@ -21,46 +21,54 @@ servicecatalog_create_constraint(AcceptLanguage, PortfolioId, ProductId,
 
 \item{Parameters}{[required] The constraint parameters, in JSON format. The syntax depends on the
 constraint type as follows:
+\subsection{LAUNCH}{
 
-LAUNCH
+Specify the \code{RoleArn} property as follows:
 
-:   Specify the \code{RoleArn} property as follows:\preformatted{`\\\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\\\}`
+\verb{\\\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\\\}}
 
-You cannot have both a `LAUNCH` and a `STACKSET` constraint.
+You cannot have both a \code{LAUNCH} and a \code{STACKSET} constraint.
 
-You also cannot have more than one `LAUNCH` constraint on a product
+You also cannot have more than one \code{LAUNCH} constraint on a product and
+portfolio.
+}
+
+\subsection{NOTIFICATION}{
+
+Specify the \code{NotificationArns} property as follows:
+
+\verb{\\\{"NotificationArns" : \\\["arn:aws:sns:us-east-1:123456789012:Topic"\\\]\\\}}
+}
+
+\subsection{RESOURCE\\_UPDATE}{
+
+Specify the \code{TagUpdatesOnProvisionedProduct} property as follows:
+
+\verb{\\\{"Version":"2.0","Properties":\\\{"TagUpdateOnProvisionedProduct":"String"\\\}\\\}}
+
+The \code{TagUpdatesOnProvisionedProduct} property accepts a string value of
+\code{ALLOWED} or \code{NOT_ALLOWED}.
+}
+
+\subsection{STACKSET}{
+
+Specify the \code{Parameters} property as follows:
+
+\verb{\\\{"Version": "String", "Properties": \\\{"AccountList": \\\[ "String" \\\], "RegionList": \\\[ "String" \\\], "AdminRole": "String", "ExecutionRole": "String"\\\}\\\}}
+
+You cannot have both a \code{LAUNCH} and a \code{STACKSET} constraint.
+
+You also cannot have more than one \code{STACKSET} constraint on a product
 and portfolio.
+
+Products with a \code{STACKSET} constraint will launch an AWS CloudFormation
+stack set.
 }
 
-NOTIFICATION
+\subsection{TEMPLATE}{
 
-:   Specify the \code{NotificationArns} property as follows:\preformatted{`\\\{"NotificationArns" : \\\["arn:aws:sns:us-east-1:123456789012:Topic"\\\]\\\}`
-}
-
-RESOURCE\\_UPDATE
-
-:   Specify the \code{TagUpdatesOnProvisionedProduct} property as follows:\preformatted{`\\\{"Version":"2.0","Properties":\\\{"TagUpdateOnProvisionedProduct":"String"\\\}\\\}`
-
-The `TagUpdatesOnProvisionedProduct` property accepts a string value
-of `ALLOWED` or `NOT_ALLOWED`.
-}
-
-STACKSET
-
-:   Specify the \code{Parameters} property as follows:\preformatted{`\\\{"Version": "String", "Properties": \\\{"AccountList": \\\[ "String" \\\], "RegionList": \\\[ "String" \\\], "AdminRole": "String", "ExecutionRole": "String"\\\}\\\}`
-
-You cannot have both a `LAUNCH` and a `STACKSET` constraint.
-
-You also cannot have more than one `STACKSET` constraint on a
-product and portfolio.
-
-Products with a `STACKSET` constraint will launch an AWS
-CloudFormation stack set.
-}
-
-TEMPLATE
-
-:   Specify the \code{Rules} property. For more information, see \href{http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html}{Template Constraint Rules}.}
+Specify the \code{Rules} property. For more information, see \href{http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html}{Template Constraint Rules}.
+}}
 
 \item{Type}{[required] The type of constraint.
 \itemize{

--- a/paws/man/servicecatalog_create_service_action.Rd
+++ b/paws/man/servicecatalog_create_service_action.Rd
@@ -13,28 +13,33 @@ servicecatalog_create_service_action(Name, DefinitionType, Definition,
 \item{DefinitionType}{[required] The service action definition type. For example, \code{SSM_AUTOMATION}.}
 
 \item{Definition}{[required] The self-service action definition. Can be one of the following:
+\subsection{Name}{
 
-Name
-
-:   The name of the AWS Systems Manager Document. For example,
+The name of the AWS Systems Manager Document. For example,
 \code{AWS-RestartEC2Instance}.
-
-Version
-
-:   The AWS Systems Manager automation document version. For example,
-\code{"Version": "1"}
-
-AssumeRole
-
-:   The Amazon Resource Name (ARN) of the role that performs the
-self-service actions on your behalf. For example,
-\code{"AssumeRole": "arn:aws:iam::12345678910:role/ActionRole"}.\preformatted{To reuse the provisioned product launch role, set to
-`"AssumeRole": "LAUNCH_ROLE"`.
 }
 
-Parameters
+\subsection{Version}{
 
-:   The list of parameters in JSON format.\preformatted{For example: `\\\[\\\{\\"Name\\":\\"InstanceId\\",\\"Type\\":\\"TARGET\\"\\\}\\\]`.
+The AWS Systems Manager automation document version. For example,
+\code{"Version": "1"}
+}
+
+\subsection{AssumeRole}{
+
+The Amazon Resource Name (ARN) of the role that performs the
+self-service actions on your behalf. For example,
+\code{"AssumeRole": "arn:aws:iam::12345678910:role/ActionRole"}.
+
+To reuse the provisioned product launch role, set to
+\code{"AssumeRole": "LAUNCH_ROLE"}.
+}
+
+\subsection{Parameters}{
+
+The list of parameters in JSON format.
+
+For example: \verb{\\\[\\\{\\"Name\\":\\"InstanceId\\",\\"Type\\":\\"TARGET\\"\\\}\\\]}.
 }}
 
 \item{Description}{The self-service action description.}

--- a/paws/man/servicecatalog_update_constraint.Rd
+++ b/paws/man/servicecatalog_update_constraint.Rd
@@ -21,46 +21,54 @@ servicecatalog_update_constraint(AcceptLanguage, Id, Description,
 
 \item{Parameters}{The constraint parameters, in JSON format. The syntax depends on the
 constraint type as follows:
+\subsection{LAUNCH}{
 
-LAUNCH
+Specify the \code{RoleArn} property as follows:
 
-:   Specify the \code{RoleArn} property as follows:\preformatted{`\\\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\\\}`
+\verb{\\\{"RoleArn" : "arn:aws:iam::123456789012:role/LaunchRole"\\\}}
 
-You cannot have both a `LAUNCH` and a `STACKSET` constraint.
+You cannot have both a \code{LAUNCH} and a \code{STACKSET} constraint.
 
-You also cannot have more than one `LAUNCH` constraint on a product
+You also cannot have more than one \code{LAUNCH} constraint on a product and
+portfolio.
+}
+
+\subsection{NOTIFICATION}{
+
+Specify the \code{NotificationArns} property as follows:
+
+\verb{\\\{"NotificationArns" : \\\["arn:aws:sns:us-east-1:123456789012:Topic"\\\]\\\}}
+}
+
+\subsection{RESOURCE\\_UPDATE}{
+
+Specify the \code{TagUpdatesOnProvisionedProduct} property as follows:
+
+\verb{\\\{"Version":"2.0","Properties":\\\{"TagUpdateOnProvisionedProduct":"String"\\\}\\\}}
+
+The \code{TagUpdatesOnProvisionedProduct} property accepts a string value of
+\code{ALLOWED} or \code{NOT_ALLOWED}.
+}
+
+\subsection{STACKSET}{
+
+Specify the \code{Parameters} property as follows:
+
+\verb{\\\{"Version": "String", "Properties": \\\{"AccountList": \\\[ "String" \\\], "RegionList": \\\[ "String" \\\], "AdminRole": "String", "ExecutionRole": "String"\\\}\\\}}
+
+You cannot have both a \code{LAUNCH} and a \code{STACKSET} constraint.
+
+You also cannot have more than one \code{STACKSET} constraint on a product
 and portfolio.
+
+Products with a \code{STACKSET} constraint will launch an AWS CloudFormation
+stack set.
 }
 
-NOTIFICATION
+\subsection{TEMPLATE}{
 
-:   Specify the \code{NotificationArns} property as follows:\preformatted{`\\\{"NotificationArns" : \\\["arn:aws:sns:us-east-1:123456789012:Topic"\\\]\\\}`
-}
-
-RESOURCE\\_UPDATE
-
-:   Specify the \code{TagUpdatesOnProvisionedProduct} property as follows:\preformatted{`\\\{"Version":"2.0","Properties":\\\{"TagUpdateOnProvisionedProduct":"String"\\\}\\\}`
-
-The `TagUpdatesOnProvisionedProduct` property accepts a string value
-of `ALLOWED` or `NOT_ALLOWED`.
-}
-
-STACKSET
-
-:   Specify the \code{Parameters} property as follows:\preformatted{`\\\{"Version": "String", "Properties": \\\{"AccountList": \\\[ "String" \\\], "RegionList": \\\[ "String" \\\], "AdminRole": "String", "ExecutionRole": "String"\\\}\\\}`
-
-You cannot have both a `LAUNCH` and a `STACKSET` constraint.
-
-You also cannot have more than one `STACKSET` constraint on a
-product and portfolio.
-
-Products with a `STACKSET` constraint will launch an AWS
-CloudFormation stack set.
-}
-
-TEMPLATE
-
-:   Specify the \code{Rules} property. For more information, see \href{http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html}{Template Constraint Rules}.}
+Specify the \code{Rules} property. For more information, see \href{http://docs.aws.amazon.com/servicecatalog/latest/adminguide/reference-template_constraint_rules.html}{Template Constraint Rules}.
+}}
 }
 \description{
 Updates the specified constraint.

--- a/paws/man/ssm_describe_patch_properties.Rd
+++ b/paws/man/ssm_describe_patch_properties.Rd
@@ -35,35 +35,41 @@ DescribePatchBaselines.
 \details{
 The following section lists the properties that can be used in filters
 for each major operating system type:
+\subsection{WINDOWS}{
 
-WINDOWS
-
-:   Valid properties: PRODUCT, PRODUCT\\_FAMILY, CLASSIFICATION,
+Valid properties: PRODUCT, PRODUCT\\_FAMILY, CLASSIFICATION,
 MSRC\\_SEVERITY
+}
 
-AMAZON\\_LINUX
+\subsection{AMAZON\\_LINUX}{
 
-:   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+}
 
-AMAZON\\_LINUX\\_2
+\subsection{AMAZON\\_LINUX\\_2}{
 
-:   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+}
 
-UBUNTU
+\subsection{UBUNTU}{
 
-:   Valid properties: PRODUCT, PRIORITY
+Valid properties: PRODUCT, PRIORITY
+}
 
-REDHAT\\_ENTERPRISE\\_LINUX
+\subsection{REDHAT\\_ENTERPRISE\\_LINUX}{
 
-:   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+}
 
-SUSE
+\subsection{SUSE}{
 
-:   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+}
 
-CENTOS
+\subsection{CENTOS}{
 
-:   Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+Valid properties: PRODUCT, CLASSIFICATION, SEVERITY
+}
 }
 \section{Request syntax}{
 \preformatted{svc$describe_patch_properties(


### PR DESCRIPTION
Address #237 by converting definition lists to paragraphs, since definition lists don't work well in R documentation.

Also addresses #213.