### PR TITLE
Allow nested values for DynamoDB 

### DIFF
--- a/paws.common/R/jsonutil.R
+++ b/paws.common/R/jsonutil.R
@@ -179,6 +179,7 @@ json_parse <- function(node, interface) {
 }
 
 json_parse_structure <- function(node, interface) {
+  if (length(interface) == 0) return(node)
 
   result <- interface
 
@@ -199,6 +200,7 @@ json_parse_structure <- function(node, interface) {
 
 json_parse_list <- function(node, interface) {
   if (length(node) == 0) return(list())
+  if (length(interface) == 0) return(node)
   names(node) <- NULL
   result <- lapply(node, function(x) json_parse(x, interface[[1]]))
   if (type(interface[[1]]) == "scalar") {
@@ -208,6 +210,7 @@ json_parse_list <- function(node, interface) {
 }
 
 json_parse_map <- function(node, interface) {
+  if (length(interface) == 0) return(node)
   result <- list()
   for (name in names(node)) {
     parsed <- json_parse(node[[name]], interface[[1]])

--- a/paws.common/R/jsonutil.R
+++ b/paws.common/R/jsonutil.R
@@ -179,6 +179,9 @@ json_parse <- function(node, interface) {
 }
 
 json_parse_structure <- function(node, interface) {
+  # If interface is empty (output shape is incomplete), return the output data.
+  # Only needed because output shapes have fixed depth, and some services,
+  # e.g. DynamoDB, can return data of arbitrary depth.
   if (length(interface) == 0) return(node)
 
   result <- interface
@@ -200,6 +203,9 @@ json_parse_structure <- function(node, interface) {
 
 json_parse_list <- function(node, interface) {
   if (length(node) == 0) return(list())
+  # If interface is empty (output shape is incomplete), return the output data.
+  # Only needed because output shapes have fixed depth, and some services,
+  # e.g. DynamoDB, can return data of arbitrary depth.
   if (length(interface) == 0) return(node)
   names(node) <- NULL
   result <- lapply(node, function(x) json_parse(x, interface[[1]]))
@@ -210,6 +216,9 @@ json_parse_list <- function(node, interface) {
 }
 
 json_parse_map <- function(node, interface) {
+  # If interface is empty (output shape is incomplete), return the output data.
+  # Only needed because output shapes have fixed depth, and some services,
+  # e.g. DynamoDB, can return data of arbitrary depth.
   if (length(interface) == 0) return(node)
   result <- list()
   for (name in names(node)) {

--- a/paws.common/R/populate.R
+++ b/paws.common/R/populate.R
@@ -13,6 +13,9 @@ check_location_name <- function(name, interface){
 # Populate the interface for a given API operation with the parameters
 # that the user submitted.
 populate_structure <- function(input, interface) {
+  # If interface is empty (input shape is incomplete), return the input data.
+  # Only needed because input shapes have fixed depth, and some services,
+  # e.g. DynamoDB, can accept data of arbitrary depth.
   if (length(interface) == 0) return(input)
   for (name in names(input)) {
     if (!(name) %in% names(interface)) {
@@ -30,6 +33,9 @@ populate_structure <- function(input, interface) {
 }
 
 populate_list <- function(input, interface) {
+  # If interface is empty (input shape is incomplete), return the input data.
+  # Only needed because input shapes have fixed depth, and some services,
+  # e.g. DynamoDB, can accept data of arbitrary depth.
   if (length(interface) == 0) return(input)
   attrs <- attributes(interface)
   interface <- lapply(input, function(x) populate(x, interface[[1]]))
@@ -38,6 +44,9 @@ populate_list <- function(input, interface) {
 }
 
 populate_map <- function(input, interface) {
+  # If interface is empty (input shape is incomplete), return the input data.
+  # Only needed because input shapes have fixed depth, and some services,
+  # e.g. DynamoDB, can accept data of arbitrary depth.
   if (length(interface) == 0) return(input)
   result <- list()
   for (name in names(input)) {

--- a/paws.common/R/populate.R
+++ b/paws.common/R/populate.R
@@ -13,6 +13,7 @@ check_location_name <- function(name, interface){
 # Populate the interface for a given API operation with the parameters
 # that the user submitted.
 populate_structure <- function(input, interface) {
+  if (length(interface) == 0) return(input)
   for (name in names(input)) {
     if (!(name) %in% names(interface)) {
       check_location <- check_location_name(name, interface)
@@ -29,6 +30,7 @@ populate_structure <- function(input, interface) {
 }
 
 populate_list <- function(input, interface) {
+  if (length(interface) == 0) return(input)
   attrs <- attributes(interface)
   interface <- lapply(input, function(x) populate(x, interface[[1]]))
   attributes(interface) <- attrs
@@ -36,6 +38,7 @@ populate_list <- function(input, interface) {
 }
 
 populate_map <- function(input, interface) {
+  if (length(interface) == 0) return(input)
   result <- list()
   for (name in names(input)) {
     result[[name]] <- populate(input[[name]], interface[[1]])

--- a/paws.common/R/tags.R
+++ b/paws.common/R/tags.R
@@ -110,7 +110,22 @@ type <- function(object) {
       "scalar"
     )
   } else {
-    t <- ""
+    t <- guess_type(object)
+  }
+  return(t)
+}
+
+# If an object has no tag information, guess the type of the object based
+# on its properties.
+guess_type <- function(object) {
+  if (!is.null(names(object))) {
+    t <- "structure"
+  } else {
+    if (is.atomic(object) && length(object) == 1) {
+      t <- "scalar"
+    } else {
+      t <- "list"
+    }
   }
   return(t)
 }

--- a/paws.common/tests/testthat/test_handlers_jsonrpc.R
+++ b/paws.common/tests/testthat/test_handlers_jsonrpc.R
@@ -332,6 +332,57 @@ test_that("build enums", {
   expect_equal(req$body, '{"FooEnum":"foo","ListEnums":["foo","","bar"]}')
 })
 
+op_input14 <- function(TableName, Item) {
+  args <- list(TableName = TableName, Item = Item)
+  interface <- Structure(
+    TableName = Scalar(type = "string"),
+    Item = Map(Structure(
+      S = Scalar(type = "string"),
+      N = Scalar(type = "string"),
+      B = Scalar(type = "blob"),
+      SS = List(Scalar(type = "string")),
+      NS = List(Scalar(type = "string")),
+      BS = List(Scalar(type = "blob")),
+      M = Map(),
+      L = List(),
+      `NULL` = Scalar(type = "boolean"),
+      BOOL = Scalar(type = "boolean")
+    ))
+  )
+  return(populate(args, interface))
+}
+
+test_that("build nested structure with incomplete input shape", {
+  input <- op_input14(
+    TableName = "myname",
+    Item = list(
+      UserId = list(
+        S = "1"
+      ),
+      Day = list(
+        N = 1
+      ),
+      HourMap = list(
+        M = list(
+          "1" = list(
+            N = "1"
+          ),
+          "2" = list(
+            N = "2"
+          ),
+          "3" = list(
+            N = "3"
+          )
+        )
+      )
+    )
+  )
+  req <- new_request(svc, op, input, NULL)
+  req <- build(req)
+  r <- req$http_request
+  expect_equal(r$body, '{"TableName":"myname","Item":{"Day":{"N":"1"},"HourMap":{"M":{"1":{"N":"1"},"2":{"N":"2"},"3":{"N":"3"}}},"UserId":{"S":"1"}}}')
+})
+
 #-------------------------------------------------------------------------------
 
 # Build with no target prefix
@@ -528,6 +579,39 @@ test_that("unmarshal enums", {
   expect_equal(out$FooEnum, "foo")
   expect_equal(out$ListEnums[1], "foo")
   expect_equal(out$ListEnums[2], "bar")
+})
+
+op_output8 <- Structure(
+  Count = Scalar(type = "integer"),
+  Items = List(Map(Structure(
+    S = Scalar(type = "string"),
+    N = Scalar(type = "string"),
+    B = Scalar(type = "blob"),
+    SS = List(Scalar(type = "string")),
+    NS = List(Scalar(type = "string")),
+    BS = List(Scalar(type = "blob")),
+    M = Map(),
+    L = List(),
+    `NULL` = Scalar(type = "boolean"),
+    BOOL = Scalar(type = "boolean")
+  ))),
+  ScannedCount = Scalar(type = "integer")
+)
+
+test_that("unmarshal nested structure with incomplete output shape", {
+  req <- new_request(svc, op, NULL, op_output8)
+  req$http_response <- HttpResponse(
+    status_code = 200,
+    body = charToRaw("{\"Count\":1,\"Items\":[{\"UserId\":{\"S\":\"1\"},\"HourMap\":{\"M\":{\"1\":{\"N\":\"1\"},\"2\":{\"N\":\"2\"},\"3\":{\"N\":\"3\"}}},\"Day\":{\"N\":\"1\"}}],\"ScannedCount\":1}")
+  )
+  req <- unmarshal(req)
+  out <- req$data
+  expect_length(out$Items, 1)
+  expect_equal(out$Items[[1]]$UserId$S, "1")
+  expect_length(out$Items[[1]]$HourMap$M, 3)
+  expect_equal(out$Items[[1]]$HourMap$M$`1`$N, "1")
+  expect_equal(out$Items[[1]]$HourMap$M$`2`$N, "2")
+  expect_equal(out$Items[[1]]$HourMap$M$`3`$N, "3")
 })
 
 test_that("unmarshal error with message in 'Message'", {

--- a/paws.common/tests/testthat/test_tags.R
+++ b/paws.common/tests/testthat/test_tags.R
@@ -74,3 +74,18 @@ test_that("delete some tags", {
   expect_equal(tag_get(result$inner[[2]], "foo2"), "")
   expect_equal(tag_get(result$inner[[3]], "foo2"), "")
 })
+
+#-------------------------------------------------------------------------------
+
+test_that("types", {
+  expect_equal(type(List()), "list")
+  expect_equal(type(Map()), "map")
+  expect_equal(type(Scalar()), "scalar")
+  expect_equal(type(Structure(Foo = logical(0))), "structure")
+
+  expect_equal(type(c(1, 2)), "list")
+  expect_equal(type(list(1, 2, 3)), "list")
+  expect_equal(type(1), "scalar")
+  expect_equal(type(c(a = 1, b = 2, c = 3)), "structure")
+  expect_equal(type(list(a = 1, b = 2, c = 3)), "structure")
+})


### PR DESCRIPTION
* Accept nested inputs to DynamoDB and other services, and correctly output nested values received in response.  Currently, Paws has fixed depth input and output shapes, and services like DynamoDB that handle data of arbitrary depth will currently don't work when processing input beyond the fixed depth in the package's defined input or output shape.

For example, the following request creates an item with data multiple levels deep.  This fails in paws.common 0.2.5 and prior.

```
svc$put_item(
  TableName = "query",
  Item = list(
    UserId = list(
      S = "3"
    ),
    Day = list(
      N = 1
    ),
    HourMap = list(
      M = list(
        "1" = list(
          N = "11"
        ),
        "2" = list(
          N = "22"
        )
      )
    )
  )
)
```