### PR TITLE
Waits to get handlers until run time

### DIFF
--- a/make.paws/R/service.R
+++ b/make.paws/R/service.R
@@ -42,10 +42,10 @@ service_file_template <- template(
     target_prefix = ${target_prefix}
   )
 
-  .${service}$handlers <- new_handlers(${protocol}, ${signer})
+  .${service}$handlers <- quote(new_handlers(${protocol}, ${signer}))
 
   .${service}$service <- function(config = list()) {
-    new_service(.${service}$metadata, .${service}$handlers, config)
+    new_service(.${service}$metadata, eval(.${service}$handlers), config)
   }
   `
 )

--- a/make.paws/R/service.R
+++ b/make.paws/R/service.R
@@ -43,8 +43,8 @@ service_file_template <- template(
   )
 
   .${service}$service <- function(config = list()) {
-    .${service}$handlers <- new_handlers(${protocol}, ${signer})
-    new_service(.${service}$metadata, .${service}$handlers, config)
+    handlers <- new_handlers(${protocol}, ${signer})
+    new_service(.${service}$metadata, handlers, config)
   }
   `
 )

--- a/make.paws/R/service.R
+++ b/make.paws/R/service.R
@@ -42,10 +42,9 @@ service_file_template <- template(
     target_prefix = ${target_prefix}
   )
 
-  .${service}$handlers <- quote(new_handlers(${protocol}, ${signer}))
-
   .${service}$service <- function(config = list()) {
-    new_service(.${service}$metadata, eval(.${service}$handlers), config)
+    .${service}$handlers <- new_handlers(${protocol}, ${signer})
+    new_service(.${service}$metadata, .${service}$handlers, config)
   }
   `
 )


### PR DESCRIPTION
I think we should discuss how we want to implement this solution, but this pull request pinpoints the issue where handlers were not changing when we update paws.common.

The issue is that, before, when we were creating a new service object, we were explicitly setting the handlers to be the handlers that existed at package development time. This fix forces the function to use the handlers as they exist at run time by delaying evaluation until then.

I tested this fix by adding a `stop` to `handlers_restxml.R` and reinstalling paws.common. 

```
# Works as normal
restxml_build <- function(request) {
  request <- rest_build(request)
  t <- rest_payload_type(request$params)
  if (t == "structure" || t == "") {
    request <- xml_build_body(request)
  }
  return(request)
}

# Changed it to
# Build the request body for the REST XML protocol.
restxml_build <- function(request) {
  stop("FOR TESTING")
  request <- rest_build(request)
  t <- rest_payload_type(request$params)
  if (t == "structure" || t == "") {
    request <- xml_build_body(request)
  }
  return(request)
}
```

As expected the following command worked without the `stop`, and failed with the `stop`.
```
library(paws)
s3 <- s3()

s3$list_buckets()
```