### PR TITLE
Sets Git to ignore DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 *.Rcheck
 .vscode
+.DS_Store


### PR DESCRIPTION
On MacOS, .DS_Store files are produced to store the customizations of a folder.
[https://en.wikipedia.org/wiki/.DS_Store](https://en.wikipedia.org/wiki/.DS_Store)

They describe an individual user's environment so they are unnecessary to store in the repo. Furthermore they are added to the `.gitignore` file for other packages such as `dplyr` so there is precedent for this change.