### PR TITLE
Include S3 data from headers in output

### DIFF
--- a/paws.common/R/handlers_rest.R
+++ b/paws.common/R/handlers_rest.R
@@ -160,19 +160,24 @@ rest_unmarshal_location_elements <- function(request) {
       name <- field_name
     }
 
+    tags <- tag_get_all(field)
     location <- tag_get(field, "location")
     if (location == "statusCode") {
-      values[[field_name]] <- rest_unmarshal_status_code(request$http_response$status_code)
+      result <- rest_unmarshal_status_code(request$http_response$status_code)
     } else if (location == "header") {
       v <- request$http_response$header[[name]]
       type <- tag_get(field, "type")
-      values[[field_name]] <- rest_unmarshal_header(v, type)
+      result <- rest_unmarshal_header(v, type)
     } else if (location == "headers") {
       v <- request$http_response$header
       prefix <- tag_get(field, "locationName")
       type <- tag_get(field, "type")
-      values[[field_name]] <- rest_unmarshal_header_map(v, prefix, type)
+      result <- rest_unmarshal_header_map(v, prefix, type)
+    } else {
+      result <- values[[field_name]]
     }
+    result <- tag_add(result, tags)
+    values[[field_name]] <- result
   }
   request$data <- values
   return(request)

--- a/paws.common/R/jsonutil.R
+++ b/paws.common/R/jsonutil.R
@@ -191,6 +191,9 @@ json_parse_structure <- function(node, interface) {
   for (name in names(interface)) {
     node_name <- tag_get(interface[[name]], "locationName")
     if (node_name == "") node_name <- name
+    # Do not over-write fields that don't also exist in the given `node` and
+    # that have already been unmarshalled, e.g. from the response header.
+    if (!(node_name %in% names(node)) && length(result[[name]]) > 0) next
     parsed <- json_parse(node[[node_name]], interface[[name]])
     result[[name]] <- parsed
   }

--- a/paws.common/R/jsonutil.R
+++ b/paws.common/R/jsonutil.R
@@ -189,11 +189,11 @@ json_parse_structure <- function(node, interface) {
   }
 
   for (name in names(interface)) {
+    # Skip fields that don't come from the response body.
+    if (tag_get(interface[[name]], "location") != "") next
+
     node_name <- tag_get(interface[[name]], "locationName")
     if (node_name == "") node_name <- name
-    # Do not over-write fields that don't also exist in the given `node` and
-    # that have already been unmarshalled, e.g. from the response header.
-    if (!(node_name %in% names(node)) && length(result[[name]]) > 0) next
     parsed <- json_parse(node[[node_name]], interface[[name]])
     result[[name]] <- parsed
   }

--- a/paws.common/R/tags.R
+++ b/paws.common/R/tags.R
@@ -34,6 +34,7 @@
 #' @name tags
 NULL
 
+# Returns the given tag on an object, or "" if not present.
 #' @rdname tags
 #' @export
 tag_get <- function(object, tag) {
@@ -42,6 +43,14 @@ tag_get <- function(object, tag) {
     return(tags[[tag]])
   }
   return("")
+}
+
+# Returns all tags on an object as a list.
+#' @rdname tags
+#' @export
+tag_get_all <- function(object) {
+  tags <- attr(object, "tags", exact = TRUE)
+  return(tags)
 }
 
 # Returns whether the object has the given tag.

--- a/paws.common/R/xmlutil.R
+++ b/paws.common/R/xmlutil.R
@@ -209,6 +209,11 @@ xml_parse_structure <- function(node, interface) {
   for (name in names(interface)) {
     field <- interface[[name]]
 
+    # Skip fields that don't come from the response body.
+    if (tag_get(field, "location") != "") {
+      next
+    }
+
     node_name <- name
     flattened <- tag_get(field, "flattened") != ""
     if (flattened && tag_get(field, "locationNameList") != "") {
@@ -220,12 +225,6 @@ xml_parse_structure <- function(node, interface) {
     elem <- node[[node_name]]
     if (flattened) {
       elem <- node[names(node) == node_name]
-    }
-
-    # Do not over-write fields that don't also exist in the given `node` and
-    # that have already been unmarshalled, e.g. from the response header.
-    if (length(elem) == 0 && length(result[[name]]) > 0) {
-      next
     }
 
     parsed <- xml_parse(elem, field)

--- a/paws.common/R/xmlutil.R
+++ b/paws.common/R/xmlutil.R
@@ -205,7 +205,7 @@ xml_parse_structure <- function(node, interface) {
     return(result)
   }
 
-  result <- list()
+  result <- interface
   for (name in names(interface)) {
     field <- interface[[name]]
 
@@ -222,8 +222,10 @@ xml_parse_structure <- function(node, interface) {
       elem <- node[names(node) == node_name]
     }
 
-    if (length(elem) == 0) {
-      # TODO: Implement.
+    # Do not over-write fields that don't also exist in the given `node` and
+    # that have already been unmarshalled, e.g. from the response header.
+    if (length(elem) == 0 && length(result[[name]] > 0)) {
+      next
     }
 
     parsed <- xml_parse(elem, field)

--- a/paws.common/R/xmlutil.R
+++ b/paws.common/R/xmlutil.R
@@ -224,7 +224,7 @@ xml_parse_structure <- function(node, interface) {
 
     # Do not over-write fields that don't also exist in the given `node` and
     # that have already been unmarshalled, e.g. from the response header.
-    if (length(elem) == 0 && length(result[[name]] > 0)) {
+    if (length(elem) == 0 && length(result[[name]]) > 0) {
       next
     }
 

--- a/paws.common/tests/testthat/test_handlers_jsonrpc.R
+++ b/paws.common/tests/testthat/test_handlers_jsonrpc.R
@@ -509,7 +509,7 @@ test_that("unmarshal ignores extra data", {
   req <- unmarshal(req)
   out <- req$data
   expect_equal(names(out), "StrType")
-  expect_equal(out$StrType, character(0))
+  expect_equivalent(out$StrType, character(0))
 })
 
 op_output7 <- Structure(

--- a/paws.common/tests/testthat/test_handlers_query.R
+++ b/paws.common/tests/testthat/test_handlers_query.R
@@ -548,8 +548,8 @@ test_that("unmarshal list of structures", {
   )
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$List[[1]], list(Bar = "firstbar", Baz = "firstbaz", Foo = "firstfoo"))
-  expect_equal(out$List[[2]], list(Bar = "secondbar", Baz = "secondbaz", Foo = "secondfoo"))
+  expect_equivalent(out$List[[1]], list(Bar = "firstbar", Baz = "firstbaz", Foo = "firstfoo"))
+  expect_equivalent(out$List[[2]], list(Bar = "secondbar", Baz = "secondbaz", Foo = "secondfoo"))
 })
 
 op_output7 <- Structure(
@@ -571,8 +571,8 @@ test_that("unmarshal flattened list of structures", {
   )
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$List[[1]], list(Bar = "firstbar", Baz = "firstbaz", Foo = "firstfoo"))
-  expect_equal(out$List[[2]], list(Bar = "secondbar", Baz = "secondbaz", Foo = "secondfoo"))
+  expect_equivalent(out$List[[1]], list(Bar = "firstbar", Baz = "firstbaz", Foo = "firstfoo"))
+  expect_equivalent(out$List[[2]], list(Bar = "secondbar", Baz = "secondbaz", Foo = "secondfoo"))
 })
 
 op_output8 <- Structure(

--- a/paws.common/tests/testthat/test_handlers_restjson.R
+++ b/paws.common/tests/testthat/test_handlers_restjson.R
@@ -623,17 +623,17 @@ test_that("unmarshal scalar members", {
   req <- unmarshal_meta(req)
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$Char, "a")
-  expect_equal(out$Double, 1.3)
-  expect_equal(out$FalseBool, FALSE)
-  expect_equal(out$Float, 1.2)
-  expect_equal(out$ImaHeader, "test")
-  expect_equal(out$ImaHeaderLocation, "abc")
-  expect_equal(out$Long, 200L)
-  expect_equal(out$Num, 123L)
-  expect_equal(out$Status, 200L)
-  expect_equal(out$Str, "myname")
-  expect_equal(out$TrueBool, TRUE)
+  expect_equivalent(out$Char, "a")
+  expect_equivalent(out$Double, 1.3)
+  expect_equivalent(out$FalseBool, FALSE)
+  expect_equivalent(out$Float, 1.2)
+  expect_equivalent(out$ImaHeader, "test")
+  expect_equivalent(out$ImaHeaderLocation, "abc")
+  expect_equivalent(out$Long, 200L)
+  expect_equivalent(out$Num, 123L)
+  expect_equivalent(out$Status, 200L)
+  expect_equivalent(out$Str, "myname")
+  expect_equivalent(out$TrueBool, TRUE)
 })
 
 test_that("unmarshal blob member", {
@@ -670,8 +670,8 @@ test_that("unmarshal timestamp member", {
   req <- unmarshal_meta(req)
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$TimeMember, unix_time(1.398796238e+09))
-  expect_equal(out$StructMember$Foo, unix_time(1.398796238e+09))
+  expect_equivalent(out$TimeMember, unix_time(1.398796238e+09))
+  expect_equivalent(out$StructMember$Foo, unix_time(1.398796238e+09))
 })
 
 test_that("unmarshal list", {
@@ -686,8 +686,8 @@ test_that("unmarshal list", {
   req <- unmarshal_meta(req)
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$ListMember[1], "a")
-  expect_equal(out$ListMember[2], "b")
+  expect_equivalent(out$ListMember[1], "a")
+  expect_equivalent(out$ListMember[2], "b")
 })
 
 test_that("unmarshal list with structure member", {
@@ -706,8 +706,8 @@ test_that("unmarshal list with structure member", {
   req <- unmarshal_meta(req)
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$ListMember[[1]]$Foo, "a")
-  expect_equal(out$ListMember[[2]]$Foo, "b")
+  expect_equivalent(out$ListMember[[1]]$Foo, "a")
+  expect_equivalent(out$ListMember[[2]]$Foo, "b")
 })
 
 test_that("unmarshal map", {
@@ -724,10 +724,10 @@ test_that("unmarshal map", {
   req <- unmarshal_meta(req)
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$MapMember[["a"]][1], 1)
-  expect_equal(out$MapMember[["a"]][2], 2)
-  expect_equal(out$MapMember[["b"]][1], 3)
-  expect_equal(out$MapMember[["b"]][2], 4)
+  expect_equivalent(out$MapMember[["a"]][1], 1)
+  expect_equivalent(out$MapMember[["a"]][2], 2)
+  expect_equivalent(out$MapMember[["b"]][1], 3)
+  expect_equivalent(out$MapMember[["b"]][2], 4)
 })
 
 test_that("unmarshal map with timestamps", {
@@ -744,8 +744,8 @@ test_that("unmarshal map with timestamps", {
   req <- unmarshal_meta(req)
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$MapMember[["a"]], unix_time(1.398796238e+09))
-  expect_equal(out$MapMember[["b"]], unix_time(1.398796238e+09))
+  expect_equivalent(out$MapMember[["a"]], unix_time(1.398796238e+09))
+  expect_equivalent(out$MapMember[["b"]], unix_time(1.398796238e+09))
 })
 
 test_that("unmarshal ignores extra data", {
@@ -760,8 +760,8 @@ test_that("unmarshal ignores extra data", {
   req <- unmarshal_meta(req)
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(names(out), c("StrType"))
-  expect_equal(out$StrType, character(0))
+  expect_equivalent(names(out), c("StrType"))
+  expect_equivalent(out$StrType, character(0))
 })
 
 test_that("unmarshal header map", {
@@ -779,11 +779,11 @@ test_that("unmarshal header map", {
   req <- unmarshal_meta(req)
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$AllHeaders[["Content-Length"]], "10")
-  expect_equal(out$AllHeaders[["X-Bam"]], "boo")
-  expect_equal(out$AllHeaders[["X-Foo"]], "bar")
-  expect_equal(out$PrefixedHeaders[["Bam"]], "boo")
-  expect_equal(out$PrefixedHeaders[["Foo"]], "bar")
+  expect_equivalent(out$AllHeaders[["Content-Length"]], "10")
+  expect_equivalent(out$AllHeaders[["X-Bam"]], "boo")
+  expect_equivalent(out$AllHeaders[["X-Foo"]], "bar")
+  expect_equivalent(out$PrefixedHeaders[["Bam"]], "boo")
+  expect_equivalent(out$PrefixedHeaders[["Foo"]], "bar")
 })
 
 test_that("JSON payload", {
@@ -803,8 +803,8 @@ test_that("JSON payload", {
   req <- unmarshal_meta(req)
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$Data$Foo, "abc")
-  expect_equal(out$Header, "baz")
+  expect_equivalent(out$Data$Foo, "abc")
+  expect_equivalent(out$Header, "baz")
 })
 
 # TODO: Streaming payload.
@@ -826,8 +826,8 @@ test_that("unmarshal blob payload", {
   req <- unmarshal_meta(req)
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(rawToChar(out$Data), "{\"Foo\": \"abc\"}")
-  expect_equal(out$Header, "baz")
+  expect_equivalent(rawToChar(out$Data), "{\"Foo\": \"abc\"}")
+  expect_equivalent(out$Header, "baz")
 })
 
 #-------------------------------------------------------------------------------

--- a/paws.common/tests/testthat/test_struct.R
+++ b/paws.common/tests/testthat/test_struct.R
@@ -1,3 +1,5 @@
+context("Structs")
+
 test_that("struct constructors", {
   Foo <- struct(a = "", b = NULL)
   bar <- Foo()

--- a/paws.common/tests/testthat/test_tags.R
+++ b/paws.common/tests/testthat/test_tags.R
@@ -2,10 +2,12 @@ context("Tags")
 
 test_that("add tags to an object without tags", {
   a <- list()
-  b <- tag_add(a, list(foo = "abc", bar = 123, baz = list(qux = "xyz")))
+  tags <- list(foo = "abc", bar = 123, baz = list(qux = "xyz"))
+  b <- tag_add(a, tags)
   expect_equal(tag_get(b, "foo"), "abc")
   expect_equal(tag_get(b, "bar"), 123)
   expect_equal(tag_get(b, "baz"), list(qux = "xyz"))
+  expect_equal(tag_get_all(b), tags)
 })
 
 test_that("add tags to an object with tags", {


### PR DESCRIPTION
Services like S3 send responses that can contain data in both the body and the header. We unmarshal both and put them in the output object, however currently the data from the header does not actually get included in the output object.

In this update, when unmarshalling data from the body, we instead start with the provided `interface` object, which may already contain data from the header, rather than an empty list. Unmarshalling from the header takes place before the body, and we pass this to the function that unmarshals the body. This ensures that any data unmarshalled from the header gets included when unmarshalling from the body.

We also check that if a given field is from some place other than the body, we don't try to unmarshal it in the unmarshal-body function.