### PR TITLE
Regenerate Paws

### DIFF
--- a/cran/paws.analytics/R/athena_service.R
+++ b/cran/paws.analytics/R/athena_service.R
@@ -100,8 +100,7 @@ athena <- function(config = list()) {
   target_prefix = "AmazonAthena"
 )
 
-.athena$handlers <- new_handlers("jsonrpc", "v4")
-
 .athena$service <- function(config = list()) {
-  new_service(.athena$metadata, .athena$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.athena$metadata, handlers, config)
 }

--- a/cran/paws.analytics/R/cloudsearch_service.R
+++ b/cran/paws.analytics/R/cloudsearch_service.R
@@ -100,8 +100,7 @@ cloudsearch <- function(config = list()) {
   target_prefix = ""
 )
 
-.cloudsearch$handlers <- new_handlers("query", "v4")
-
 .cloudsearch$service <- function(config = list()) {
-  new_service(.cloudsearch$metadata, .cloudsearch$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.cloudsearch$metadata, handlers, config)
 }

--- a/cran/paws.analytics/R/cloudsearchdomain_service.R
+++ b/cran/paws.analytics/R/cloudsearchdomain_service.R
@@ -76,8 +76,7 @@ cloudsearchdomain <- function(config = list()) {
   target_prefix = ""
 )
 
-.cloudsearchdomain$handlers <- new_handlers("restjson", "v4")
-
 .cloudsearchdomain$service <- function(config = list()) {
-  new_service(.cloudsearchdomain$metadata, .cloudsearchdomain$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.cloudsearchdomain$metadata, handlers, config)
 }

--- a/cran/paws.analytics/R/datapipeline_service.R
+++ b/cran/paws.analytics/R/datapipeline_service.R
@@ -103,8 +103,7 @@ datapipeline <- function(config = list()) {
   target_prefix = "DataPipeline"
 )
 
-.datapipeline$handlers <- new_handlers("jsonrpc", "v4")
-
 .datapipeline$service <- function(config = list()) {
-  new_service(.datapipeline$metadata, .datapipeline$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.datapipeline$metadata, handlers, config)
 }

--- a/cran/paws.analytics/R/elasticsearchservice_service.R
+++ b/cran/paws.analytics/R/elasticsearchservice_service.R
@@ -100,8 +100,7 @@ elasticsearchservice <- function(config = list()) {
   target_prefix = ""
 )
 
-.elasticsearchservice$handlers <- new_handlers("restjson", "v4")
-
 .elasticsearchservice$service <- function(config = list()) {
-  new_service(.elasticsearchservice$metadata, .elasticsearchservice$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.elasticsearchservice$metadata, handlers, config)
 }

--- a/cran/paws.analytics/R/emr_service.R
+++ b/cran/paws.analytics/R/emr_service.R
@@ -96,8 +96,7 @@ emr <- function(config = list()) {
   target_prefix = "ElasticMapReduce"
 )
 
-.emr$handlers <- new_handlers("jsonrpc", "v4")
-
 .emr$service <- function(config = list()) {
-  new_service(.emr$metadata, .emr$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.emr$metadata, handlers, config)
 }

--- a/cran/paws.analytics/R/firehose_service.R
+++ b/cran/paws.analytics/R/firehose_service.R
@@ -79,8 +79,7 @@ firehose <- function(config = list()) {
   target_prefix = "Firehose_20150804"
 )
 
-.firehose$handlers <- new_handlers("jsonrpc", "v4")
-
 .firehose$service <- function(config = list()) {
-  new_service(.firehose$metadata, .firehose$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.firehose$metadata, handlers, config)
 }

--- a/cran/paws.analytics/R/glue_service.R
+++ b/cran/paws.analytics/R/glue_service.R
@@ -185,8 +185,7 @@ glue <- function(config = list()) {
   target_prefix = "AWSGlue"
 )
 
-.glue$handlers <- new_handlers("jsonrpc", "v4")
-
 .glue$service <- function(config = list()) {
-  new_service(.glue$metadata, .glue$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.glue$metadata, handlers, config)
 }

--- a/cran/paws.analytics/R/kafka_service.R
+++ b/cran/paws.analytics/R/kafka_service.R
@@ -81,8 +81,7 @@ kafka <- function(config = list()) {
   target_prefix = ""
 )
 
-.kafka$handlers <- new_handlers("restjson", "v4")
-
 .kafka$service <- function(config = list()) {
-  new_service(.kafka$metadata, .kafka$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.kafka$metadata, handlers, config)
 }

--- a/cran/paws.analytics/R/kinesis_service.R
+++ b/cran/paws.analytics/R/kinesis_service.R
@@ -92,8 +92,7 @@ kinesis <- function(config = list()) {
   target_prefix = "Kinesis_20131202"
 )
 
-.kinesis$handlers <- new_handlers("jsonrpc", "v4")
-
 .kinesis$service <- function(config = list()) {
-  new_service(.kinesis$metadata, .kinesis$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.kinesis$metadata, handlers, config)
 }

--- a/cran/paws.analytics/R/kinesisanalytics_service.R
+++ b/cran/paws.analytics/R/kinesisanalytics_service.R
@@ -90,8 +90,7 @@ kinesisanalytics <- function(config = list()) {
   target_prefix = "KinesisAnalytics_20150814"
 )
 
-.kinesisanalytics$handlers <- new_handlers("jsonrpc", "v4")
-
 .kinesisanalytics$service <- function(config = list()) {
-  new_service(.kinesisanalytics$metadata, .kinesisanalytics$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.kinesisanalytics$metadata, handlers, config)
 }

--- a/cran/paws.analytics/R/kinesisanalyticsv2_service.R
+++ b/cran/paws.analytics/R/kinesisanalyticsv2_service.R
@@ -92,8 +92,7 @@ kinesisanalyticsv2 <- function(config = list()) {
   target_prefix = "KinesisAnalytics_20180523"
 )
 
-.kinesisanalyticsv2$handlers <- new_handlers("jsonrpc", "v4")
-
 .kinesisanalyticsv2$service <- function(config = list()) {
-  new_service(.kinesisanalyticsv2$metadata, .kinesisanalyticsv2$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.kinesisanalyticsv2$metadata, handlers, config)
 }

--- a/cran/paws.analytics/R/mturk_service.R
+++ b/cran/paws.analytics/R/mturk_service.R
@@ -101,8 +101,7 @@ mturk <- function(config = list()) {
   target_prefix = "MTurkRequesterServiceV20170117"
 )
 
-.mturk$handlers <- new_handlers("jsonrpc", "v4")
-
 .mturk$service <- function(config = list()) {
-  new_service(.mturk$metadata, .mturk$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.mturk$metadata, handlers, config)
 }

--- a/cran/paws.analytics/R/quicksight_service.R
+++ b/cran/paws.analytics/R/quicksight_service.R
@@ -133,8 +133,7 @@ quicksight <- function(config = list()) {
   target_prefix = ""
 )
 
-.quicksight$handlers <- new_handlers("restjson", "v4")
-
 .quicksight$service <- function(config = list()) {
-  new_service(.quicksight$metadata, .quicksight$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.quicksight$metadata, handlers, config)
 }

--- a/cran/paws.application.integration/R/eventbridge_service.R
+++ b/cran/paws.application.integration/R/eventbridge_service.R
@@ -113,8 +113,7 @@ eventbridge <- function(config = list()) {
   target_prefix = "AWSEvents"
 )
 
-.eventbridge$handlers <- new_handlers("jsonrpc", "v4")
-
 .eventbridge$service <- function(config = list()) {
-  new_service(.eventbridge$metadata, .eventbridge$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.eventbridge$metadata, handlers, config)
 }

--- a/cran/paws.application.integration/R/mq_service.R
+++ b/cran/paws.application.integration/R/mq_service.R
@@ -84,8 +84,7 @@ mq <- function(config = list()) {
   target_prefix = ""
 )
 
-.mq$handlers <- new_handlers("restjson", "v4")
-
 .mq$service <- function(config = list()) {
-  new_service(.mq$metadata, .mq$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mq$metadata, handlers, config)
 }

--- a/cran/paws.application.integration/R/sfn_service.R
+++ b/cran/paws.application.integration/R/sfn_service.R
@@ -104,8 +104,7 @@ sfn <- function(config = list()) {
   target_prefix = "AWSStepFunctions"
 )
 
-.sfn$handlers <- new_handlers("jsonrpc", "v4")
-
 .sfn$service <- function(config = list()) {
-  new_service(.sfn$metadata, .sfn$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.sfn$metadata, handlers, config)
 }

--- a/cran/paws.application.integration/R/sns_service.R
+++ b/cran/paws.application.integration/R/sns_service.R
@@ -110,8 +110,7 @@ sns <- function(config = list()) {
   target_prefix = ""
 )
 
-.sns$handlers <- new_handlers("query", "v4")
-
 .sns$service <- function(config = list()) {
-  new_service(.sns$metadata, .sns$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.sns$metadata, handlers, config)
 }

--- a/cran/paws.application.integration/R/sqs_service.R
+++ b/cran/paws.application.integration/R/sqs_service.R
@@ -120,8 +120,7 @@ sqs <- function(config = list()) {
   target_prefix = ""
 )
 
-.sqs$handlers <- new_handlers("query", "v4")
-
 .sqs$service <- function(config = list()) {
-  new_service(.sqs$metadata, .sqs$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.sqs$metadata, handlers, config)
 }

--- a/cran/paws.application.integration/R/swf_service.R
+++ b/cran/paws.application.integration/R/swf_service.R
@@ -113,8 +113,7 @@ swf <- function(config = list()) {
   target_prefix = "SimpleWorkflowService"
 )
 
-.swf$handlers <- new_handlers("jsonrpc", "v4")
-
 .swf$service <- function(config = list()) {
-  new_service(.swf$metadata, .swf$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.swf$metadata, handlers, config)
 }

--- a/cran/paws.business.applications/R/alexaforbusiness_service.R
+++ b/cran/paws.business.applications/R/alexaforbusiness_service.R
@@ -165,8 +165,7 @@ alexaforbusiness <- function(config = list()) {
   target_prefix = "AlexaForBusiness"
 )
 
-.alexaforbusiness$handlers <- new_handlers("jsonrpc", "v4")
-
 .alexaforbusiness$service <- function(config = list()) {
-  new_service(.alexaforbusiness$metadata, .alexaforbusiness$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.alexaforbusiness$metadata, handlers, config)
 }

--- a/cran/paws.business.applications/R/chime_service.R
+++ b/cran/paws.business.applications/R/chime_service.R
@@ -203,8 +203,7 @@ chime <- function(config = list()) {
   target_prefix = ""
 )
 
-.chime$handlers <- new_handlers("restjson", "v4")
-
 .chime$service <- function(config = list()) {
-  new_service(.chime$metadata, .chime$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.chime$metadata, handlers, config)
 }

--- a/cran/paws.business.applications/R/workmail_service.R
+++ b/cran/paws.business.applications/R/workmail_service.R
@@ -129,8 +129,7 @@ workmail <- function(config = list()) {
   target_prefix = "WorkMailService"
 )
 
-.workmail$handlers <- new_handlers("jsonrpc", "v4")
-
 .workmail$service <- function(config = list()) {
-  new_service(.workmail$metadata, .workmail$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.workmail$metadata, handlers, config)
 }

--- a/cran/paws.compute/R/batch_service.R
+++ b/cran/paws.compute/R/batch_service.R
@@ -97,8 +97,7 @@ batch <- function(config = list()) {
   target_prefix = ""
 )
 
-.batch$handlers <- new_handlers("restjson", "v4")
-
 .batch$service <- function(config = list()) {
-  new_service(.batch$metadata, .batch$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.batch$metadata, handlers, config)
 }

--- a/cran/paws.compute/R/ec2_service.R
+++ b/cran/paws.compute/R/ec2_service.R
@@ -479,8 +479,7 @@ ec2 <- function(config = list()) {
   target_prefix = ""
 )
 
-.ec2$handlers <- new_handlers("ec2query", "v4")
-
 .ec2$service <- function(config = list()) {
-  new_service(.ec2$metadata, .ec2$handlers, config)
+  handlers <- new_handlers("ec2query", "v4")
+  new_service(.ec2$metadata, handlers, config)
 }

--- a/cran/paws.compute/R/ec2instanceconnect_service.R
+++ b/cran/paws.compute/R/ec2instanceconnect_service.R
@@ -71,8 +71,7 @@ ec2instanceconnect <- function(config = list()) {
   target_prefix = "AWSEC2InstanceConnectService"
 )
 
-.ec2instanceconnect$handlers <- new_handlers("jsonrpc", "v4")
-
 .ec2instanceconnect$service <- function(config = list()) {
-  new_service(.ec2instanceconnect$metadata, .ec2instanceconnect$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.ec2instanceconnect$metadata, handlers, config)
 }

--- a/cran/paws.compute/R/ecr_service.R
+++ b/cran/paws.compute/R/ecr_service.R
@@ -106,8 +106,7 @@ ecr <- function(config = list()) {
   target_prefix = "AmazonEC2ContainerRegistry_V20150921"
 )
 
-.ecr$handlers <- new_handlers("jsonrpc", "v4")
-
 .ecr$service <- function(config = list()) {
-  new_service(.ecr$metadata, .ecr$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.ecr$metadata, handlers, config)
 }

--- a/cran/paws.compute/R/ecs_service.R
+++ b/cran/paws.compute/R/ecs_service.R
@@ -132,8 +132,7 @@ ecs <- function(config = list()) {
   target_prefix = "AmazonEC2ContainerServiceV20141113"
 )
 
-.ecs$handlers <- new_handlers("jsonrpc", "v4")
-
 .ecs$service <- function(config = list()) {
-  new_service(.ecs$metadata, .ecs$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.ecs$metadata, handlers, config)
 }

--- a/cran/paws.compute/R/eks_service.R
+++ b/cran/paws.compute/R/eks_service.R
@@ -108,8 +108,7 @@ eks <- function(config = list()) {
   target_prefix = ""
 )
 
-.eks$handlers <- new_handlers("restjson", "v4")
-
 .eks$service <- function(config = list()) {
-  new_service(.eks$metadata, .eks$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.eks$metadata, handlers, config)
 }

--- a/cran/paws.compute/R/elasticbeanstalk_service.R
+++ b/cran/paws.compute/R/elasticbeanstalk_service.R
@@ -126,8 +126,7 @@ elasticbeanstalk <- function(config = list()) {
   target_prefix = ""
 )
 
-.elasticbeanstalk$handlers <- new_handlers("query", "v4")
-
 .elasticbeanstalk$service <- function(config = list()) {
-  new_service(.elasticbeanstalk$metadata, .elasticbeanstalk$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.elasticbeanstalk$metadata, handlers, config)
 }

--- a/cran/paws.compute/R/lambda_service.R
+++ b/cran/paws.compute/R/lambda_service.R
@@ -125,8 +125,7 @@ lambda <- function(config = list()) {
   target_prefix = ""
 )
 
-.lambda$handlers <- new_handlers("restjson", "v4")
-
 .lambda$service <- function(config = list()) {
-  new_service(.lambda$metadata, .lambda$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.lambda$metadata, handlers, config)
 }

--- a/cran/paws.compute/R/lightsail_service.R
+++ b/cran/paws.compute/R/lightsail_service.R
@@ -181,8 +181,7 @@ lightsail <- function(config = list()) {
   target_prefix = "Lightsail_20161128"
 )
 
-.lightsail$handlers <- new_handlers("jsonrpc", "v4")
-
 .lightsail$service <- function(config = list()) {
-  new_service(.lightsail$metadata, .lightsail$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.lightsail$metadata, handlers, config)
 }

--- a/cran/paws.compute/R/serverlessapplicationrepository_service.R
+++ b/cran/paws.compute/R/serverlessapplicationrepository_service.R
@@ -107,8 +107,7 @@ serverlessapplicationrepository <- function(config = list()) {
   target_prefix = ""
 )
 
-.serverlessapplicationrepository$handlers <- new_handlers("restjson", "v4")
-
 .serverlessapplicationrepository$service <- function(config = list()) {
-  new_service(.serverlessapplicationrepository$metadata, .serverlessapplicationrepository$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.serverlessapplicationrepository$metadata, handlers, config)
 }

--- a/cran/paws.cost.management/R/budgets_service.R
+++ b/cran/paws.cost.management/R/budgets_service.R
@@ -120,8 +120,7 @@ budgets <- function(config = list()) {
   target_prefix = "AWSBudgetServiceGateway"
 )
 
-.budgets$handlers <- new_handlers("jsonrpc", "v4")
-
 .budgets$service <- function(config = list()) {
-  new_service(.budgets$metadata, .budgets$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.budgets$metadata, handlers, config)
 }

--- a/cran/paws.cost.management/R/costandusagereportservice_service.R
+++ b/cran/paws.cost.management/R/costandusagereportservice_service.R
@@ -81,8 +81,7 @@ costandusagereportservice <- function(config = list()) {
   target_prefix = "AWSOrigamiServiceGatewayService"
 )
 
-.costandusagereportservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .costandusagereportservice$service <- function(config = list()) {
-  new_service(.costandusagereportservice$metadata, .costandusagereportservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.costandusagereportservice$metadata, handlers, config)
 }

--- a/cran/paws.cost.management/R/costexplorer_service.R
+++ b/cran/paws.cost.management/R/costexplorer_service.R
@@ -95,8 +95,7 @@ costexplorer <- function(config = list()) {
   target_prefix = "AWSInsightsIndexService"
 )
 
-.costexplorer$handlers <- new_handlers("jsonrpc", "v4")
-
 .costexplorer$service <- function(config = list()) {
-  new_service(.costexplorer$metadata, .costexplorer$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.costexplorer$metadata, handlers, config)
 }

--- a/cran/paws.cost.management/R/marketplacecommerceanalytics_service.R
+++ b/cran/paws.cost.management/R/marketplacecommerceanalytics_service.R
@@ -64,8 +64,7 @@ marketplacecommerceanalytics <- function(config = list()) {
   target_prefix = "MarketplaceCommerceAnalytics20150701"
 )
 
-.marketplacecommerceanalytics$handlers <- new_handlers("jsonrpc", "v4")
-
 .marketplacecommerceanalytics$service <- function(config = list()) {
-  new_service(.marketplacecommerceanalytics$metadata, .marketplacecommerceanalytics$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.marketplacecommerceanalytics$metadata, handlers, config)
 }

--- a/cran/paws.cost.management/R/marketplaceentitlementservice_service.R
+++ b/cran/paws.cost.management/R/marketplaceentitlementservice_service.R
@@ -74,8 +74,7 @@ marketplaceentitlementservice <- function(config = list()) {
   target_prefix = "AWSMPEntitlementService"
 )
 
-.marketplaceentitlementservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .marketplaceentitlementservice$service <- function(config = list()) {
-  new_service(.marketplaceentitlementservice$metadata, .marketplaceentitlementservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.marketplaceentitlementservice$metadata, handlers, config)
 }

--- a/cran/paws.cost.management/R/marketplacemetering_service.R
+++ b/cran/paws.cost.management/R/marketplacemetering_service.R
@@ -109,8 +109,7 @@ marketplacemetering <- function(config = list()) {
   target_prefix = "AWSMPMeteringService"
 )
 
-.marketplacemetering$handlers <- new_handlers("jsonrpc", "v4")
-
 .marketplacemetering$service <- function(config = list()) {
-  new_service(.marketplacemetering$metadata, .marketplacemetering$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.marketplacemetering$metadata, handlers, config)
 }

--- a/cran/paws.cost.management/R/pricing_service.R
+++ b/cran/paws.cost.management/R/pricing_service.R
@@ -92,8 +92,7 @@ pricing <- function(config = list()) {
   target_prefix = "AWSPriceListService"
 )
 
-.pricing$handlers <- new_handlers("jsonrpc", "v4")
-
 .pricing$service <- function(config = list()) {
-  new_service(.pricing$metadata, .pricing$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.pricing$metadata, handlers, config)
 }

--- a/cran/paws.customer.engagement/R/connect_service.R
+++ b/cran/paws.customer.engagement/R/connect_service.R
@@ -103,8 +103,7 @@ connect <- function(config = list()) {
   target_prefix = ""
 )
 
-.connect$handlers <- new_handlers("restjson", "v4")
-
 .connect$service <- function(config = list()) {
-  new_service(.connect$metadata, .connect$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.connect$metadata, handlers, config)
 }

--- a/cran/paws.customer.engagement/R/pinpoint_service.R
+++ b/cran/paws.customer.engagement/R/pinpoint_service.R
@@ -169,8 +169,7 @@ pinpoint <- function(config = list()) {
   target_prefix = ""
 )
 
-.pinpoint$handlers <- new_handlers("restjson", "v4")
-
 .pinpoint$service <- function(config = list()) {
-  new_service(.pinpoint$metadata, .pinpoint$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.pinpoint$metadata, handlers, config)
 }

--- a/cran/paws.customer.engagement/R/pinpointemail_service.R
+++ b/cran/paws.customer.engagement/R/pinpointemail_service.R
@@ -142,8 +142,7 @@ pinpointemail <- function(config = list()) {
   target_prefix = ""
 )
 
-.pinpointemail$handlers <- new_handlers("restjson", "v4")
-
 .pinpointemail$service <- function(config = list()) {
-  new_service(.pinpointemail$metadata, .pinpointemail$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.pinpointemail$metadata, handlers, config)
 }

--- a/cran/paws.customer.engagement/R/pinpointsmsvoice_service.R
+++ b/cran/paws.customer.engagement/R/pinpointsmsvoice_service.R
@@ -70,8 +70,7 @@ pinpointsmsvoice <- function(config = list()) {
   target_prefix = ""
 )
 
-.pinpointsmsvoice$handlers <- new_handlers("restjson", "v4")
-
 .pinpointsmsvoice$service <- function(config = list()) {
-  new_service(.pinpointsmsvoice$metadata, .pinpointsmsvoice$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.pinpointsmsvoice$metadata, handlers, config)
 }

--- a/cran/paws.customer.engagement/R/ses_operations.R
+++ b/cran/paws.customer.engagement/R/ses_operations.R
@@ -2567,9 +2567,9 @@ ses_send_bounce <- function(OriginalMessageId, BounceSender, Explanation = NULL,
 #' Guide](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html).
 #' 
 #' Amazon SES does not support the SMTPUTF8 extension, as described in
-#' [RFC6531](https://tools.ietf.org/html/rfc6531). For this reason, the
-#' *local part* of a source email address (the part of the email address
-#' that precedes the @ sign) may only contain [7-bit ASCII
+#' RFC6531. For this reason, the *local part* of a source email address
+#' (the part of the email address that precedes the @ sign) may only
+#' contain [7-bit ASCII
 #' characters](https://en.wikipedia.org/wiki/Email_address#Local-part). If
 #' the *domain part* of an address (the part after the @ sign) contains
 #' non-ASCII characters, they must be encoded using Punycode, as described

--- a/cran/paws.customer.engagement/R/ses_service.R
+++ b/cran/paws.customer.engagement/R/ses_service.R
@@ -146,8 +146,7 @@ ses <- function(config = list()) {
   target_prefix = ""
 )
 
-.ses$handlers <- new_handlers("query", "v4")
-
 .ses$service <- function(config = list()) {
-  new_service(.ses$metadata, .ses$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.ses$metadata, handlers, config)
 }

--- a/cran/paws.customer.engagement/man/ses_send_bulk_templated_email.Rd
+++ b/cran/paws.customer.engagement/man/ses_send_bulk_templated_email.Rd
@@ -20,9 +20,9 @@ do so by a sending authorization policy, then you must also specify the
 see the \href{https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html}{Amazon SES Developer Guide}.
 
 Amazon SES does not support the SMTPUTF8 extension, as described in
-\href{https://tools.ietf.org/html/rfc6531}{RFC6531}. For this reason, the
-\emph{local part} of a source email address (the part of the email address
-that precedes the @ sign) may only contain \href{https://en.wikipedia.org/wiki/Email_address#Local-part}{7-bit ASCII characters}. If
+RFC6531. For this reason, the \emph{local part} of a source email address
+(the part of the email address that precedes the @ sign) may only
+contain \href{https://en.wikipedia.org/wiki/Email_address#Local-part}{7-bit ASCII characters}. If
 the \emph{domain part} of an address (the part after the @ sign) contains
 non-ASCII characters, they must be encoded using Punycode, as described
 in \href{https://tools.ietf.org/html/rfc3492.html}{RFC3492}. The sender name

--- a/cran/paws.database/R/dax_service.R
+++ b/cran/paws.database/R/dax_service.R
@@ -89,8 +89,7 @@ dax <- function(config = list()) {
   target_prefix = "AmazonDAXV3"
 )
 
-.dax$handlers <- new_handlers("jsonrpc", "v4")
-
 .dax$service <- function(config = list()) {
-  new_service(.dax$metadata, .dax$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.dax$metadata, handlers, config)
 }

--- a/cran/paws.database/R/docdb_service.R
+++ b/cran/paws.database/R/docdb_service.R
@@ -104,8 +104,7 @@ docdb <- function(config = list()) {
   target_prefix = ""
 )
 
-.docdb$handlers <- new_handlers("query", "v4")
-
 .docdb$service <- function(config = list()) {
-  new_service(.docdb$metadata, .docdb$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.docdb$metadata, handlers, config)
 }

--- a/cran/paws.database/R/dynamodb_service.R
+++ b/cran/paws.database/R/dynamodb_service.R
@@ -153,8 +153,7 @@ dynamodb <- function(config = list()) {
   target_prefix = "DynamoDB_20120810"
 )
 
-.dynamodb$handlers <- new_handlers("jsonrpc", "v4")
-
 .dynamodb$service <- function(config = list()) {
-  new_service(.dynamodb$metadata, .dynamodb$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.dynamodb$metadata, handlers, config)
 }

--- a/cran/paws.database/R/dynamodbstreams_service.R
+++ b/cran/paws.database/R/dynamodbstreams_service.R
@@ -73,8 +73,7 @@ dynamodbstreams <- function(config = list()) {
   target_prefix = "DynamoDBStreams_20120810"
 )
 
-.dynamodbstreams$handlers <- new_handlers("jsonrpc", "v4")
-
 .dynamodbstreams$service <- function(config = list()) {
-  new_service(.dynamodbstreams$metadata, .dynamodbstreams$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.dynamodbstreams$metadata, handlers, config)
 }

--- a/cran/paws.database/R/elasticache_service.R
+++ b/cran/paws.database/R/elasticache_service.R
@@ -121,8 +121,7 @@ elasticache <- function(config = list()) {
   target_prefix = ""
 )
 
-.elasticache$handlers <- new_handlers("query", "v4")
-
 .elasticache$service <- function(config = list()) {
-  new_service(.elasticache$metadata, .elasticache$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.elasticache$metadata, handlers, config)
 }

--- a/cran/paws.database/R/neptune_service.R
+++ b/cran/paws.database/R/neptune_service.R
@@ -139,8 +139,7 @@ neptune <- function(config = list()) {
   target_prefix = ""
 )
 
-.neptune$handlers <- new_handlers("query", "v4")
-
 .neptune$service <- function(config = list()) {
-  new_service(.neptune$metadata, .neptune$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.neptune$metadata, handlers, config)
 }

--- a/cran/paws.database/R/rds_service.R
+++ b/cran/paws.database/R/rds_service.R
@@ -239,8 +239,7 @@ rds <- function(config = list()) {
   target_prefix = ""
 )
 
-.rds$handlers <- new_handlers("query", "v4")
-
 .rds$service <- function(config = list()) {
-  new_service(.rds$metadata, .rds$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.rds$metadata, handlers, config)
 }

--- a/cran/paws.database/R/rdsdataservice_service.R
+++ b/cran/paws.database/R/rdsdataservice_service.R
@@ -80,8 +80,7 @@ rdsdataservice <- function(config = list()) {
   target_prefix = ""
 )
 
-.rdsdataservice$handlers <- new_handlers("restjson", "v4")
-
 .rdsdataservice$service <- function(config = list()) {
-  new_service(.rdsdataservice$metadata, .rdsdataservice$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.rdsdataservice$metadata, handlers, config)
 }

--- a/cran/paws.database/R/redshift_service.R
+++ b/cran/paws.database/R/redshift_service.R
@@ -175,8 +175,7 @@ redshift <- function(config = list()) {
   target_prefix = ""
 )
 
-.redshift$handlers <- new_handlers("query", "v4")
-
 .redshift$service <- function(config = list()) {
-  new_service(.redshift$metadata, .redshift$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.redshift$metadata, handlers, config)
 }

--- a/cran/paws.database/R/simpledb_service.R
+++ b/cran/paws.database/R/simpledb_service.R
@@ -72,8 +72,7 @@ simpledb <- function(config = list()) {
   target_prefix = ""
 )
 
-.simpledb$handlers <- new_handlers("query", "v2")
-
 .simpledb$service <- function(config = list()) {
-  new_service(.simpledb$metadata, .simpledb$handlers, config)
+  handlers <- new_handlers("query", "v2")
+  new_service(.simpledb$metadata, handlers, config)
 }

--- a/cran/paws.developer.tools/R/cloud9_service.R
+++ b/cran/paws.developer.tools/R/cloud9_service.R
@@ -114,8 +114,7 @@ cloud9 <- function(config = list()) {
   target_prefix = "AWSCloud9WorkspaceManagementService"
 )
 
-.cloud9$handlers <- new_handlers("jsonrpc", "v4")
-
 .cloud9$service <- function(config = list()) {
-  new_service(.cloud9$metadata, .cloud9$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cloud9$metadata, handlers, config)
 }

--- a/cran/paws.developer.tools/R/codebuild_service.R
+++ b/cran/paws.developer.tools/R/codebuild_service.R
@@ -214,8 +214,7 @@ codebuild <- function(config = list()) {
   target_prefix = "CodeBuild_20161006"
 )
 
-.codebuild$handlers <- new_handlers("jsonrpc", "v4")
-
 .codebuild$service <- function(config = list()) {
-  new_service(.codebuild$metadata, .codebuild$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.codebuild$metadata, handlers, config)
 }

--- a/cran/paws.developer.tools/R/codecommit_service.R
+++ b/cran/paws.developer.tools/R/codecommit_service.R
@@ -404,8 +404,7 @@ codecommit <- function(config = list()) {
   target_prefix = "CodeCommit_20150413"
 )
 
-.codecommit$handlers <- new_handlers("jsonrpc", "v4")
-
 .codecommit$service <- function(config = list()) {
-  new_service(.codecommit$metadata, .codecommit$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.codecommit$metadata, handlers, config)
 }

--- a/cran/paws.developer.tools/R/codedeploy_service.R
+++ b/cran/paws.developer.tools/R/codedeploy_service.R
@@ -186,8 +186,7 @@ codedeploy <- function(config = list()) {
   target_prefix = "CodeDeploy_20141006"
 )
 
-.codedeploy$handlers <- new_handlers("jsonrpc", "v4")
-
 .codedeploy$service <- function(config = list()) {
-  new_service(.codedeploy$metadata, .codedeploy$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.codedeploy$metadata, handlers, config)
 }

--- a/cran/paws.developer.tools/R/codepipeline_service.R
+++ b/cran/paws.developer.tools/R/codepipeline_service.R
@@ -233,8 +233,7 @@ codepipeline <- function(config = list()) {
   target_prefix = "CodePipeline_20150709"
 )
 
-.codepipeline$handlers <- new_handlers("jsonrpc", "v4")
-
 .codepipeline$service <- function(config = list()) {
-  new_service(.codepipeline$metadata, .codepipeline$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.codepipeline$metadata, handlers, config)
 }

--- a/cran/paws.developer.tools/R/codestar_service.R
+++ b/cran/paws.developer.tools/R/codestar_service.R
@@ -133,8 +133,7 @@ codestar <- function(config = list()) {
   target_prefix = "CodeStar_20170419"
 )
 
-.codestar$handlers <- new_handlers("jsonrpc", "v4")
-
 .codestar$service <- function(config = list()) {
-  new_service(.codestar$metadata, .codestar$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.codestar$metadata, handlers, config)
 }

--- a/cran/paws.developer.tools/R/xray_service.R
+++ b/cran/paws.developer.tools/R/xray_service.R
@@ -83,8 +83,7 @@ xray <- function(config = list()) {
   target_prefix = ""
 )
 
-.xray$handlers <- new_handlers("restjson", "v4")
-
 .xray$service <- function(config = list()) {
-  new_service(.xray$metadata, .xray$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.xray$metadata, handlers, config)
 }

--- a/cran/paws.end.user.computing/R/appstream_service.R
+++ b/cran/paws.end.user.computing/R/appstream_service.R
@@ -131,8 +131,7 @@ appstream <- function(config = list()) {
   target_prefix = "PhotonAdminProxyService"
 )
 
-.appstream$handlers <- new_handlers("jsonrpc", "v4")
-
 .appstream$service <- function(config = list()) {
-  new_service(.appstream$metadata, .appstream$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.appstream$metadata, handlers, config)
 }

--- a/cran/paws.end.user.computing/R/workdocs_service.R
+++ b/cran/paws.end.user.computing/R/workdocs_service.R
@@ -135,8 +135,7 @@ workdocs <- function(config = list()) {
   target_prefix = ""
 )
 
-.workdocs$handlers <- new_handlers("restjson", "v4")
-
 .workdocs$service <- function(config = list()) {
-  new_service(.workdocs$metadata, .workdocs$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.workdocs$metadata, handlers, config)
 }

--- a/cran/paws.end.user.computing/R/worklink_service.R
+++ b/cran/paws.end.user.computing/R/worklink_service.R
@@ -100,8 +100,7 @@ worklink <- function(config = list()) {
   target_prefix = ""
 )
 
-.worklink$handlers <- new_handlers("restjson", "v4")
-
 .worklink$service <- function(config = list()) {
-  new_service(.worklink$metadata, .worklink$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.worklink$metadata, handlers, config)
 }

--- a/cran/paws.end.user.computing/R/workspaces_service.R
+++ b/cran/paws.end.user.computing/R/workspaces_service.R
@@ -106,8 +106,7 @@ workspaces <- function(config = list()) {
   target_prefix = "WorkspacesService"
 )
 
-.workspaces$handlers <- new_handlers("jsonrpc", "v4")
-
 .workspaces$service <- function(config = list()) {
-  new_service(.workspaces$metadata, .workspaces$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.workspaces$metadata, handlers, config)
 }

--- a/cran/paws.game.development/R/gamelift_service.R
+++ b/cran/paws.game.development/R/gamelift_service.R
@@ -175,8 +175,7 @@ gamelift <- function(config = list()) {
   target_prefix = "GameLift"
 )
 
-.gamelift$handlers <- new_handlers("jsonrpc", "v4")
-
 .gamelift$service <- function(config = list()) {
-  new_service(.gamelift$metadata, .gamelift$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.gamelift$metadata, handlers, config)
 }

--- a/cran/paws.internet.of.things/R/greengrass_service.R
+++ b/cran/paws.internet.of.things/R/greengrass_service.R
@@ -152,8 +152,7 @@ greengrass <- function(config = list()) {
   target_prefix = ""
 )
 
-.greengrass$handlers <- new_handlers("restjson", "v4")
-
 .greengrass$service <- function(config = list()) {
-  new_service(.greengrass$metadata, .greengrass$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.greengrass$metadata, handlers, config)
 }

--- a/cran/paws.internet.of.things/R/iot1clickdevicesservice_service.R
+++ b/cran/paws.internet.of.things/R/iot1clickdevicesservice_service.R
@@ -77,8 +77,7 @@ iot1clickdevicesservice <- function(config = list()) {
   target_prefix = ""
 )
 
-.iot1clickdevicesservice$handlers <- new_handlers("restjson", "v4")
-
 .iot1clickdevicesservice$service <- function(config = list()) {
-  new_service(.iot1clickdevicesservice$metadata, .iot1clickdevicesservice$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.iot1clickdevicesservice$metadata, handlers, config)
 }

--- a/cran/paws.internet.of.things/R/iot1clickprojects_service.R
+++ b/cran/paws.internet.of.things/R/iot1clickprojects_service.R
@@ -78,8 +78,7 @@ iot1clickprojects <- function(config = list()) {
   target_prefix = ""
 )
 
-.iot1clickprojects$handlers <- new_handlers("restjson", "v4")
-
 .iot1clickprojects$service <- function(config = list()) {
-  new_service(.iot1clickprojects$metadata, .iot1clickprojects$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.iot1clickprojects$metadata, handlers, config)
 }

--- a/cran/paws.internet.of.things/R/iot_service.R
+++ b/cran/paws.internet.of.things/R/iot_service.R
@@ -276,8 +276,7 @@ iot <- function(config = list()) {
   target_prefix = ""
 )
 
-.iot$handlers <- new_handlers("restjson", "v4")
-
 .iot$service <- function(config = list()) {
-  new_service(.iot$metadata, .iot$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.iot$metadata, handlers, config)
 }

--- a/cran/paws.internet.of.things/R/iotanalytics_service.R
+++ b/cran/paws.internet.of.things/R/iotanalytics_service.R
@@ -121,8 +121,7 @@ iotanalytics <- function(config = list()) {
   target_prefix = ""
 )
 
-.iotanalytics$handlers <- new_handlers("restjson", "v4")
-
 .iotanalytics$service <- function(config = list()) {
-  new_service(.iotanalytics$metadata, .iotanalytics$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.iotanalytics$metadata, handlers, config)
 }

--- a/cran/paws.internet.of.things/R/iotdataplane_service.R
+++ b/cran/paws.internet.of.things/R/iotdataplane_service.R
@@ -74,8 +74,7 @@ iotdataplane <- function(config = list()) {
   target_prefix = ""
 )
 
-.iotdataplane$handlers <- new_handlers("restjson", "v4")
-
 .iotdataplane$service <- function(config = list()) {
-  new_service(.iotdataplane$metadata, .iotdataplane$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.iotdataplane$metadata, handlers, config)
 }

--- a/cran/paws.internet.of.things/R/iotjobsdataplane_service.R
+++ b/cran/paws.internet.of.things/R/iotjobsdataplane_service.R
@@ -83,8 +83,7 @@ iotjobsdataplane <- function(config = list()) {
   target_prefix = ""
 )
 
-.iotjobsdataplane$handlers <- new_handlers("restjson", "v4")
-
 .iotjobsdataplane$service <- function(config = list()) {
-  new_service(.iotjobsdataplane$metadata, .iotjobsdataplane$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.iotjobsdataplane$metadata, handlers, config)
 }

--- a/cran/paws.internet.of.things/R/signer_service.R
+++ b/cran/paws.internet.of.things/R/signer_service.R
@@ -86,8 +86,7 @@ signer <- function(config = list()) {
   target_prefix = ""
 )
 
-.signer$handlers <- new_handlers("restjson", "v4")
-
 .signer$service <- function(config = list()) {
-  new_service(.signer$metadata, .signer$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.signer$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/comprehend_service.R
+++ b/cran/paws.machine.learning/R/comprehend_service.R
@@ -116,8 +116,7 @@ comprehend <- function(config = list()) {
   target_prefix = "Comprehend_20171127"
 )
 
-.comprehend$handlers <- new_handlers("jsonrpc", "v4")
-
 .comprehend$service <- function(config = list()) {
-  new_service(.comprehend$metadata, .comprehend$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.comprehend$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/comprehendmedical_service.R
+++ b/cran/paws.machine.learning/R/comprehendmedical_service.R
@@ -77,8 +77,7 @@ comprehendmedical <- function(config = list()) {
   target_prefix = "ComprehendMedical_20181030"
 )
 
-.comprehendmedical$handlers <- new_handlers("jsonrpc", "v4")
-
 .comprehendmedical$service <- function(config = list()) {
-  new_service(.comprehendmedical$metadata, .comprehendmedical$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.comprehendmedical$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/lexmodelbuildingservice_service.R
+++ b/cran/paws.machine.learning/R/lexmodelbuildingservice_service.R
@@ -104,8 +104,7 @@ lexmodelbuildingservice <- function(config = list()) {
   target_prefix = ""
 )
 
-.lexmodelbuildingservice$handlers <- new_handlers("restjson", "v4")
-
 .lexmodelbuildingservice$service <- function(config = list()) {
-  new_service(.lexmodelbuildingservice$metadata, .lexmodelbuildingservice$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.lexmodelbuildingservice$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/lexruntimeservice_service.R
+++ b/cran/paws.machine.learning/R/lexruntimeservice_service.R
@@ -78,8 +78,7 @@ lexruntimeservice <- function(config = list()) {
   target_prefix = ""
 )
 
-.lexruntimeservice$handlers <- new_handlers("restjson", "v4")
-
 .lexruntimeservice$service <- function(config = list()) {
-  new_service(.lexruntimeservice$metadata, .lexruntimeservice$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.lexruntimeservice$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/machinelearning_service.R
+++ b/cran/paws.machine.learning/R/machinelearning_service.R
@@ -90,8 +90,7 @@ machinelearning <- function(config = list()) {
   target_prefix = "AmazonML_20141212"
 )
 
-.machinelearning$handlers <- new_handlers("jsonrpc", "v4")
-
 .machinelearning$service <- function(config = list()) {
-  new_service(.machinelearning$metadata, .machinelearning$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.machinelearning$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/personalize_service.R
+++ b/cran/paws.machine.learning/R/personalize_service.R
@@ -102,8 +102,7 @@ personalize <- function(config = list()) {
   target_prefix = "AmazonPersonalize"
 )
 
-.personalize$handlers <- new_handlers("jsonrpc", "v4")
-
 .personalize$service <- function(config = list()) {
-  new_service(.personalize$metadata, .personalize$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.personalize$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/personalizeevents_service.R
+++ b/cran/paws.machine.learning/R/personalizeevents_service.R
@@ -62,8 +62,7 @@ personalizeevents <- function(config = list()) {
   target_prefix = ""
 )
 
-.personalizeevents$handlers <- new_handlers("restjson", "v4")
-
 .personalizeevents$service <- function(config = list()) {
-  new_service(.personalizeevents$metadata, .personalizeevents$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.personalizeevents$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/personalizeruntime_service.R
+++ b/cran/paws.machine.learning/R/personalizeruntime_service.R
@@ -63,8 +63,7 @@ personalizeruntime <- function(config = list()) {
   target_prefix = ""
 )
 
-.personalizeruntime$handlers <- new_handlers("restjson", "v4")
-
 .personalizeruntime$service <- function(config = list()) {
-  new_service(.personalizeruntime$metadata, .personalizeruntime$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.personalizeruntime$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/polly_service.R
+++ b/cran/paws.machine.learning/R/polly_service.R
@@ -78,8 +78,7 @@ polly <- function(config = list()) {
   target_prefix = ""
 )
 
-.polly$handlers <- new_handlers("restjson", "v4")
-
 .polly$service <- function(config = list()) {
-  new_service(.polly$metadata, .polly$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.polly$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/rekognition_service.R
+++ b/cran/paws.machine.learning/R/rekognition_service.R
@@ -117,8 +117,7 @@ rekognition <- function(config = list()) {
   target_prefix = "RekognitionService"
 )
 
-.rekognition$handlers <- new_handlers("jsonrpc", "v4")
-
 .rekognition$service <- function(config = list()) {
-  new_service(.rekognition$metadata, .rekognition$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.rekognition$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/sagemaker_service.R
+++ b/cran/paws.machine.learning/R/sagemaker_service.R
@@ -193,8 +193,7 @@ sagemaker <- function(config = list()) {
   target_prefix = "SageMaker"
 )
 
-.sagemaker$handlers <- new_handlers("jsonrpc", "v4")
-
 .sagemaker$service <- function(config = list()) {
-  new_service(.sagemaker$metadata, .sagemaker$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.sagemaker$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/sagemakerruntime_service.R
+++ b/cran/paws.machine.learning/R/sagemakerruntime_service.R
@@ -63,8 +63,7 @@ sagemakerruntime <- function(config = list()) {
   target_prefix = ""
 )
 
-.sagemakerruntime$handlers <- new_handlers("restjson", "v4")
-
 .sagemakerruntime$service <- function(config = list()) {
-  new_service(.sagemakerruntime$metadata, .sagemakerruntime$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.sagemakerruntime$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/textract_service.R
+++ b/cran/paws.machine.learning/R/textract_service.R
@@ -70,8 +70,7 @@ textract <- function(config = list()) {
   target_prefix = "Textract"
 )
 
-.textract$handlers <- new_handlers("jsonrpc", "v4")
-
 .textract$service <- function(config = list()) {
-  new_service(.textract$metadata, .textract$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.textract$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/transcribeservice_service.R
+++ b/cran/paws.machine.learning/R/transcribeservice_service.R
@@ -76,8 +76,7 @@ transcribeservice <- function(config = list()) {
   target_prefix = "Transcribe"
 )
 
-.transcribeservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .transcribeservice$service <- function(config = list()) {
-  new_service(.transcribeservice$metadata, .transcribeservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.transcribeservice$metadata, handlers, config)
 }

--- a/cran/paws.machine.learning/R/translate_service.R
+++ b/cran/paws.machine.learning/R/translate_service.R
@@ -72,8 +72,7 @@ translate <- function(config = list()) {
   target_prefix = "AWSShineFrontendService_20170701"
 )
 
-.translate$handlers <- new_handlers("jsonrpc", "v4")
-
 .translate$service <- function(config = list()) {
-  new_service(.translate$metadata, .translate$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.translate$metadata, handlers, config)
 }

--- a/cran/paws.management/R/applicationautoscaling_service.R
+++ b/cran/paws.management/R/applicationautoscaling_service.R
@@ -126,8 +126,7 @@ applicationautoscaling <- function(config = list()) {
   target_prefix = "AnyScaleFrontendService"
 )
 
-.applicationautoscaling$handlers <- new_handlers("jsonrpc", "v4")
-
 .applicationautoscaling$service <- function(config = list()) {
-  new_service(.applicationautoscaling$metadata, .applicationautoscaling$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.applicationautoscaling$metadata, handlers, config)
 }

--- a/cran/paws.management/R/applicationinsights_service.R
+++ b/cran/paws.management/R/applicationinsights_service.R
@@ -105,8 +105,7 @@ applicationinsights <- function(config = list()) {
   target_prefix = "EC2WindowsBarleyService"
 )
 
-.applicationinsights$handlers <- new_handlers("jsonrpc", "v4")
-
 .applicationinsights$service <- function(config = list()) {
-  new_service(.applicationinsights$metadata, .applicationinsights$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.applicationinsights$metadata, handlers, config)
 }

--- a/cran/paws.management/R/autoscaling_service.R
+++ b/cran/paws.management/R/autoscaling_service.R
@@ -131,8 +131,7 @@ autoscaling <- function(config = list()) {
   target_prefix = ""
 )
 
-.autoscaling$handlers <- new_handlers("query", "v4")
-
 .autoscaling$service <- function(config = list()) {
-  new_service(.autoscaling$metadata, .autoscaling$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.autoscaling$metadata, handlers, config)
 }

--- a/cran/paws.management/R/autoscalingplans_service.R
+++ b/cran/paws.management/R/autoscalingplans_service.R
@@ -82,8 +82,7 @@ autoscalingplans <- function(config = list()) {
   target_prefix = "AnyScaleScalingPlannerFrontendService"
 )
 
-.autoscalingplans$handlers <- new_handlers("jsonrpc", "v4")
-
 .autoscalingplans$service <- function(config = list()) {
-  new_service(.autoscalingplans$metadata, .autoscalingplans$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.autoscalingplans$metadata, handlers, config)
 }

--- a/cran/paws.management/R/cloudformation_service.R
+++ b/cran/paws.management/R/cloudformation_service.R
@@ -137,8 +137,7 @@ cloudformation <- function(config = list()) {
   target_prefix = ""
 )
 
-.cloudformation$handlers <- new_handlers("query", "v4")
-
 .cloudformation$service <- function(config = list()) {
-  new_service(.cloudformation$metadata, .cloudformation$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.cloudformation$metadata, handlers, config)
 }

--- a/cran/paws.management/R/cloudtrail_service.R
+++ b/cran/paws.management/R/cloudtrail_service.R
@@ -102,8 +102,7 @@ cloudtrail <- function(config = list()) {
   target_prefix = "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101"
 )
 
-.cloudtrail$handlers <- new_handlers("jsonrpc", "v4")
-
 .cloudtrail$service <- function(config = list()) {
-  new_service(.cloudtrail$metadata, .cloudtrail$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cloudtrail$metadata, handlers, config)
 }

--- a/cran/paws.management/R/cloudwatch_service.R
+++ b/cran/paws.management/R/cloudwatch_service.R
@@ -106,8 +106,7 @@ cloudwatch <- function(config = list()) {
   target_prefix = ""
 )
 
-.cloudwatch$handlers <- new_handlers("query", "v4")
-
 .cloudwatch$service <- function(config = list()) {
-  new_service(.cloudwatch$metadata, .cloudwatch$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.cloudwatch$metadata, handlers, config)
 }

--- a/cran/paws.management/R/cloudwatchevents_service.R
+++ b/cran/paws.management/R/cloudwatchevents_service.R
@@ -113,8 +113,7 @@ cloudwatchevents <- function(config = list()) {
   target_prefix = "AWSEvents"
 )
 
-.cloudwatchevents$handlers <- new_handlers("jsonrpc", "v4")
-
 .cloudwatchevents$service <- function(config = list()) {
-  new_service(.cloudwatchevents$metadata, .cloudwatchevents$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cloudwatchevents$metadata, handlers, config)
 }

--- a/cran/paws.management/R/cloudwatchlogs_service.R
+++ b/cran/paws.management/R/cloudwatchlogs_service.R
@@ -133,8 +133,7 @@ cloudwatchlogs <- function(config = list()) {
   target_prefix = "Logs_20140328"
 )
 
-.cloudwatchlogs$handlers <- new_handlers("jsonrpc", "v4")
-
 .cloudwatchlogs$service <- function(config = list()) {
-  new_service(.cloudwatchlogs$metadata, .cloudwatchlogs$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cloudwatchlogs$metadata, handlers, config)
 }

--- a/cran/paws.management/R/configservice_service.R
+++ b/cran/paws.management/R/configservice_service.R
@@ -162,8 +162,7 @@ configservice <- function(config = list()) {
   target_prefix = "StarlingDoveService"
 )
 
-.configservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .configservice$service <- function(config = list()) {
-  new_service(.configservice$metadata, .configservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.configservice$metadata, handlers, config)
 }

--- a/cran/paws.management/R/health_service.R
+++ b/cran/paws.management/R/health_service.R
@@ -146,8 +146,7 @@ health <- function(config = list()) {
   target_prefix = "AWSHealth_20160804"
 )
 
-.health$handlers <- new_handlers("jsonrpc", "v4")
-
 .health$service <- function(config = list()) {
-  new_service(.health$metadata, .health$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.health$metadata, handlers, config)
 }

--- a/cran/paws.management/R/licensemanager_service.R
+++ b/cran/paws.management/R/licensemanager_service.R
@@ -79,8 +79,7 @@ licensemanager <- function(config = list()) {
   target_prefix = "AWSLicenseManager"
 )
 
-.licensemanager$handlers <- new_handlers("jsonrpc", "v4")
-
 .licensemanager$service <- function(config = list()) {
-  new_service(.licensemanager$metadata, .licensemanager$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.licensemanager$metadata, handlers, config)
 }

--- a/cran/paws.management/R/opsworks_service.R
+++ b/cran/paws.management/R/opsworks_service.R
@@ -219,8 +219,7 @@ opsworks <- function(config = list()) {
   target_prefix = "OpsWorks_20130218"
 )
 
-.opsworks$handlers <- new_handlers("jsonrpc", "v4")
-
 .opsworks$service <- function(config = list()) {
-  new_service(.opsworks$metadata, .opsworks$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.opsworks$metadata, handlers, config)
 }

--- a/cran/paws.management/R/opsworkscm_service.R
+++ b/cran/paws.management/R/opsworkscm_service.R
@@ -145,8 +145,7 @@ opsworkscm <- function(config = list()) {
   target_prefix = "OpsWorksCM_V2016_11_01"
 )
 
-.opsworkscm$handlers <- new_handlers("jsonrpc", "v4")
-
 .opsworkscm$service <- function(config = list()) {
-  new_service(.opsworkscm$metadata, .opsworkscm$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.opsworkscm$metadata, handlers, config)
 }

--- a/cran/paws.management/R/organizations_service.R
+++ b/cran/paws.management/R/organizations_service.R
@@ -113,8 +113,7 @@ organizations <- function(config = list()) {
   target_prefix = "AWSOrganizationsV20161128"
 )
 
-.organizations$handlers <- new_handlers("jsonrpc", "v4")
-
 .organizations$service <- function(config = list()) {
-  new_service(.organizations$metadata, .organizations$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.organizations$metadata, handlers, config)
 }

--- a/cran/paws.management/R/pi_service.R
+++ b/cran/paws.management/R/pi_service.R
@@ -82,8 +82,7 @@ pi <- function(config = list()) {
   target_prefix = "PerformanceInsightsv20180227"
 )
 
-.pi$handlers <- new_handlers("jsonrpc", "v4")
-
 .pi$service <- function(config = list()) {
-  new_service(.pi$metadata, .pi$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.pi$metadata, handlers, config)
 }

--- a/cran/paws.management/R/resourcegroups_service.R
+++ b/cran/paws.management/R/resourcegroups_service.R
@@ -109,8 +109,7 @@ resourcegroups <- function(config = list()) {
   target_prefix = ""
 )
 
-.resourcegroups$handlers <- new_handlers("restjson", "v4")
-
 .resourcegroups$service <- function(config = list()) {
-  new_service(.resourcegroups$metadata, .resourcegroups$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.resourcegroups$metadata, handlers, config)
 }

--- a/cran/paws.management/R/resourcegroupstaggingapi_service.R
+++ b/cran/paws.management/R/resourcegroupstaggingapi_service.R
@@ -297,8 +297,7 @@ resourcegroupstaggingapi <- function(config = list()) {
   target_prefix = "ResourceGroupsTaggingAPI_20170126"
 )
 
-.resourcegroupstaggingapi$handlers <- new_handlers("jsonrpc", "v4")
-
 .resourcegroupstaggingapi$service <- function(config = list()) {
-  new_service(.resourcegroupstaggingapi$metadata, .resourcegroupstaggingapi$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.resourcegroupstaggingapi$metadata, handlers, config)
 }

--- a/cran/paws.management/R/servicecatalog_service.R
+++ b/cran/paws.management/R/servicecatalog_service.R
@@ -150,8 +150,7 @@ servicecatalog <- function(config = list()) {
   target_prefix = "AWS242ServiceCatalogService"
 )
 
-.servicecatalog$handlers <- new_handlers("jsonrpc", "v4")
-
 .servicecatalog$service <- function(config = list()) {
-  new_service(.servicecatalog$metadata, .servicecatalog$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.servicecatalog$metadata, handlers, config)
 }

--- a/cran/paws.management/R/servicequotas_service.R
+++ b/cran/paws.management/R/servicequotas_service.R
@@ -91,8 +91,7 @@ servicequotas <- function(config = list()) {
   target_prefix = "ServiceQuotasV20190624"
 )
 
-.servicequotas$handlers <- new_handlers("jsonrpc", "v4")
-
 .servicequotas$service <- function(config = list()) {
-  new_service(.servicequotas$metadata, .servicequotas$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.servicequotas$metadata, handlers, config)
 }

--- a/cran/paws.management/R/ssm_service.R
+++ b/cran/paws.management/R/ssm_service.R
@@ -207,8 +207,7 @@ ssm <- function(config = list()) {
   target_prefix = "AmazonSSM"
 )
 
-.ssm$handlers <- new_handlers("jsonrpc", "v4")
-
 .ssm$service <- function(config = list()) {
-  new_service(.ssm$metadata, .ssm$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.ssm$metadata, handlers, config)
 }

--- a/cran/paws.management/R/support_service.R
+++ b/cran/paws.management/R/support_service.R
@@ -133,8 +133,7 @@ support <- function(config = list()) {
   target_prefix = "AWSSupport_20130415"
 )
 
-.support$handlers <- new_handlers("jsonrpc", "v4")
-
 .support$service <- function(config = list()) {
-  new_service(.support$metadata, .support$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.support$metadata, handlers, config)
 }

--- a/cran/paws.media.services/R/elastictranscoder_service.R
+++ b/cran/paws.media.services/R/elastictranscoder_service.R
@@ -81,8 +81,7 @@ elastictranscoder <- function(config = list()) {
   target_prefix = ""
 )
 
-.elastictranscoder$handlers <- new_handlers("restjson", "v4")
-
 .elastictranscoder$service <- function(config = list()) {
-  new_service(.elastictranscoder$metadata, .elastictranscoder$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.elastictranscoder$metadata, handlers, config)
 }

--- a/cran/paws.media.services/R/kinesisvideo_service.R
+++ b/cran/paws.media.services/R/kinesisvideo_service.R
@@ -80,8 +80,7 @@ kinesisvideo <- function(config = list()) {
   target_prefix = ""
 )
 
-.kinesisvideo$handlers <- new_handlers("restjson", "v4")
-
 .kinesisvideo$service <- function(config = list()) {
-  new_service(.kinesisvideo$metadata, .kinesisvideo$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.kinesisvideo$metadata, handlers, config)
 }

--- a/cran/paws.media.services/R/kinesisvideoarchivedmedia_service.R
+++ b/cran/paws.media.services/R/kinesisvideoarchivedmedia_service.R
@@ -65,8 +65,7 @@ kinesisvideoarchivedmedia <- function(config = list()) {
   target_prefix = ""
 )
 
-.kinesisvideoarchivedmedia$handlers <- new_handlers("restjson", "v4")
-
 .kinesisvideoarchivedmedia$service <- function(config = list()) {
-  new_service(.kinesisvideoarchivedmedia$metadata, .kinesisvideoarchivedmedia$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.kinesisvideoarchivedmedia$metadata, handlers, config)
 }

--- a/cran/paws.media.services/R/kinesisvideomedia_service.R
+++ b/cran/paws.media.services/R/kinesisvideomedia_service.R
@@ -62,8 +62,7 @@ kinesisvideomedia <- function(config = list()) {
   target_prefix = ""
 )
 
-.kinesisvideomedia$handlers <- new_handlers("restjson", "v4")
-
 .kinesisvideomedia$service <- function(config = list()) {
-  new_service(.kinesisvideomedia$metadata, .kinesisvideomedia$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.kinesisvideomedia$metadata, handlers, config)
 }

--- a/cran/paws.media.services/R/mediaconnect_service.R
+++ b/cran/paws.media.services/R/mediaconnect_service.R
@@ -79,8 +79,7 @@ mediaconnect <- function(config = list()) {
   target_prefix = ""
 )
 
-.mediaconnect$handlers <- new_handlers("restjson", "v4")
-
 .mediaconnect$service <- function(config = list()) {
-  new_service(.mediaconnect$metadata, .mediaconnect$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mediaconnect$metadata, handlers, config)
 }

--- a/cran/paws.media.services/R/mediaconvert_service.R
+++ b/cran/paws.media.services/R/mediaconvert_service.R
@@ -87,8 +87,7 @@ mediaconvert <- function(config = list()) {
   target_prefix = ""
 )
 
-.mediaconvert$handlers <- new_handlers("restjson", "v4")
-
 .mediaconvert$service <- function(config = list()) {
-  new_service(.mediaconvert$metadata, .mediaconvert$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mediaconvert$metadata, handlers, config)
 }

--- a/cran/paws.media.services/R/medialive_service.R
+++ b/cran/paws.media.services/R/medialive_service.R
@@ -105,8 +105,7 @@ medialive <- function(config = list()) {
   target_prefix = ""
 )
 
-.medialive$handlers <- new_handlers("restjson", "v4")
-
 .medialive$service <- function(config = list()) {
-  new_service(.medialive$metadata, .medialive$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.medialive$metadata, handlers, config)
 }

--- a/cran/paws.media.services/R/mediapackage_service.R
+++ b/cran/paws.media.services/R/mediapackage_service.R
@@ -80,8 +80,7 @@ mediapackage <- function(config = list()) {
   target_prefix = ""
 )
 
-.mediapackage$handlers <- new_handlers("restjson", "v4")
-
 .mediapackage$service <- function(config = list()) {
-  new_service(.mediapackage$metadata, .mediapackage$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mediapackage$metadata, handlers, config)
 }

--- a/cran/paws.media.services/R/mediastore_service.R
+++ b/cran/paws.media.services/R/mediastore_service.R
@@ -82,8 +82,7 @@ mediastore <- function(config = list()) {
   target_prefix = "MediaStore_20170901"
 )
 
-.mediastore$handlers <- new_handlers("jsonrpc", "v4")
-
 .mediastore$service <- function(config = list()) {
-  new_service(.mediastore$metadata, .mediastore$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.mediastore$metadata, handlers, config)
 }

--- a/cran/paws.media.services/R/mediastoredata_service.R
+++ b/cran/paws.media.services/R/mediastoredata_service.R
@@ -69,8 +69,7 @@ mediastoredata <- function(config = list()) {
   target_prefix = ""
 )
 
-.mediastoredata$handlers <- new_handlers("restjson", "v4")
-
 .mediastoredata$service <- function(config = list()) {
-  new_service(.mediastoredata$metadata, .mediastoredata$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mediastoredata$metadata, handlers, config)
 }

--- a/cran/paws.media.services/R/mediatailor_service.R
+++ b/cran/paws.media.services/R/mediatailor_service.R
@@ -79,8 +79,7 @@ mediatailor <- function(config = list()) {
   target_prefix = ""
 )
 
-.mediatailor$handlers <- new_handlers("restjson", "v4")
-
 .mediatailor$service <- function(config = list()) {
-  new_service(.mediatailor$metadata, .mediatailor$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mediatailor$metadata, handlers, config)
 }

--- a/cran/paws.migration/R/applicationdiscoveryservice_service.R
+++ b/cran/paws.migration/R/applicationdiscoveryservice_service.R
@@ -154,8 +154,7 @@ applicationdiscoveryservice <- function(config = list()) {
   target_prefix = "AWSPoseidonService_V2015_11_01"
 )
 
-.applicationdiscoveryservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .applicationdiscoveryservice$service <- function(config = list()) {
-  new_service(.applicationdiscoveryservice$metadata, .applicationdiscoveryservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.applicationdiscoveryservice$metadata, handlers, config)
 }

--- a/cran/paws.migration/R/databasemigrationservice_service.R
+++ b/cran/paws.migration/R/databasemigrationservice_service.R
@@ -130,8 +130,7 @@ databasemigrationservice <- function(config = list()) {
   target_prefix = "AmazonDMSv20160101"
 )
 
-.databasemigrationservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .databasemigrationservice$service <- function(config = list()) {
-  new_service(.databasemigrationservice$metadata, .databasemigrationservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.databasemigrationservice$metadata, handlers, config)
 }

--- a/cran/paws.migration/R/datasync_service.R
+++ b/cran/paws.migration/R/datasync_service.R
@@ -95,8 +95,7 @@ datasync <- function(config = list()) {
   target_prefix = "FmrsService"
 )
 
-.datasync$handlers <- new_handlers("jsonrpc", "v4")
-
 .datasync$service <- function(config = list()) {
-  new_service(.datasync$metadata, .datasync$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.datasync$metadata, handlers, config)
 }

--- a/cran/paws.migration/R/importexport_service.R
+++ b/cran/paws.migration/R/importexport_service.R
@@ -74,8 +74,7 @@ importexport <- function(config = list()) {
   target_prefix = ""
 )
 
-.importexport$handlers <- new_handlers("query", "v2")
-
 .importexport$service <- function(config = list()) {
-  new_service(.importexport$metadata, .importexport$handlers, config)
+  handlers <- new_handlers("query", "v2")
+  new_service(.importexport$metadata, handlers, config)
 }

--- a/cran/paws.migration/R/migrationhub_service.R
+++ b/cran/paws.migration/R/migrationhub_service.R
@@ -85,8 +85,7 @@ migrationhub <- function(config = list()) {
   target_prefix = "AWSMigrationHub"
 )
 
-.migrationhub$handlers <- new_handlers("jsonrpc", "v4")
-
 .migrationhub$service <- function(config = list()) {
-  new_service(.migrationhub$metadata, .migrationhub$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.migrationhub$metadata, handlers, config)
 }

--- a/cran/paws.migration/R/sms_service.R
+++ b/cran/paws.migration/R/sms_service.R
@@ -109,8 +109,7 @@ sms <- function(config = list()) {
   target_prefix = "AWSServerMigrationService_V2016_10_24"
 )
 
-.sms$handlers <- new_handlers("jsonrpc", "v4")
-
 .sms$service <- function(config = list()) {
-  new_service(.sms$metadata, .sms$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.sms$metadata, handlers, config)
 }

--- a/cran/paws.migration/R/snowball_service.R
+++ b/cran/paws.migration/R/snowball_service.R
@@ -92,8 +92,7 @@ snowball <- function(config = list()) {
   target_prefix = "AWSIESnowballJobManagementService"
 )
 
-.snowball$handlers <- new_handlers("jsonrpc", "v4")
-
 .snowball$service <- function(config = list()) {
-  new_service(.snowball$metadata, .snowball$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.snowball$metadata, handlers, config)
 }

--- a/cran/paws.migration/R/transfer_service.R
+++ b/cran/paws.migration/R/transfer_service.R
@@ -90,8 +90,7 @@ transfer <- function(config = list()) {
   target_prefix = "TransferService"
 )
 
-.transfer$handlers <- new_handlers("jsonrpc", "v4")
-
 .transfer$service <- function(config = list()) {
-  new_service(.transfer$metadata, .transfer$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.transfer$metadata, handlers, config)
 }

--- a/cran/paws.mobile/R/amplify_service.R
+++ b/cran/paws.mobile/R/amplify_service.R
@@ -100,8 +100,7 @@ amplify <- function(config = list()) {
   target_prefix = ""
 )
 
-.amplify$handlers <- new_handlers("restjson", "v4")
-
 .amplify$service <- function(config = list()) {
-  new_service(.amplify$metadata, .amplify$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.amplify$metadata, handlers, config)
 }

--- a/cran/paws.mobile/R/appsync_service.R
+++ b/cran/paws.mobile/R/appsync_service.R
@@ -104,8 +104,7 @@ appsync <- function(config = list()) {
   target_prefix = ""
 )
 
-.appsync$handlers <- new_handlers("restjson", "v4")
-
 .appsync$service <- function(config = list()) {
-  new_service(.appsync$metadata, .appsync$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.appsync$metadata, handlers, config)
 }

--- a/cran/paws.mobile/R/devicefarm_service.R
+++ b/cran/paws.mobile/R/devicefarm_service.R
@@ -160,8 +160,7 @@ devicefarm <- function(config = list()) {
   target_prefix = "DeviceFarm_20150623"
 )
 
-.devicefarm$handlers <- new_handlers("jsonrpc", "v4")
-
 .devicefarm$service <- function(config = list()) {
-  new_service(.devicefarm$metadata, .devicefarm$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.devicefarm$metadata, handlers, config)
 }

--- a/cran/paws.mobile/R/mobile_service.R
+++ b/cran/paws.mobile/R/mobile_service.R
@@ -74,8 +74,7 @@ mobile <- function(config = list()) {
   target_prefix = ""
 )
 
-.mobile$handlers <- new_handlers("restjson", "v4")
-
 .mobile$service <- function(config = list()) {
-  new_service(.mobile$metadata, .mobile$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mobile$metadata, handlers, config)
 }

--- a/cran/paws.mobile/R/mobileanalytics_service.R
+++ b/cran/paws.mobile/R/mobileanalytics_service.R
@@ -64,8 +64,7 @@ mobileanalytics <- function(config = list()) {
   target_prefix = ""
 )
 
-.mobileanalytics$handlers <- new_handlers("restjson", "v4")
-
 .mobileanalytics$service <- function(config = list()) {
-  new_service(.mobileanalytics$metadata, .mobileanalytics$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mobileanalytics$metadata, handlers, config)
 }

--- a/cran/paws.networking/R/apigateway_service.R
+++ b/cran/paws.networking/R/apigateway_service.R
@@ -186,8 +186,7 @@ apigateway <- function(config = list()) {
   target_prefix = ""
 )
 
-.apigateway$handlers <- new_handlers("restjson", "v4")
-
 .apigateway$service <- function(config = list()) {
-  new_service(.apigateway$metadata, .apigateway$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.apigateway$metadata, handlers, config)
 }

--- a/cran/paws.networking/R/apigatewaymanagementapi_service.R
+++ b/cran/paws.networking/R/apigatewaymanagementapi_service.R
@@ -71,8 +71,7 @@ apigatewaymanagementapi <- function(config = list()) {
   target_prefix = ""
 )
 
-.apigatewaymanagementapi$handlers <- new_handlers("restjson", "v4")
-
 .apigatewaymanagementapi$service <- function(config = list()) {
-  new_service(.apigatewaymanagementapi$metadata, .apigatewaymanagementapi$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.apigatewaymanagementapi$metadata, handlers, config)
 }

--- a/cran/paws.networking/R/apigatewayv2_service.R
+++ b/cran/paws.networking/R/apigatewayv2_service.R
@@ -125,8 +125,7 @@ apigatewayv2 <- function(config = list()) {
   target_prefix = ""
 )
 
-.apigatewayv2$handlers <- new_handlers("restjson", "v4")
-
 .apigatewayv2$service <- function(config = list()) {
-  new_service(.apigatewayv2$metadata, .apigatewayv2$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.apigatewayv2$metadata, handlers, config)
 }

--- a/cran/paws.networking/R/appmesh_service.R
+++ b/cran/paws.networking/R/appmesh_service.R
@@ -107,8 +107,7 @@ appmesh <- function(config = list()) {
   target_prefix = ""
 )
 
-.appmesh$handlers <- new_handlers("restjson", "v4")
-
 .appmesh$service <- function(config = list()) {
-  new_service(.appmesh$metadata, .appmesh$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.appmesh$metadata, handlers, config)
 }

--- a/cran/paws.networking/R/cloudfront_service.R
+++ b/cran/paws.networking/R/cloudfront_service.R
@@ -110,8 +110,7 @@ cloudfront <- function(config = list()) {
   target_prefix = ""
 )
 
-.cloudfront$handlers <- new_handlers("restxml", "v4")
-
 .cloudfront$service <- function(config = list()) {
-  new_service(.cloudfront$metadata, .cloudfront$handlers, config)
+  handlers <- new_handlers("restxml", "v4")
+  new_service(.cloudfront$metadata, handlers, config)
 }

--- a/cran/paws.networking/R/directconnect_service.R
+++ b/cran/paws.networking/R/directconnect_service.R
@@ -124,8 +124,7 @@ directconnect <- function(config = list()) {
   target_prefix = "OvertureService"
 )
 
-.directconnect$handlers <- new_handlers("jsonrpc", "v4")
-
 .directconnect$service <- function(config = list()) {
-  new_service(.directconnect$metadata, .directconnect$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.directconnect$metadata, handlers, config)
 }

--- a/cran/paws.networking/R/elb_service.R
+++ b/cran/paws.networking/R/elb_service.R
@@ -130,8 +130,7 @@ elb <- function(config = list()) {
   target_prefix = ""
 )
 
-.elb$handlers <- new_handlers("query", "v4")
-
 .elb$service <- function(config = list()) {
-  new_service(.elb$metadata, .elb$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.elb$metadata, handlers, config)
 }

--- a/cran/paws.networking/R/elbv2_service.R
+++ b/cran/paws.networking/R/elbv2_service.R
@@ -135,8 +135,7 @@ elbv2 <- function(config = list()) {
   target_prefix = ""
 )
 
-.elbv2$handlers <- new_handlers("query", "v4")
-
 .elbv2$service <- function(config = list()) {
-  new_service(.elbv2$metadata, .elbv2$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.elbv2$metadata, handlers, config)
 }

--- a/cran/paws.networking/R/globalaccelerator_service.R
+++ b/cran/paws.networking/R/globalaccelerator_service.R
@@ -165,8 +165,7 @@ globalaccelerator <- function(config = list()) {
   target_prefix = "GlobalAccelerator_V20180706"
 )
 
-.globalaccelerator$handlers <- new_handlers("jsonrpc", "v4")
-
 .globalaccelerator$service <- function(config = list()) {
-  new_service(.globalaccelerator$metadata, .globalaccelerator$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.globalaccelerator$metadata, handlers, config)
 }

--- a/cran/paws.networking/R/route53_service.R
+++ b/cran/paws.networking/R/route53_service.R
@@ -126,8 +126,7 @@ route53 <- function(config = list()) {
   target_prefix = ""
 )
 
-.route53$handlers <- new_handlers("restxml", "v4")
-
 .route53$service <- function(config = list()) {
-  new_service(.route53$metadata, .route53$handlers, config)
+  handlers <- new_handlers("restxml", "v4")
+  new_service(.route53$metadata, handlers, config)
 }

--- a/cran/paws.networking/R/route53domains_service.R
+++ b/cran/paws.networking/R/route53domains_service.R
@@ -87,8 +87,7 @@ route53domains <- function(config = list()) {
   target_prefix = "Route53Domains_v20140515"
 )
 
-.route53domains$handlers <- new_handlers("jsonrpc", "v4")
-
 .route53domains$service <- function(config = list()) {
-  new_service(.route53domains$metadata, .route53domains$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.route53domains$metadata, handlers, config)
 }

--- a/cran/paws.networking/R/route53resolver_service.R
+++ b/cran/paws.networking/R/route53resolver_service.R
@@ -116,8 +116,7 @@ route53resolver <- function(config = list()) {
   target_prefix = "Route53Resolver"
 )
 
-.route53resolver$handlers <- new_handlers("jsonrpc", "v4")
-
 .route53resolver$service <- function(config = list()) {
-  new_service(.route53resolver$metadata, .route53resolver$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.route53resolver$metadata, handlers, config)
 }

--- a/cran/paws.networking/R/servicediscovery_service.R
+++ b/cran/paws.networking/R/servicediscovery_service.R
@@ -89,8 +89,7 @@ servicediscovery <- function(config = list()) {
   target_prefix = "Route53AutoNaming_v20170314"
 )
 
-.servicediscovery$handlers <- new_handlers("jsonrpc", "v4")
-
 .servicediscovery$service <- function(config = list()) {
-  new_service(.servicediscovery$metadata, .servicediscovery$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.servicediscovery$metadata, handlers, config)
 }

--- a/cran/paws.robotics/R/robomaker_service.R
+++ b/cran/paws.robotics/R/robomaker_service.R
@@ -99,8 +99,7 @@ robomaker <- function(config = list()) {
   target_prefix = ""
 )
 
-.robomaker$handlers <- new_handlers("restjson", "v4")
-
 .robomaker$service <- function(config = list()) {
-  new_service(.robomaker$metadata, .robomaker$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.robomaker$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/acm_service.R
+++ b/cran/paws.security.identity/R/acm_service.R
@@ -80,8 +80,7 @@ acm <- function(config = list()) {
   target_prefix = "CertificateManager"
 )
 
-.acm$handlers <- new_handlers("jsonrpc", "v4")
-
 .acm$service <- function(config = list()) {
-  new_service(.acm$metadata, .acm$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.acm$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/acmpca_service.R
+++ b/cran/paws.security.identity/R/acmpca_service.R
@@ -97,8 +97,7 @@ acmpca <- function(config = list()) {
   target_prefix = "ACMPrivateCA"
 )
 
-.acmpca$handlers <- new_handlers("jsonrpc", "v4")
-
 .acmpca$service <- function(config = list()) {
-  new_service(.acmpca$metadata, .acmpca$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.acmpca$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/clouddirectory_service.R
+++ b/cran/paws.security.identity/R/clouddirectory_service.R
@@ -138,8 +138,7 @@ clouddirectory <- function(config = list()) {
   target_prefix = ""
 )
 
-.clouddirectory$handlers <- new_handlers("restjson", "v4")
-
 .clouddirectory$service <- function(config = list()) {
-  new_service(.clouddirectory$metadata, .clouddirectory$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.clouddirectory$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/cloudhsm_service.R
+++ b/cran/paws.security.identity/R/cloudhsm_service.R
@@ -96,8 +96,7 @@ cloudhsm <- function(config = list()) {
   target_prefix = "CloudHsmFrontendService"
 )
 
-.cloudhsm$handlers <- new_handlers("jsonrpc", "v4")
-
 .cloudhsm$service <- function(config = list()) {
-  new_service(.cloudhsm$metadata, .cloudhsm$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cloudhsm$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/cloudhsmv2_service.R
+++ b/cran/paws.security.identity/R/cloudhsmv2_service.R
@@ -77,8 +77,7 @@ cloudhsmv2 <- function(config = list()) {
   target_prefix = "BaldrApiService"
 )
 
-.cloudhsmv2$handlers <- new_handlers("jsonrpc", "v4")
-
 .cloudhsmv2$service <- function(config = list()) {
-  new_service(.cloudhsmv2$metadata, .cloudhsmv2$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cloudhsmv2$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/cognitoidentity_service.R
+++ b/cran/paws.security.identity/R/cognitoidentity_service.R
@@ -103,8 +103,7 @@ cognitoidentity <- function(config = list()) {
   target_prefix = "AWSCognitoIdentityService"
 )
 
-.cognitoidentity$handlers <- new_handlers("jsonrpc", "v4")
-
 .cognitoidentity$service <- function(config = list()) {
-  new_service(.cognitoidentity$metadata, .cognitoidentity$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cognitoidentity$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/cognitoidentityprovider_service.R
+++ b/cran/paws.security.identity/R/cognitoidentityprovider_service.R
@@ -169,8 +169,7 @@ cognitoidentityprovider <- function(config = list()) {
   target_prefix = "AWSCognitoIdentityProviderService"
 )
 
-.cognitoidentityprovider$handlers <- new_handlers("jsonrpc", "v4")
-
 .cognitoidentityprovider$service <- function(config = list()) {
-  new_service(.cognitoidentityprovider$metadata, .cognitoidentityprovider$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cognitoidentityprovider$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/cognitosync_service.R
+++ b/cran/paws.security.identity/R/cognitosync_service.R
@@ -100,8 +100,7 @@ cognitosync <- function(config = list()) {
   target_prefix = ""
 )
 
-.cognitosync$handlers <- new_handlers("restjson", "v4")
-
 .cognitosync$service <- function(config = list()) {
-  new_service(.cognitosync$metadata, .cognitosync$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.cognitosync$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/directoryservice_service.R
+++ b/cran/paws.security.identity/R/directoryservice_service.R
@@ -134,8 +134,7 @@ directoryservice <- function(config = list()) {
   target_prefix = "DirectoryService_20150416"
 )
 
-.directoryservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .directoryservice$service <- function(config = list()) {
-  new_service(.directoryservice$metadata, .directoryservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.directoryservice$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/fms_service.R
+++ b/cran/paws.security.identity/R/fms_service.R
@@ -85,8 +85,7 @@ fms <- function(config = list()) {
   target_prefix = "AWSFMS_20180101"
 )
 
-.fms$handlers <- new_handlers("jsonrpc", "v4")
-
 .fms$service <- function(config = list()) {
-  new_service(.fms$metadata, .fms$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.fms$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/guardduty_service.R
+++ b/cran/paws.security.identity/R/guardduty_service.R
@@ -128,8 +128,7 @@ guardduty <- function(config = list()) {
   target_prefix = ""
 )
 
-.guardduty$handlers <- new_handlers("restjson", "v4")
-
 .guardduty$service <- function(config = list()) {
-  new_service(.guardduty$metadata, .guardduty$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.guardduty$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/iam_service.R
+++ b/cran/paws.security.identity/R/iam_service.R
@@ -267,8 +267,7 @@ iam <- function(config = list()) {
   target_prefix = ""
 )
 
-.iam$handlers <- new_handlers("query", "v4")
-
 .iam$service <- function(config = list()) {
-  new_service(.iam$metadata, .iam$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.iam$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/inspector_service.R
+++ b/cran/paws.security.identity/R/inspector_service.R
@@ -112,8 +112,7 @@ inspector <- function(config = list()) {
   target_prefix = "InspectorService"
 )
 
-.inspector$handlers <- new_handlers("jsonrpc", "v4")
-
 .inspector$service <- function(config = list()) {
-  new_service(.inspector$metadata, .inspector$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.inspector$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/kms_service.R
+++ b/cran/paws.security.identity/R/kms_service.R
@@ -189,8 +189,7 @@ kms <- function(config = list()) {
   target_prefix = "TrentService"
 )
 
-.kms$handlers <- new_handlers("jsonrpc", "v4")
-
 .kms$service <- function(config = list()) {
-  new_service(.kms$metadata, .kms$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.kms$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/macie_service.R
+++ b/cran/paws.security.identity/R/macie_service.R
@@ -75,8 +75,7 @@ macie <- function(config = list()) {
   target_prefix = "MacieService"
 )
 
-.macie$handlers <- new_handlers("jsonrpc", "v4")
-
 .macie$service <- function(config = list()) {
-  new_service(.macie$metadata, .macie$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.macie$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/ram_service.R
+++ b/cran/paws.security.identity/R/ram_service.R
@@ -93,8 +93,7 @@ ram <- function(config = list()) {
   target_prefix = ""
 )
 
-.ram$handlers <- new_handlers("restjson", "v4")
-
 .ram$service <- function(config = list()) {
-  new_service(.ram$metadata, .ram$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.ram$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/secretsmanager_service.R
+++ b/cran/paws.security.identity/R/secretsmanager_service.R
@@ -154,8 +154,7 @@ secretsmanager <- function(config = list()) {
   target_prefix = "secretsmanager"
 )
 
-.secretsmanager$handlers <- new_handlers("jsonrpc", "v4")
-
 .secretsmanager$service <- function(config = list()) {
-  new_service(.secretsmanager$metadata, .secretsmanager$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.secretsmanager$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/securityhub_service.R
+++ b/cran/paws.security.identity/R/securityhub_service.R
@@ -133,8 +133,7 @@ securityhub <- function(config = list()) {
   target_prefix = ""
 )
 
-.securityhub$handlers <- new_handlers("restjson", "v4")
-
 .securityhub$service <- function(config = list()) {
-  new_service(.securityhub$metadata, .securityhub$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.securityhub$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/shield_service.R
+++ b/cran/paws.security.identity/R/shield_service.R
@@ -88,8 +88,7 @@ shield <- function(config = list()) {
   target_prefix = "AWSShield_20160616"
 )
 
-.shield$handlers <- new_handlers("jsonrpc", "v4")
-
 .shield$service <- function(config = list()) {
-  new_service(.shield$metadata, .shield$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.shield$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/sts_service.R
+++ b/cran/paws.security.identity/R/sts_service.R
@@ -187,8 +187,7 @@ sts <- function(config = list()) {
   target_prefix = ""
 )
 
-.sts$handlers <- new_handlers("query", "v4")
-
 .sts$service <- function(config = list()) {
-  new_service(.sts$metadata, .sts$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.sts$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/waf_service.R
+++ b/cran/paws.security.identity/R/waf_service.R
@@ -148,8 +148,7 @@ waf <- function(config = list()) {
   target_prefix = "AWSWAF_20150824"
 )
 
-.waf$handlers <- new_handlers("jsonrpc", "v4")
-
 .waf$service <- function(config = list()) {
-  new_service(.waf$metadata, .waf$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.waf$metadata, handlers, config)
 }

--- a/cran/paws.security.identity/R/wafregional_service.R
+++ b/cran/paws.security.identity/R/wafregional_service.R
@@ -154,8 +154,7 @@ wafregional <- function(config = list()) {
   target_prefix = "AWSWAF_Regional_20161128"
 )
 
-.wafregional$handlers <- new_handlers("jsonrpc", "v4")
-
 .wafregional$service <- function(config = list()) {
-  new_service(.wafregional$metadata, .wafregional$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.wafregional$metadata, handlers, config)
 }

--- a/cran/paws.storage/R/backup_service.R
+++ b/cran/paws.storage/R/backup_service.R
@@ -108,8 +108,7 @@ backup <- function(config = list()) {
   target_prefix = ""
 )
 
-.backup$handlers <- new_handlers("restjson", "v4")
-
 .backup$service <- function(config = list()) {
-  new_service(.backup$metadata, .backup$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.backup$metadata, handlers, config)
 }

--- a/cran/paws.storage/R/dlm_service.R
+++ b/cran/paws.storage/R/dlm_service.R
@@ -78,8 +78,7 @@ dlm <- function(config = list()) {
   target_prefix = ""
 )
 
-.dlm$handlers <- new_handlers("restjson", "v4")
-
 .dlm$service <- function(config = list()) {
-  new_service(.dlm$metadata, .dlm$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.dlm$metadata, handlers, config)
 }

--- a/cran/paws.storage/R/efs_service.R
+++ b/cran/paws.storage/R/efs_service.R
@@ -90,8 +90,7 @@ efs <- function(config = list()) {
   target_prefix = ""
 )
 
-.efs$handlers <- new_handlers("restjson", "v4")
-
 .efs$service <- function(config = list()) {
-  new_service(.efs$metadata, .efs$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.efs$metadata, handlers, config)
 }

--- a/cran/paws.storage/R/fsx_service.R
+++ b/cran/paws.storage/R/fsx_service.R
@@ -84,8 +84,7 @@ fsx <- function(config = list()) {
   target_prefix = "AWSSimbaAPIService_v20180301"
 )
 
-.fsx$handlers <- new_handlers("jsonrpc", "v4")
-
 .fsx$service <- function(config = list()) {
-  new_service(.fsx$metadata, .fsx$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.fsx$metadata, handlers, config)
 }

--- a/cran/paws.storage/R/glacier_service.R
+++ b/cran/paws.storage/R/glacier_service.R
@@ -133,8 +133,7 @@ glacier <- function(config = list()) {
   target_prefix = ""
 )
 
-.glacier$handlers <- new_handlers("restjson", "v4")
-
 .glacier$service <- function(config = list()) {
-  new_service(.glacier$metadata, .glacier$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.glacier$metadata, handlers, config)
 }

--- a/cran/paws.storage/R/s3_service.R
+++ b/cran/paws.storage/R/s3_service.R
@@ -152,8 +152,7 @@ s3 <- function(config = list()) {
   target_prefix = ""
 )
 
-.s3$handlers <- new_handlers("restxml", "s3")
-
 .s3$service <- function(config = list()) {
-  new_service(.s3$metadata, .s3$handlers, config)
+  handlers <- new_handlers("restxml", "s3")
+  new_service(.s3$metadata, handlers, config)
 }

--- a/cran/paws.storage/R/s3control_service.R
+++ b/cran/paws.storage/R/s3control_service.R
@@ -78,8 +78,7 @@ s3control <- function(config = list()) {
   target_prefix = ""
 )
 
-.s3control$handlers <- new_handlers("restxml", "s3v4")
-
 .s3control$service <- function(config = list()) {
-  new_service(.s3control$metadata, .s3control$handlers, config)
+  handlers <- new_handlers("restxml", "s3v4")
+  new_service(.s3control$metadata, handlers, config)
 }

--- a/cran/paws.storage/R/storagegateway_service.R
+++ b/cran/paws.storage/R/storagegateway_service.R
@@ -207,8 +207,7 @@ storagegateway <- function(config = list()) {
   target_prefix = "StorageGateway_20130630"
 )
 
-.storagegateway$handlers <- new_handlers("jsonrpc", "v4")
-
 .storagegateway$service <- function(config = list()) {
-  new_service(.storagegateway$metadata, .storagegateway$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.storagegateway$metadata, handlers, config)
 }

--- a/paws/R/accessanalyzer_service.R
+++ b/paws/R/accessanalyzer_service.R
@@ -91,8 +91,7 @@ accessanalyzer <- function(config = list()) {
   target_prefix = ""
 )
 
-.accessanalyzer$handlers <- new_handlers("restjson", "v4")
-
 .accessanalyzer$service <- function(config = list()) {
-  new_service(.accessanalyzer$metadata, .accessanalyzer$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.accessanalyzer$metadata, handlers, config)
 }

--- a/paws/R/acm_service.R
+++ b/paws/R/acm_service.R
@@ -80,8 +80,7 @@ acm <- function(config = list()) {
   target_prefix = "CertificateManager"
 )
 
-.acm$handlers <- new_handlers("jsonrpc", "v4")
-
 .acm$service <- function(config = list()) {
-  new_service(.acm$metadata, .acm$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.acm$metadata, handlers, config)
 }

--- a/paws/R/acmpca_service.R
+++ b/paws/R/acmpca_service.R
@@ -97,8 +97,7 @@ acmpca <- function(config = list()) {
   target_prefix = "ACMPrivateCA"
 )
 
-.acmpca$handlers <- new_handlers("jsonrpc", "v4")
-
 .acmpca$service <- function(config = list()) {
-  new_service(.acmpca$metadata, .acmpca$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.acmpca$metadata, handlers, config)
 }

--- a/paws/R/alexaforbusiness_service.R
+++ b/paws/R/alexaforbusiness_service.R
@@ -165,8 +165,7 @@ alexaforbusiness <- function(config = list()) {
   target_prefix = "AlexaForBusiness"
 )
 
-.alexaforbusiness$handlers <- new_handlers("jsonrpc", "v4")
-
 .alexaforbusiness$service <- function(config = list()) {
-  new_service(.alexaforbusiness$metadata, .alexaforbusiness$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.alexaforbusiness$metadata, handlers, config)
 }

--- a/paws/R/amplify_service.R
+++ b/paws/R/amplify_service.R
@@ -100,8 +100,7 @@ amplify <- function(config = list()) {
   target_prefix = ""
 )
 
-.amplify$handlers <- new_handlers("restjson", "v4")
-
 .amplify$service <- function(config = list()) {
-  new_service(.amplify$metadata, .amplify$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.amplify$metadata, handlers, config)
 }

--- a/paws/R/apigateway_service.R
+++ b/paws/R/apigateway_service.R
@@ -186,8 +186,7 @@ apigateway <- function(config = list()) {
   target_prefix = ""
 )
 
-.apigateway$handlers <- new_handlers("restjson", "v4")
-
 .apigateway$service <- function(config = list()) {
-  new_service(.apigateway$metadata, .apigateway$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.apigateway$metadata, handlers, config)
 }

--- a/paws/R/apigatewaymanagementapi_service.R
+++ b/paws/R/apigatewaymanagementapi_service.R
@@ -71,8 +71,7 @@ apigatewaymanagementapi <- function(config = list()) {
   target_prefix = ""
 )
 
-.apigatewaymanagementapi$handlers <- new_handlers("restjson", "v4")
-
 .apigatewaymanagementapi$service <- function(config = list()) {
-  new_service(.apigatewaymanagementapi$metadata, .apigatewaymanagementapi$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.apigatewaymanagementapi$metadata, handlers, config)
 }

--- a/paws/R/apigatewayv2_service.R
+++ b/paws/R/apigatewayv2_service.R
@@ -125,8 +125,7 @@ apigatewayv2 <- function(config = list()) {
   target_prefix = ""
 )
 
-.apigatewayv2$handlers <- new_handlers("restjson", "v4")
-
 .apigatewayv2$service <- function(config = list()) {
-  new_service(.apigatewayv2$metadata, .apigatewayv2$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.apigatewayv2$metadata, handlers, config)
 }

--- a/paws/R/appconfig_service.R
+++ b/paws/R/appconfig_service.R
@@ -135,8 +135,7 @@ appconfig <- function(config = list()) {
   target_prefix = ""
 )
 
-.appconfig$handlers <- new_handlers("restjson", "v4")
-
 .appconfig$service <- function(config = list()) {
-  new_service(.appconfig$metadata, .appconfig$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.appconfig$metadata, handlers, config)
 }

--- a/paws/R/applicationautoscaling_service.R
+++ b/paws/R/applicationautoscaling_service.R
@@ -126,8 +126,7 @@ applicationautoscaling <- function(config = list()) {
   target_prefix = "AnyScaleFrontendService"
 )
 
-.applicationautoscaling$handlers <- new_handlers("jsonrpc", "v4")
-
 .applicationautoscaling$service <- function(config = list()) {
-  new_service(.applicationautoscaling$metadata, .applicationautoscaling$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.applicationautoscaling$metadata, handlers, config)
 }

--- a/paws/R/applicationdiscoveryservice_service.R
+++ b/paws/R/applicationdiscoveryservice_service.R
@@ -154,8 +154,7 @@ applicationdiscoveryservice <- function(config = list()) {
   target_prefix = "AWSPoseidonService_V2015_11_01"
 )
 
-.applicationdiscoveryservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .applicationdiscoveryservice$service <- function(config = list()) {
-  new_service(.applicationdiscoveryservice$metadata, .applicationdiscoveryservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.applicationdiscoveryservice$metadata, handlers, config)
 }

--- a/paws/R/applicationinsights_service.R
+++ b/paws/R/applicationinsights_service.R
@@ -105,8 +105,7 @@ applicationinsights <- function(config = list()) {
   target_prefix = "EC2WindowsBarleyService"
 )
 
-.applicationinsights$handlers <- new_handlers("jsonrpc", "v4")
-
 .applicationinsights$service <- function(config = list()) {
-  new_service(.applicationinsights$metadata, .applicationinsights$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.applicationinsights$metadata, handlers, config)
 }

--- a/paws/R/appmesh_service.R
+++ b/paws/R/appmesh_service.R
@@ -107,8 +107,7 @@ appmesh <- function(config = list()) {
   target_prefix = ""
 )
 
-.appmesh$handlers <- new_handlers("restjson", "v4")
-
 .appmesh$service <- function(config = list()) {
-  new_service(.appmesh$metadata, .appmesh$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.appmesh$metadata, handlers, config)
 }

--- a/paws/R/appstream_service.R
+++ b/paws/R/appstream_service.R
@@ -131,8 +131,7 @@ appstream <- function(config = list()) {
   target_prefix = "PhotonAdminProxyService"
 )
 
-.appstream$handlers <- new_handlers("jsonrpc", "v4")
-
 .appstream$service <- function(config = list()) {
-  new_service(.appstream$metadata, .appstream$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.appstream$metadata, handlers, config)
 }

--- a/paws/R/appsync_service.R
+++ b/paws/R/appsync_service.R
@@ -104,8 +104,7 @@ appsync <- function(config = list()) {
   target_prefix = ""
 )
 
-.appsync$handlers <- new_handlers("restjson", "v4")
-
 .appsync$service <- function(config = list()) {
-  new_service(.appsync$metadata, .appsync$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.appsync$metadata, handlers, config)
 }

--- a/paws/R/athena_service.R
+++ b/paws/R/athena_service.R
@@ -100,8 +100,7 @@ athena <- function(config = list()) {
   target_prefix = "AmazonAthena"
 )
 
-.athena$handlers <- new_handlers("jsonrpc", "v4")
-
 .athena$service <- function(config = list()) {
-  new_service(.athena$metadata, .athena$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.athena$metadata, handlers, config)
 }

--- a/paws/R/augmentedairuntime_service.R
+++ b/paws/R/augmentedairuntime_service.R
@@ -98,8 +98,7 @@ augmentedairuntime <- function(config = list()) {
   target_prefix = ""
 )
 
-.augmentedairuntime$handlers <- new_handlers("restjson", "v4")
-
 .augmentedairuntime$service <- function(config = list()) {
-  new_service(.augmentedairuntime$metadata, .augmentedairuntime$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.augmentedairuntime$metadata, handlers, config)
 }

--- a/paws/R/autoscaling_service.R
+++ b/paws/R/autoscaling_service.R
@@ -131,8 +131,7 @@ autoscaling <- function(config = list()) {
   target_prefix = ""
 )
 
-.autoscaling$handlers <- new_handlers("query", "v4")
-
 .autoscaling$service <- function(config = list()) {
-  new_service(.autoscaling$metadata, .autoscaling$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.autoscaling$metadata, handlers, config)
 }

--- a/paws/R/autoscalingplans_service.R
+++ b/paws/R/autoscalingplans_service.R
@@ -82,8 +82,7 @@ autoscalingplans <- function(config = list()) {
   target_prefix = "AnyScaleScalingPlannerFrontendService"
 )
 
-.autoscalingplans$handlers <- new_handlers("jsonrpc", "v4")
-
 .autoscalingplans$service <- function(config = list()) {
-  new_service(.autoscalingplans$metadata, .autoscalingplans$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.autoscalingplans$metadata, handlers, config)
 }

--- a/paws/R/backup_service.R
+++ b/paws/R/backup_service.R
@@ -108,8 +108,7 @@ backup <- function(config = list()) {
   target_prefix = ""
 )
 
-.backup$handlers <- new_handlers("restjson", "v4")
-
 .backup$service <- function(config = list()) {
-  new_service(.backup$metadata, .backup$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.backup$metadata, handlers, config)
 }

--- a/paws/R/batch_service.R
+++ b/paws/R/batch_service.R
@@ -97,8 +97,7 @@ batch <- function(config = list()) {
   target_prefix = ""
 )
 
-.batch$handlers <- new_handlers("restjson", "v4")
-
 .batch$service <- function(config = list()) {
-  new_service(.batch$metadata, .batch$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.batch$metadata, handlers, config)
 }

--- a/paws/R/budgets_service.R
+++ b/paws/R/budgets_service.R
@@ -120,8 +120,7 @@ budgets <- function(config = list()) {
   target_prefix = "AWSBudgetServiceGateway"
 )
 
-.budgets$handlers <- new_handlers("jsonrpc", "v4")
-
 .budgets$service <- function(config = list()) {
-  new_service(.budgets$metadata, .budgets$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.budgets$metadata, handlers, config)
 }

--- a/paws/R/chime_service.R
+++ b/paws/R/chime_service.R
@@ -203,8 +203,7 @@ chime <- function(config = list()) {
   target_prefix = ""
 )
 
-.chime$handlers <- new_handlers("restjson", "v4")
-
 .chime$service <- function(config = list()) {
-  new_service(.chime$metadata, .chime$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.chime$metadata, handlers, config)
 }

--- a/paws/R/cloud9_service.R
+++ b/paws/R/cloud9_service.R
@@ -114,8 +114,7 @@ cloud9 <- function(config = list()) {
   target_prefix = "AWSCloud9WorkspaceManagementService"
 )
 
-.cloud9$handlers <- new_handlers("jsonrpc", "v4")
-
 .cloud9$service <- function(config = list()) {
-  new_service(.cloud9$metadata, .cloud9$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cloud9$metadata, handlers, config)
 }

--- a/paws/R/clouddirectory_service.R
+++ b/paws/R/clouddirectory_service.R
@@ -138,8 +138,7 @@ clouddirectory <- function(config = list()) {
   target_prefix = ""
 )
 
-.clouddirectory$handlers <- new_handlers("restjson", "v4")
-
 .clouddirectory$service <- function(config = list()) {
-  new_service(.clouddirectory$metadata, .clouddirectory$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.clouddirectory$metadata, handlers, config)
 }

--- a/paws/R/cloudformation_service.R
+++ b/paws/R/cloudformation_service.R
@@ -137,8 +137,7 @@ cloudformation <- function(config = list()) {
   target_prefix = ""
 )
 
-.cloudformation$handlers <- new_handlers("query", "v4")
-
 .cloudformation$service <- function(config = list()) {
-  new_service(.cloudformation$metadata, .cloudformation$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.cloudformation$metadata, handlers, config)
 }

--- a/paws/R/cloudfront_service.R
+++ b/paws/R/cloudfront_service.R
@@ -110,8 +110,7 @@ cloudfront <- function(config = list()) {
   target_prefix = ""
 )
 
-.cloudfront$handlers <- new_handlers("restxml", "v4")
-
 .cloudfront$service <- function(config = list()) {
-  new_service(.cloudfront$metadata, .cloudfront$handlers, config)
+  handlers <- new_handlers("restxml", "v4")
+  new_service(.cloudfront$metadata, handlers, config)
 }

--- a/paws/R/cloudhsm_service.R
+++ b/paws/R/cloudhsm_service.R
@@ -96,8 +96,7 @@ cloudhsm <- function(config = list()) {
   target_prefix = "CloudHsmFrontendService"
 )
 
-.cloudhsm$handlers <- new_handlers("jsonrpc", "v4")
-
 .cloudhsm$service <- function(config = list()) {
-  new_service(.cloudhsm$metadata, .cloudhsm$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cloudhsm$metadata, handlers, config)
 }

--- a/paws/R/cloudhsmv2_service.R
+++ b/paws/R/cloudhsmv2_service.R
@@ -77,8 +77,7 @@ cloudhsmv2 <- function(config = list()) {
   target_prefix = "BaldrApiService"
 )
 
-.cloudhsmv2$handlers <- new_handlers("jsonrpc", "v4")
-
 .cloudhsmv2$service <- function(config = list()) {
-  new_service(.cloudhsmv2$metadata, .cloudhsmv2$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cloudhsmv2$metadata, handlers, config)
 }

--- a/paws/R/cloudsearch_service.R
+++ b/paws/R/cloudsearch_service.R
@@ -100,8 +100,7 @@ cloudsearch <- function(config = list()) {
   target_prefix = ""
 )
 
-.cloudsearch$handlers <- new_handlers("query", "v4")
-
 .cloudsearch$service <- function(config = list()) {
-  new_service(.cloudsearch$metadata, .cloudsearch$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.cloudsearch$metadata, handlers, config)
 }

--- a/paws/R/cloudsearchdomain_service.R
+++ b/paws/R/cloudsearchdomain_service.R
@@ -76,8 +76,7 @@ cloudsearchdomain <- function(config = list()) {
   target_prefix = ""
 )
 
-.cloudsearchdomain$handlers <- new_handlers("restjson", "v4")
-
 .cloudsearchdomain$service <- function(config = list()) {
-  new_service(.cloudsearchdomain$metadata, .cloudsearchdomain$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.cloudsearchdomain$metadata, handlers, config)
 }

--- a/paws/R/cloudtrail_service.R
+++ b/paws/R/cloudtrail_service.R
@@ -102,8 +102,7 @@ cloudtrail <- function(config = list()) {
   target_prefix = "com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101"
 )
 
-.cloudtrail$handlers <- new_handlers("jsonrpc", "v4")
-
 .cloudtrail$service <- function(config = list()) {
-  new_service(.cloudtrail$metadata, .cloudtrail$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cloudtrail$metadata, handlers, config)
 }

--- a/paws/R/cloudwatch_service.R
+++ b/paws/R/cloudwatch_service.R
@@ -106,8 +106,7 @@ cloudwatch <- function(config = list()) {
   target_prefix = ""
 )
 
-.cloudwatch$handlers <- new_handlers("query", "v4")
-
 .cloudwatch$service <- function(config = list()) {
-  new_service(.cloudwatch$metadata, .cloudwatch$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.cloudwatch$metadata, handlers, config)
 }

--- a/paws/R/cloudwatchevents_service.R
+++ b/paws/R/cloudwatchevents_service.R
@@ -113,8 +113,7 @@ cloudwatchevents <- function(config = list()) {
   target_prefix = "AWSEvents"
 )
 
-.cloudwatchevents$handlers <- new_handlers("jsonrpc", "v4")
-
 .cloudwatchevents$service <- function(config = list()) {
-  new_service(.cloudwatchevents$metadata, .cloudwatchevents$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cloudwatchevents$metadata, handlers, config)
 }

--- a/paws/R/cloudwatchlogs_service.R
+++ b/paws/R/cloudwatchlogs_service.R
@@ -133,8 +133,7 @@ cloudwatchlogs <- function(config = list()) {
   target_prefix = "Logs_20140328"
 )
 
-.cloudwatchlogs$handlers <- new_handlers("jsonrpc", "v4")
-
 .cloudwatchlogs$service <- function(config = list()) {
-  new_service(.cloudwatchlogs$metadata, .cloudwatchlogs$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cloudwatchlogs$metadata, handlers, config)
 }

--- a/paws/R/codebuild_service.R
+++ b/paws/R/codebuild_service.R
@@ -214,8 +214,7 @@ codebuild <- function(config = list()) {
   target_prefix = "CodeBuild_20161006"
 )
 
-.codebuild$handlers <- new_handlers("jsonrpc", "v4")
-
 .codebuild$service <- function(config = list()) {
-  new_service(.codebuild$metadata, .codebuild$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.codebuild$metadata, handlers, config)
 }

--- a/paws/R/codecommit_service.R
+++ b/paws/R/codecommit_service.R
@@ -404,8 +404,7 @@ codecommit <- function(config = list()) {
   target_prefix = "CodeCommit_20150413"
 )
 
-.codecommit$handlers <- new_handlers("jsonrpc", "v4")
-
 .codecommit$service <- function(config = list()) {
-  new_service(.codecommit$metadata, .codecommit$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.codecommit$metadata, handlers, config)
 }

--- a/paws/R/codedeploy_service.R
+++ b/paws/R/codedeploy_service.R
@@ -186,8 +186,7 @@ codedeploy <- function(config = list()) {
   target_prefix = "CodeDeploy_20141006"
 )
 
-.codedeploy$handlers <- new_handlers("jsonrpc", "v4")
-
 .codedeploy$service <- function(config = list()) {
-  new_service(.codedeploy$metadata, .codedeploy$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.codedeploy$metadata, handlers, config)
 }

--- a/paws/R/codeguruprofiler_service.R
+++ b/paws/R/codeguruprofiler_service.R
@@ -71,8 +71,7 @@ codeguruprofiler <- function(config = list()) {
   target_prefix = ""
 )
 
-.codeguruprofiler$handlers <- new_handlers("restjson", "v4")
-
 .codeguruprofiler$service <- function(config = list()) {
-  new_service(.codeguruprofiler$metadata, .codeguruprofiler$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.codeguruprofiler$metadata, handlers, config)
 }

--- a/paws/R/codegurureviewer_service.R
+++ b/paws/R/codegurureviewer_service.R
@@ -67,8 +67,7 @@ codegurureviewer <- function(config = list()) {
   target_prefix = ""
 )
 
-.codegurureviewer$handlers <- new_handlers("restjson", "v4")
-
 .codegurureviewer$service <- function(config = list()) {
-  new_service(.codegurureviewer$metadata, .codegurureviewer$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.codegurureviewer$metadata, handlers, config)
 }

--- a/paws/R/codepipeline_service.R
+++ b/paws/R/codepipeline_service.R
@@ -233,8 +233,7 @@ codepipeline <- function(config = list()) {
   target_prefix = "CodePipeline_20150709"
 )
 
-.codepipeline$handlers <- new_handlers("jsonrpc", "v4")
-
 .codepipeline$service <- function(config = list()) {
-  new_service(.codepipeline$metadata, .codepipeline$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.codepipeline$metadata, handlers, config)
 }

--- a/paws/R/codestar_service.R
+++ b/paws/R/codestar_service.R
@@ -133,8 +133,7 @@ codestar <- function(config = list()) {
   target_prefix = "CodeStar_20170419"
 )
 
-.codestar$handlers <- new_handlers("jsonrpc", "v4")
-
 .codestar$service <- function(config = list()) {
-  new_service(.codestar$metadata, .codestar$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.codestar$metadata, handlers, config)
 }

--- a/paws/R/codestarconnections_service.R
+++ b/paws/R/codestarconnections_service.R
@@ -100,8 +100,7 @@ codestarconnections <- function(config = list()) {
   target_prefix = "com.amazonaws.codestar.connections.CodeStar_connections_20191201"
 )
 
-.codestarconnections$handlers <- new_handlers("jsonrpc", "v4")
-
 .codestarconnections$service <- function(config = list()) {
-  new_service(.codestarconnections$metadata, .codestarconnections$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.codestarconnections$metadata, handlers, config)
 }

--- a/paws/R/codestarnotifications_service.R
+++ b/paws/R/codestarnotifications_service.R
@@ -125,8 +125,7 @@ codestarnotifications <- function(config = list()) {
   target_prefix = ""
 )
 
-.codestarnotifications$handlers <- new_handlers("restjson", "v4")
-
 .codestarnotifications$service <- function(config = list()) {
-  new_service(.codestarnotifications$metadata, .codestarnotifications$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.codestarnotifications$metadata, handlers, config)
 }

--- a/paws/R/cognitoidentity_service.R
+++ b/paws/R/cognitoidentity_service.R
@@ -103,8 +103,7 @@ cognitoidentity <- function(config = list()) {
   target_prefix = "AWSCognitoIdentityService"
 )
 
-.cognitoidentity$handlers <- new_handlers("jsonrpc", "v4")
-
 .cognitoidentity$service <- function(config = list()) {
-  new_service(.cognitoidentity$metadata, .cognitoidentity$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cognitoidentity$metadata, handlers, config)
 }

--- a/paws/R/cognitoidentityprovider_service.R
+++ b/paws/R/cognitoidentityprovider_service.R
@@ -169,8 +169,7 @@ cognitoidentityprovider <- function(config = list()) {
   target_prefix = "AWSCognitoIdentityProviderService"
 )
 
-.cognitoidentityprovider$handlers <- new_handlers("jsonrpc", "v4")
-
 .cognitoidentityprovider$service <- function(config = list()) {
-  new_service(.cognitoidentityprovider$metadata, .cognitoidentityprovider$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.cognitoidentityprovider$metadata, handlers, config)
 }

--- a/paws/R/cognitosync_service.R
+++ b/paws/R/cognitosync_service.R
@@ -100,8 +100,7 @@ cognitosync <- function(config = list()) {
   target_prefix = ""
 )
 
-.cognitosync$handlers <- new_handlers("restjson", "v4")
-
 .cognitosync$service <- function(config = list()) {
-  new_service(.cognitosync$metadata, .cognitosync$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.cognitosync$metadata, handlers, config)
 }

--- a/paws/R/comprehend_service.R
+++ b/paws/R/comprehend_service.R
@@ -116,8 +116,7 @@ comprehend <- function(config = list()) {
   target_prefix = "Comprehend_20171127"
 )
 
-.comprehend$handlers <- new_handlers("jsonrpc", "v4")
-
 .comprehend$service <- function(config = list()) {
-  new_service(.comprehend$metadata, .comprehend$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.comprehend$metadata, handlers, config)
 }

--- a/paws/R/comprehendmedical_service.R
+++ b/paws/R/comprehendmedical_service.R
@@ -77,8 +77,7 @@ comprehendmedical <- function(config = list()) {
   target_prefix = "ComprehendMedical_20181030"
 )
 
-.comprehendmedical$handlers <- new_handlers("jsonrpc", "v4")
-
 .comprehendmedical$service <- function(config = list()) {
-  new_service(.comprehendmedical$metadata, .comprehendmedical$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.comprehendmedical$metadata, handlers, config)
 }

--- a/paws/R/computeoptimizer_service.R
+++ b/paws/R/computeoptimizer_service.R
@@ -80,8 +80,7 @@ computeoptimizer <- function(config = list()) {
   target_prefix = "ComputeOptimizerService"
 )
 
-.computeoptimizer$handlers <- new_handlers("jsonrpc", "v4")
-
 .computeoptimizer$service <- function(config = list()) {
-  new_service(.computeoptimizer$metadata, .computeoptimizer$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.computeoptimizer$metadata, handlers, config)
 }

--- a/paws/R/configservice_service.R
+++ b/paws/R/configservice_service.R
@@ -162,8 +162,7 @@ configservice <- function(config = list()) {
   target_prefix = "StarlingDoveService"
 )
 
-.configservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .configservice$service <- function(config = list()) {
-  new_service(.configservice$metadata, .configservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.configservice$metadata, handlers, config)
 }

--- a/paws/R/connect_service.R
+++ b/paws/R/connect_service.R
@@ -103,8 +103,7 @@ connect <- function(config = list()) {
   target_prefix = ""
 )
 
-.connect$handlers <- new_handlers("restjson", "v4")
-
 .connect$service <- function(config = list()) {
-  new_service(.connect$metadata, .connect$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.connect$metadata, handlers, config)
 }

--- a/paws/R/connectparticipant_service.R
+++ b/paws/R/connectparticipant_service.R
@@ -74,8 +74,7 @@ connectparticipant <- function(config = list()) {
   target_prefix = ""
 )
 
-.connectparticipant$handlers <- new_handlers("restjson", "v4")
-
 .connectparticipant$service <- function(config = list()) {
-  new_service(.connectparticipant$metadata, .connectparticipant$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.connectparticipant$metadata, handlers, config)
 }

--- a/paws/R/costandusagereportservice_service.R
+++ b/paws/R/costandusagereportservice_service.R
@@ -81,8 +81,7 @@ costandusagereportservice <- function(config = list()) {
   target_prefix = "AWSOrigamiServiceGatewayService"
 )
 
-.costandusagereportservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .costandusagereportservice$service <- function(config = list()) {
-  new_service(.costandusagereportservice$metadata, .costandusagereportservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.costandusagereportservice$metadata, handlers, config)
 }

--- a/paws/R/costexplorer_service.R
+++ b/paws/R/costexplorer_service.R
@@ -95,8 +95,7 @@ costexplorer <- function(config = list()) {
   target_prefix = "AWSInsightsIndexService"
 )
 
-.costexplorer$handlers <- new_handlers("jsonrpc", "v4")
-
 .costexplorer$service <- function(config = list()) {
-  new_service(.costexplorer$metadata, .costexplorer$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.costexplorer$metadata, handlers, config)
 }

--- a/paws/R/databasemigrationservice_service.R
+++ b/paws/R/databasemigrationservice_service.R
@@ -130,8 +130,7 @@ databasemigrationservice <- function(config = list()) {
   target_prefix = "AmazonDMSv20160101"
 )
 
-.databasemigrationservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .databasemigrationservice$service <- function(config = list()) {
-  new_service(.databasemigrationservice$metadata, .databasemigrationservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.databasemigrationservice$metadata, handlers, config)
 }

--- a/paws/R/dataexchange_service.R
+++ b/paws/R/dataexchange_service.R
@@ -104,8 +104,7 @@ dataexchange <- function(config = list()) {
   target_prefix = ""
 )
 
-.dataexchange$handlers <- new_handlers("restjson", "v4")
-
 .dataexchange$service <- function(config = list()) {
-  new_service(.dataexchange$metadata, .dataexchange$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.dataexchange$metadata, handlers, config)
 }

--- a/paws/R/datapipeline_service.R
+++ b/paws/R/datapipeline_service.R
@@ -103,8 +103,7 @@ datapipeline <- function(config = list()) {
   target_prefix = "DataPipeline"
 )
 
-.datapipeline$handlers <- new_handlers("jsonrpc", "v4")
-
 .datapipeline$service <- function(config = list()) {
-  new_service(.datapipeline$metadata, .datapipeline$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.datapipeline$metadata, handlers, config)
 }

--- a/paws/R/datasync_service.R
+++ b/paws/R/datasync_service.R
@@ -95,8 +95,7 @@ datasync <- function(config = list()) {
   target_prefix = "FmrsService"
 )
 
-.datasync$handlers <- new_handlers("jsonrpc", "v4")
-
 .datasync$service <- function(config = list()) {
-  new_service(.datasync$metadata, .datasync$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.datasync$metadata, handlers, config)
 }

--- a/paws/R/dax_service.R
+++ b/paws/R/dax_service.R
@@ -89,8 +89,7 @@ dax <- function(config = list()) {
   target_prefix = "AmazonDAXV3"
 )
 
-.dax$handlers <- new_handlers("jsonrpc", "v4")
-
 .dax$service <- function(config = list()) {
-  new_service(.dax$metadata, .dax$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.dax$metadata, handlers, config)
 }

--- a/paws/R/detective_service.R
+++ b/paws/R/detective_service.R
@@ -115,8 +115,7 @@ detective <- function(config = list()) {
   target_prefix = ""
 )
 
-.detective$handlers <- new_handlers("restjson", "v4")
-
 .detective$service <- function(config = list()) {
-  new_service(.detective$metadata, .detective$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.detective$metadata, handlers, config)
 }

--- a/paws/R/devicefarm_service.R
+++ b/paws/R/devicefarm_service.R
@@ -160,8 +160,7 @@ devicefarm <- function(config = list()) {
   target_prefix = "DeviceFarm_20150623"
 )
 
-.devicefarm$handlers <- new_handlers("jsonrpc", "v4")
-
 .devicefarm$service <- function(config = list()) {
-  new_service(.devicefarm$metadata, .devicefarm$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.devicefarm$metadata, handlers, config)
 }

--- a/paws/R/directconnect_service.R
+++ b/paws/R/directconnect_service.R
@@ -124,8 +124,7 @@ directconnect <- function(config = list()) {
   target_prefix = "OvertureService"
 )
 
-.directconnect$handlers <- new_handlers("jsonrpc", "v4")
-
 .directconnect$service <- function(config = list()) {
-  new_service(.directconnect$metadata, .directconnect$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.directconnect$metadata, handlers, config)
 }

--- a/paws/R/directoryservice_service.R
+++ b/paws/R/directoryservice_service.R
@@ -134,8 +134,7 @@ directoryservice <- function(config = list()) {
   target_prefix = "DirectoryService_20150416"
 )
 
-.directoryservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .directoryservice$service <- function(config = list()) {
-  new_service(.directoryservice$metadata, .directoryservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.directoryservice$metadata, handlers, config)
 }

--- a/paws/R/dlm_service.R
+++ b/paws/R/dlm_service.R
@@ -78,8 +78,7 @@ dlm <- function(config = list()) {
   target_prefix = ""
 )
 
-.dlm$handlers <- new_handlers("restjson", "v4")
-
 .dlm$service <- function(config = list()) {
-  new_service(.dlm$metadata, .dlm$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.dlm$metadata, handlers, config)
 }

--- a/paws/R/docdb_service.R
+++ b/paws/R/docdb_service.R
@@ -104,8 +104,7 @@ docdb <- function(config = list()) {
   target_prefix = ""
 )
 
-.docdb$handlers <- new_handlers("query", "v4")
-
 .docdb$service <- function(config = list()) {
-  new_service(.docdb$metadata, .docdb$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.docdb$metadata, handlers, config)
 }

--- a/paws/R/dynamodb_service.R
+++ b/paws/R/dynamodb_service.R
@@ -153,8 +153,7 @@ dynamodb <- function(config = list()) {
   target_prefix = "DynamoDB_20120810"
 )
 
-.dynamodb$handlers <- new_handlers("jsonrpc", "v4")
-
 .dynamodb$service <- function(config = list()) {
-  new_service(.dynamodb$metadata, .dynamodb$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.dynamodb$metadata, handlers, config)
 }

--- a/paws/R/dynamodbstreams_service.R
+++ b/paws/R/dynamodbstreams_service.R
@@ -73,8 +73,7 @@ dynamodbstreams <- function(config = list()) {
   target_prefix = "DynamoDBStreams_20120810"
 )
 
-.dynamodbstreams$handlers <- new_handlers("jsonrpc", "v4")
-
 .dynamodbstreams$service <- function(config = list()) {
-  new_service(.dynamodbstreams$metadata, .dynamodbstreams$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.dynamodbstreams$metadata, handlers, config)
 }

--- a/paws/R/ebs_service.R
+++ b/paws/R/ebs_service.R
@@ -88,8 +88,7 @@ ebs <- function(config = list()) {
   target_prefix = ""
 )
 
-.ebs$handlers <- new_handlers("restjson", "v4")
-
 .ebs$service <- function(config = list()) {
-  new_service(.ebs$metadata, .ebs$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.ebs$metadata, handlers, config)
 }

--- a/paws/R/ec2_service.R
+++ b/paws/R/ec2_service.R
@@ -479,8 +479,7 @@ ec2 <- function(config = list()) {
   target_prefix = ""
 )
 
-.ec2$handlers <- new_handlers("ec2query", "v4")
-
 .ec2$service <- function(config = list()) {
-  new_service(.ec2$metadata, .ec2$handlers, config)
+  handlers <- new_handlers("ec2query", "v4")
+  new_service(.ec2$metadata, handlers, config)
 }

--- a/paws/R/ec2instanceconnect_service.R
+++ b/paws/R/ec2instanceconnect_service.R
@@ -71,8 +71,7 @@ ec2instanceconnect <- function(config = list()) {
   target_prefix = "AWSEC2InstanceConnectService"
 )
 
-.ec2instanceconnect$handlers <- new_handlers("jsonrpc", "v4")
-
 .ec2instanceconnect$service <- function(config = list()) {
-  new_service(.ec2instanceconnect$metadata, .ec2instanceconnect$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.ec2instanceconnect$metadata, handlers, config)
 }

--- a/paws/R/ecr_service.R
+++ b/paws/R/ecr_service.R
@@ -106,8 +106,7 @@ ecr <- function(config = list()) {
   target_prefix = "AmazonEC2ContainerRegistry_V20150921"
 )
 
-.ecr$handlers <- new_handlers("jsonrpc", "v4")
-
 .ecr$service <- function(config = list()) {
-  new_service(.ecr$metadata, .ecr$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.ecr$metadata, handlers, config)
 }

--- a/paws/R/ecs_service.R
+++ b/paws/R/ecs_service.R
@@ -132,8 +132,7 @@ ecs <- function(config = list()) {
   target_prefix = "AmazonEC2ContainerServiceV20141113"
 )
 
-.ecs$handlers <- new_handlers("jsonrpc", "v4")
-
 .ecs$service <- function(config = list()) {
-  new_service(.ecs$metadata, .ecs$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.ecs$metadata, handlers, config)
 }

--- a/paws/R/efs_service.R
+++ b/paws/R/efs_service.R
@@ -90,8 +90,7 @@ efs <- function(config = list()) {
   target_prefix = ""
 )
 
-.efs$handlers <- new_handlers("restjson", "v4")
-
 .efs$service <- function(config = list()) {
-  new_service(.efs$metadata, .efs$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.efs$metadata, handlers, config)
 }

--- a/paws/R/eks_service.R
+++ b/paws/R/eks_service.R
@@ -108,8 +108,7 @@ eks <- function(config = list()) {
   target_prefix = ""
 )
 
-.eks$handlers <- new_handlers("restjson", "v4")
-
 .eks$service <- function(config = list()) {
-  new_service(.eks$metadata, .eks$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.eks$metadata, handlers, config)
 }

--- a/paws/R/elasticache_service.R
+++ b/paws/R/elasticache_service.R
@@ -121,8 +121,7 @@ elasticache <- function(config = list()) {
   target_prefix = ""
 )
 
-.elasticache$handlers <- new_handlers("query", "v4")
-
 .elasticache$service <- function(config = list()) {
-  new_service(.elasticache$metadata, .elasticache$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.elasticache$metadata, handlers, config)
 }

--- a/paws/R/elasticbeanstalk_service.R
+++ b/paws/R/elasticbeanstalk_service.R
@@ -126,8 +126,7 @@ elasticbeanstalk <- function(config = list()) {
   target_prefix = ""
 )
 
-.elasticbeanstalk$handlers <- new_handlers("query", "v4")
-
 .elasticbeanstalk$service <- function(config = list()) {
-  new_service(.elasticbeanstalk$metadata, .elasticbeanstalk$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.elasticbeanstalk$metadata, handlers, config)
 }

--- a/paws/R/elasticinference_service.R
+++ b/paws/R/elasticinference_service.R
@@ -65,8 +65,7 @@ elasticinference <- function(config = list()) {
   target_prefix = ""
 )
 
-.elasticinference$handlers <- new_handlers("restjson", "v4")
-
 .elasticinference$service <- function(config = list()) {
-  new_service(.elasticinference$metadata, .elasticinference$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.elasticinference$metadata, handlers, config)
 }

--- a/paws/R/elasticsearchservice_service.R
+++ b/paws/R/elasticsearchservice_service.R
@@ -100,8 +100,7 @@ elasticsearchservice <- function(config = list()) {
   target_prefix = ""
 )
 
-.elasticsearchservice$handlers <- new_handlers("restjson", "v4")
-
 .elasticsearchservice$service <- function(config = list()) {
-  new_service(.elasticsearchservice$metadata, .elasticsearchservice$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.elasticsearchservice$metadata, handlers, config)
 }

--- a/paws/R/elastictranscoder_service.R
+++ b/paws/R/elastictranscoder_service.R
@@ -81,8 +81,7 @@ elastictranscoder <- function(config = list()) {
   target_prefix = ""
 )
 
-.elastictranscoder$handlers <- new_handlers("restjson", "v4")
-
 .elastictranscoder$service <- function(config = list()) {
-  new_service(.elastictranscoder$metadata, .elastictranscoder$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.elastictranscoder$metadata, handlers, config)
 }

--- a/paws/R/elb_service.R
+++ b/paws/R/elb_service.R
@@ -130,8 +130,7 @@ elb <- function(config = list()) {
   target_prefix = ""
 )
 
-.elb$handlers <- new_handlers("query", "v4")
-
 .elb$service <- function(config = list()) {
-  new_service(.elb$metadata, .elb$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.elb$metadata, handlers, config)
 }

--- a/paws/R/elbv2_service.R
+++ b/paws/R/elbv2_service.R
@@ -135,8 +135,7 @@ elbv2 <- function(config = list()) {
   target_prefix = ""
 )
 
-.elbv2$handlers <- new_handlers("query", "v4")
-
 .elbv2$service <- function(config = list()) {
-  new_service(.elbv2$metadata, .elbv2$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.elbv2$metadata, handlers, config)
 }

--- a/paws/R/emr_service.R
+++ b/paws/R/emr_service.R
@@ -96,8 +96,7 @@ emr <- function(config = list()) {
   target_prefix = "ElasticMapReduce"
 )
 
-.emr$handlers <- new_handlers("jsonrpc", "v4")
-
 .emr$service <- function(config = list()) {
-  new_service(.emr$metadata, .emr$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.emr$metadata, handlers, config)
 }

--- a/paws/R/eventbridge_service.R
+++ b/paws/R/eventbridge_service.R
@@ -113,8 +113,7 @@ eventbridge <- function(config = list()) {
   target_prefix = "AWSEvents"
 )
 
-.eventbridge$handlers <- new_handlers("jsonrpc", "v4")
-
 .eventbridge$service <- function(config = list()) {
-  new_service(.eventbridge$metadata, .eventbridge$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.eventbridge$metadata, handlers, config)
 }

--- a/paws/R/firehose_service.R
+++ b/paws/R/firehose_service.R
@@ -79,8 +79,7 @@ firehose <- function(config = list()) {
   target_prefix = "Firehose_20150804"
 )
 
-.firehose$handlers <- new_handlers("jsonrpc", "v4")
-
 .firehose$service <- function(config = list()) {
-  new_service(.firehose$metadata, .firehose$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.firehose$metadata, handlers, config)
 }

--- a/paws/R/fms_service.R
+++ b/paws/R/fms_service.R
@@ -85,8 +85,7 @@ fms <- function(config = list()) {
   target_prefix = "AWSFMS_20180101"
 )
 
-.fms$handlers <- new_handlers("jsonrpc", "v4")
-
 .fms$service <- function(config = list()) {
-  new_service(.fms$metadata, .fms$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.fms$metadata, handlers, config)
 }

--- a/paws/R/forecastqueryservice_service.R
+++ b/paws/R/forecastqueryservice_service.R
@@ -63,8 +63,7 @@ forecastqueryservice <- function(config = list()) {
   target_prefix = "AmazonForecastRuntime"
 )
 
-.forecastqueryservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .forecastqueryservice$service <- function(config = list()) {
-  new_service(.forecastqueryservice$metadata, .forecastqueryservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.forecastqueryservice$metadata, handlers, config)
 }

--- a/paws/R/forecastservice_operations.R
+++ b/paws/R/forecastservice_operations.R
@@ -28,8 +28,8 @@ NULL
 #' 
 #' To get a list of all your datasets, use the ListDatasets operation.
 #' 
-#' For example Forecast datasets, see the [Amazon Forecast Sample GitHub
-#' repository](https://github.com/aws-samples/amazon-forecast-samples/tree/master/data).
+#' For example Forecast datasets, see the Amazon Forecast Sample GitHub
+#' repository.
 #' 
 #' The `Status` of a dataset must be `ACTIVE` before you can import
 #' training data. Use the DescribeDataset operation to get the status.

--- a/paws/R/forecastservice_service.R
+++ b/paws/R/forecastservice_service.R
@@ -88,8 +88,7 @@ forecastservice <- function(config = list()) {
   target_prefix = "AmazonForecast"
 )
 
-.forecastservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .forecastservice$service <- function(config = list()) {
-  new_service(.forecastservice$metadata, .forecastservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.forecastservice$metadata, handlers, config)
 }

--- a/paws/R/frauddetector_service.R
+++ b/paws/R/frauddetector_service.R
@@ -96,8 +96,7 @@ frauddetector <- function(config = list()) {
   target_prefix = "AWSHawksNestServiceFacade"
 )
 
-.frauddetector$handlers <- new_handlers("jsonrpc", "v4")
-
 .frauddetector$service <- function(config = list()) {
-  new_service(.frauddetector$metadata, .frauddetector$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.frauddetector$metadata, handlers, config)
 }

--- a/paws/R/fsx_service.R
+++ b/paws/R/fsx_service.R
@@ -84,8 +84,7 @@ fsx <- function(config = list()) {
   target_prefix = "AWSSimbaAPIService_v20180301"
 )
 
-.fsx$handlers <- new_handlers("jsonrpc", "v4")
-
 .fsx$service <- function(config = list()) {
-  new_service(.fsx$metadata, .fsx$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.fsx$metadata, handlers, config)
 }

--- a/paws/R/gamelift_service.R
+++ b/paws/R/gamelift_service.R
@@ -175,8 +175,7 @@ gamelift <- function(config = list()) {
   target_prefix = "GameLift"
 )
 
-.gamelift$handlers <- new_handlers("jsonrpc", "v4")
-
 .gamelift$service <- function(config = list()) {
-  new_service(.gamelift$metadata, .gamelift$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.gamelift$metadata, handlers, config)
 }

--- a/paws/R/glacier_service.R
+++ b/paws/R/glacier_service.R
@@ -133,8 +133,7 @@ glacier <- function(config = list()) {
   target_prefix = ""
 )
 
-.glacier$handlers <- new_handlers("restjson", "v4")
-
 .glacier$service <- function(config = list()) {
-  new_service(.glacier$metadata, .glacier$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.glacier$metadata, handlers, config)
 }

--- a/paws/R/globalaccelerator_service.R
+++ b/paws/R/globalaccelerator_service.R
@@ -165,8 +165,7 @@ globalaccelerator <- function(config = list()) {
   target_prefix = "GlobalAccelerator_V20180706"
 )
 
-.globalaccelerator$handlers <- new_handlers("jsonrpc", "v4")
-
 .globalaccelerator$service <- function(config = list()) {
-  new_service(.globalaccelerator$metadata, .globalaccelerator$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.globalaccelerator$metadata, handlers, config)
 }

--- a/paws/R/glue_service.R
+++ b/paws/R/glue_service.R
@@ -185,8 +185,7 @@ glue <- function(config = list()) {
   target_prefix = "AWSGlue"
 )
 
-.glue$handlers <- new_handlers("jsonrpc", "v4")
-
 .glue$service <- function(config = list()) {
-  new_service(.glue$metadata, .glue$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.glue$metadata, handlers, config)
 }

--- a/paws/R/greengrass_service.R
+++ b/paws/R/greengrass_service.R
@@ -152,8 +152,7 @@ greengrass <- function(config = list()) {
   target_prefix = ""
 )
 
-.greengrass$handlers <- new_handlers("restjson", "v4")
-
 .greengrass$service <- function(config = list()) {
-  new_service(.greengrass$metadata, .greengrass$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.greengrass$metadata, handlers, config)
 }

--- a/paws/R/groundstation_service.R
+++ b/paws/R/groundstation_service.R
@@ -91,8 +91,7 @@ groundstation <- function(config = list()) {
   target_prefix = ""
 )
 
-.groundstation$handlers <- new_handlers("restjson", "v4")
-
 .groundstation$service <- function(config = list()) {
-  new_service(.groundstation$metadata, .groundstation$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.groundstation$metadata, handlers, config)
 }

--- a/paws/R/guardduty_service.R
+++ b/paws/R/guardduty_service.R
@@ -128,8 +128,7 @@ guardduty <- function(config = list()) {
   target_prefix = ""
 )
 
-.guardduty$handlers <- new_handlers("restjson", "v4")
-
 .guardduty$service <- function(config = list()) {
-  new_service(.guardduty$metadata, .guardduty$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.guardduty$metadata, handlers, config)
 }

--- a/paws/R/health_service.R
+++ b/paws/R/health_service.R
@@ -146,8 +146,7 @@ health <- function(config = list()) {
   target_prefix = "AWSHealth_20160804"
 )
 
-.health$handlers <- new_handlers("jsonrpc", "v4")
-
 .health$service <- function(config = list()) {
-  new_service(.health$metadata, .health$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.health$metadata, handlers, config)
 }

--- a/paws/R/iam_service.R
+++ b/paws/R/iam_service.R
@@ -267,8 +267,7 @@ iam <- function(config = list()) {
   target_prefix = ""
 )
 
-.iam$handlers <- new_handlers("query", "v4")
-
 .iam$service <- function(config = list()) {
-  new_service(.iam$metadata, .iam$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.iam$metadata, handlers, config)
 }

--- a/paws/R/imagebuilder_service.R
+++ b/paws/R/imagebuilder_service.R
@@ -115,8 +115,7 @@ imagebuilder <- function(config = list()) {
   target_prefix = ""
 )
 
-.imagebuilder$handlers <- new_handlers("restjson", "v4")
-
 .imagebuilder$service <- function(config = list()) {
-  new_service(.imagebuilder$metadata, .imagebuilder$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.imagebuilder$metadata, handlers, config)
 }

--- a/paws/R/importexport_service.R
+++ b/paws/R/importexport_service.R
@@ -74,8 +74,7 @@ importexport <- function(config = list()) {
   target_prefix = ""
 )
 
-.importexport$handlers <- new_handlers("query", "v2")
-
 .importexport$service <- function(config = list()) {
-  new_service(.importexport$metadata, .importexport$handlers, config)
+  handlers <- new_handlers("query", "v2")
+  new_service(.importexport$metadata, handlers, config)
 }

--- a/paws/R/inspector_service.R
+++ b/paws/R/inspector_service.R
@@ -112,8 +112,7 @@ inspector <- function(config = list()) {
   target_prefix = "InspectorService"
 )
 
-.inspector$handlers <- new_handlers("jsonrpc", "v4")
-
 .inspector$service <- function(config = list()) {
-  new_service(.inspector$metadata, .inspector$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.inspector$metadata, handlers, config)
 }

--- a/paws/R/iot1clickdevicesservice_service.R
+++ b/paws/R/iot1clickdevicesservice_service.R
@@ -77,8 +77,7 @@ iot1clickdevicesservice <- function(config = list()) {
   target_prefix = ""
 )
 
-.iot1clickdevicesservice$handlers <- new_handlers("restjson", "v4")
-
 .iot1clickdevicesservice$service <- function(config = list()) {
-  new_service(.iot1clickdevicesservice$metadata, .iot1clickdevicesservice$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.iot1clickdevicesservice$metadata, handlers, config)
 }

--- a/paws/R/iot1clickprojects_service.R
+++ b/paws/R/iot1clickprojects_service.R
@@ -78,8 +78,7 @@ iot1clickprojects <- function(config = list()) {
   target_prefix = ""
 )
 
-.iot1clickprojects$handlers <- new_handlers("restjson", "v4")
-
 .iot1clickprojects$service <- function(config = list()) {
-  new_service(.iot1clickprojects$metadata, .iot1clickprojects$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.iot1clickprojects$metadata, handlers, config)
 }

--- a/paws/R/iot_service.R
+++ b/paws/R/iot_service.R
@@ -276,8 +276,7 @@ iot <- function(config = list()) {
   target_prefix = ""
 )
 
-.iot$handlers <- new_handlers("restjson", "v4")
-
 .iot$service <- function(config = list()) {
-  new_service(.iot$metadata, .iot$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.iot$metadata, handlers, config)
 }

--- a/paws/R/iotanalytics_service.R
+++ b/paws/R/iotanalytics_service.R
@@ -121,8 +121,7 @@ iotanalytics <- function(config = list()) {
   target_prefix = ""
 )
 
-.iotanalytics$handlers <- new_handlers("restjson", "v4")
-
 .iotanalytics$service <- function(config = list()) {
-  new_service(.iotanalytics$metadata, .iotanalytics$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.iotanalytics$metadata, handlers, config)
 }

--- a/paws/R/iotdataplane_service.R
+++ b/paws/R/iotdataplane_service.R
@@ -74,8 +74,7 @@ iotdataplane <- function(config = list()) {
   target_prefix = ""
 )
 
-.iotdataplane$handlers <- new_handlers("restjson", "v4")
-
 .iotdataplane$service <- function(config = list()) {
-  new_service(.iotdataplane$metadata, .iotdataplane$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.iotdataplane$metadata, handlers, config)
 }

--- a/paws/R/iotevents_service.R
+++ b/paws/R/iotevents_service.R
@@ -81,8 +81,7 @@ iotevents <- function(config = list()) {
   target_prefix = ""
 )
 
-.iotevents$handlers <- new_handlers("restjson", "v4")
-
 .iotevents$service <- function(config = list()) {
-  new_service(.iotevents$metadata, .iotevents$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.iotevents$metadata, handlers, config)
 }

--- a/paws/R/ioteventsdata_service.R
+++ b/paws/R/ioteventsdata_service.R
@@ -69,8 +69,7 @@ ioteventsdata <- function(config = list()) {
   target_prefix = ""
 )
 
-.ioteventsdata$handlers <- new_handlers("restjson", "v4")
-
 .ioteventsdata$service <- function(config = list()) {
-  new_service(.ioteventsdata$metadata, .ioteventsdata$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.ioteventsdata$metadata, handlers, config)
 }

--- a/paws/R/iotjobsdataplane_service.R
+++ b/paws/R/iotjobsdataplane_service.R
@@ -83,8 +83,7 @@ iotjobsdataplane <- function(config = list()) {
   target_prefix = ""
 )
 
-.iotjobsdataplane$handlers <- new_handlers("restjson", "v4")
-
 .iotjobsdataplane$service <- function(config = list()) {
-  new_service(.iotjobsdataplane$metadata, .iotjobsdataplane$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.iotjobsdataplane$metadata, handlers, config)
 }

--- a/paws/R/iotsecuretunneling_service.R
+++ b/paws/R/iotsecuretunneling_service.R
@@ -73,8 +73,7 @@ iotsecuretunneling <- function(config = list()) {
   target_prefix = "IoTSecuredTunneling"
 )
 
-.iotsecuretunneling$handlers <- new_handlers("jsonrpc", "v4")
-
 .iotsecuretunneling$service <- function(config = list()) {
-  new_service(.iotsecuretunneling$metadata, .iotsecuretunneling$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.iotsecuretunneling$metadata, handlers, config)
 }

--- a/paws/R/iotthingsgraph_service.R
+++ b/paws/R/iotthingsgraph_service.R
@@ -105,8 +105,7 @@ iotthingsgraph <- function(config = list()) {
   target_prefix = "IotThingsGraphFrontEndService"
 )
 
-.iotthingsgraph$handlers <- new_handlers("jsonrpc", "v4")
-
 .iotthingsgraph$service <- function(config = list()) {
-  new_service(.iotthingsgraph$metadata, .iotthingsgraph$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.iotthingsgraph$metadata, handlers, config)
 }

--- a/paws/R/kafka_service.R
+++ b/paws/R/kafka_service.R
@@ -81,8 +81,7 @@ kafka <- function(config = list()) {
   target_prefix = ""
 )
 
-.kafka$handlers <- new_handlers("restjson", "v4")
-
 .kafka$service <- function(config = list()) {
-  new_service(.kafka$metadata, .kafka$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.kafka$metadata, handlers, config)
 }

--- a/paws/R/kendra_service.R
+++ b/paws/R/kendra_service.R
@@ -82,8 +82,7 @@ kendra <- function(config = list()) {
   target_prefix = "AWSKendraFrontendService"
 )
 
-.kendra$handlers <- new_handlers("jsonrpc", "v4")
-
 .kendra$service <- function(config = list()) {
-  new_service(.kendra$metadata, .kendra$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.kendra$metadata, handlers, config)
 }

--- a/paws/R/kinesis_service.R
+++ b/paws/R/kinesis_service.R
@@ -92,8 +92,7 @@ kinesis <- function(config = list()) {
   target_prefix = "Kinesis_20131202"
 )
 
-.kinesis$handlers <- new_handlers("jsonrpc", "v4")
-
 .kinesis$service <- function(config = list()) {
-  new_service(.kinesis$metadata, .kinesis$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.kinesis$metadata, handlers, config)
 }

--- a/paws/R/kinesisanalytics_service.R
+++ b/paws/R/kinesisanalytics_service.R
@@ -90,8 +90,7 @@ kinesisanalytics <- function(config = list()) {
   target_prefix = "KinesisAnalytics_20150814"
 )
 
-.kinesisanalytics$handlers <- new_handlers("jsonrpc", "v4")
-
 .kinesisanalytics$service <- function(config = list()) {
-  new_service(.kinesisanalytics$metadata, .kinesisanalytics$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.kinesisanalytics$metadata, handlers, config)
 }

--- a/paws/R/kinesisanalyticsv2_service.R
+++ b/paws/R/kinesisanalyticsv2_service.R
@@ -92,8 +92,7 @@ kinesisanalyticsv2 <- function(config = list()) {
   target_prefix = "KinesisAnalytics_20180523"
 )
 
-.kinesisanalyticsv2$handlers <- new_handlers("jsonrpc", "v4")
-
 .kinesisanalyticsv2$service <- function(config = list()) {
-  new_service(.kinesisanalyticsv2$metadata, .kinesisanalyticsv2$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.kinesisanalyticsv2$metadata, handlers, config)
 }

--- a/paws/R/kinesisvideo_service.R
+++ b/paws/R/kinesisvideo_service.R
@@ -80,8 +80,7 @@ kinesisvideo <- function(config = list()) {
   target_prefix = ""
 )
 
-.kinesisvideo$handlers <- new_handlers("restjson", "v4")
-
 .kinesisvideo$service <- function(config = list()) {
-  new_service(.kinesisvideo$metadata, .kinesisvideo$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.kinesisvideo$metadata, handlers, config)
 }

--- a/paws/R/kinesisvideoarchivedmedia_service.R
+++ b/paws/R/kinesisvideoarchivedmedia_service.R
@@ -65,8 +65,7 @@ kinesisvideoarchivedmedia <- function(config = list()) {
   target_prefix = ""
 )
 
-.kinesisvideoarchivedmedia$handlers <- new_handlers("restjson", "v4")
-
 .kinesisvideoarchivedmedia$service <- function(config = list()) {
-  new_service(.kinesisvideoarchivedmedia$metadata, .kinesisvideoarchivedmedia$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.kinesisvideoarchivedmedia$metadata, handlers, config)
 }

--- a/paws/R/kinesisvideomedia_service.R
+++ b/paws/R/kinesisvideomedia_service.R
@@ -62,8 +62,7 @@ kinesisvideomedia <- function(config = list()) {
   target_prefix = ""
 )
 
-.kinesisvideomedia$handlers <- new_handlers("restjson", "v4")
-
 .kinesisvideomedia$service <- function(config = list()) {
-  new_service(.kinesisvideomedia$metadata, .kinesisvideomedia$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.kinesisvideomedia$metadata, handlers, config)
 }

--- a/paws/R/kinesisvideosignalingchannels_service.R
+++ b/paws/R/kinesisvideosignalingchannels_service.R
@@ -67,8 +67,7 @@ kinesisvideosignalingchannels <- function(config = list()) {
   target_prefix = ""
 )
 
-.kinesisvideosignalingchannels$handlers <- new_handlers("restjson", "v4")
-
 .kinesisvideosignalingchannels$service <- function(config = list()) {
-  new_service(.kinesisvideosignalingchannels$metadata, .kinesisvideosignalingchannels$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.kinesisvideosignalingchannels$metadata, handlers, config)
 }

--- a/paws/R/kms_service.R
+++ b/paws/R/kms_service.R
@@ -189,8 +189,7 @@ kms <- function(config = list()) {
   target_prefix = "TrentService"
 )
 
-.kms$handlers <- new_handlers("jsonrpc", "v4")
-
 .kms$service <- function(config = list()) {
-  new_service(.kms$metadata, .kms$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.kms$metadata, handlers, config)
 }

--- a/paws/R/lakeformation_service.R
+++ b/paws/R/lakeformation_service.R
@@ -75,8 +75,7 @@ lakeformation <- function(config = list()) {
   target_prefix = "AWSLakeFormation"
 )
 
-.lakeformation$handlers <- new_handlers("jsonrpc", "v4")
-
 .lakeformation$service <- function(config = list()) {
-  new_service(.lakeformation$metadata, .lakeformation$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.lakeformation$metadata, handlers, config)
 }

--- a/paws/R/lambda_service.R
+++ b/paws/R/lambda_service.R
@@ -125,8 +125,7 @@ lambda <- function(config = list()) {
   target_prefix = ""
 )
 
-.lambda$handlers <- new_handlers("restjson", "v4")
-
 .lambda$service <- function(config = list()) {
-  new_service(.lambda$metadata, .lambda$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.lambda$metadata, handlers, config)
 }

--- a/paws/R/lexmodelbuildingservice_service.R
+++ b/paws/R/lexmodelbuildingservice_service.R
@@ -104,8 +104,7 @@ lexmodelbuildingservice <- function(config = list()) {
   target_prefix = ""
 )
 
-.lexmodelbuildingservice$handlers <- new_handlers("restjson", "v4")
-
 .lexmodelbuildingservice$service <- function(config = list()) {
-  new_service(.lexmodelbuildingservice$metadata, .lexmodelbuildingservice$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.lexmodelbuildingservice$metadata, handlers, config)
 }

--- a/paws/R/lexruntimeservice_service.R
+++ b/paws/R/lexruntimeservice_service.R
@@ -78,8 +78,7 @@ lexruntimeservice <- function(config = list()) {
   target_prefix = ""
 )
 
-.lexruntimeservice$handlers <- new_handlers("restjson", "v4")
-
 .lexruntimeservice$service <- function(config = list()) {
-  new_service(.lexruntimeservice$metadata, .lexruntimeservice$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.lexruntimeservice$metadata, handlers, config)
 }

--- a/paws/R/licensemanager_service.R
+++ b/paws/R/licensemanager_service.R
@@ -79,8 +79,7 @@ licensemanager <- function(config = list()) {
   target_prefix = "AWSLicenseManager"
 )
 
-.licensemanager$handlers <- new_handlers("jsonrpc", "v4")
-
 .licensemanager$service <- function(config = list()) {
-  new_service(.licensemanager$metadata, .licensemanager$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.licensemanager$metadata, handlers, config)
 }

--- a/paws/R/lightsail_service.R
+++ b/paws/R/lightsail_service.R
@@ -181,8 +181,7 @@ lightsail <- function(config = list()) {
   target_prefix = "Lightsail_20161128"
 )
 
-.lightsail$handlers <- new_handlers("jsonrpc", "v4")
-
 .lightsail$service <- function(config = list()) {
-  new_service(.lightsail$metadata, .lightsail$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.lightsail$metadata, handlers, config)
 }

--- a/paws/R/machinelearning_service.R
+++ b/paws/R/machinelearning_service.R
@@ -90,8 +90,7 @@ machinelearning <- function(config = list()) {
   target_prefix = "AmazonML_20141212"
 )
 
-.machinelearning$handlers <- new_handlers("jsonrpc", "v4")
-
 .machinelearning$service <- function(config = list()) {
-  new_service(.machinelearning$metadata, .machinelearning$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.machinelearning$metadata, handlers, config)
 }

--- a/paws/R/macie_service.R
+++ b/paws/R/macie_service.R
@@ -75,8 +75,7 @@ macie <- function(config = list()) {
   target_prefix = "MacieService"
 )
 
-.macie$handlers <- new_handlers("jsonrpc", "v4")
-
 .macie$service <- function(config = list()) {
-  new_service(.macie$metadata, .macie$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.macie$metadata, handlers, config)
 }

--- a/paws/R/managedblockchain_service.R
+++ b/paws/R/managedblockchain_service.R
@@ -85,8 +85,7 @@ managedblockchain <- function(config = list()) {
   target_prefix = ""
 )
 
-.managedblockchain$handlers <- new_handlers("restjson", "v4")
-
 .managedblockchain$service <- function(config = list()) {
-  new_service(.managedblockchain$metadata, .managedblockchain$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.managedblockchain$metadata, handlers, config)
 }

--- a/paws/R/marketplacecatalog_service.R
+++ b/paws/R/marketplacecatalog_service.R
@@ -75,8 +75,7 @@ marketplacecatalog <- function(config = list()) {
   target_prefix = ""
 )
 
-.marketplacecatalog$handlers <- new_handlers("restjson", "v4")
-
 .marketplacecatalog$service <- function(config = list()) {
-  new_service(.marketplacecatalog$metadata, .marketplacecatalog$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.marketplacecatalog$metadata, handlers, config)
 }

--- a/paws/R/marketplacecommerceanalytics_service.R
+++ b/paws/R/marketplacecommerceanalytics_service.R
@@ -64,8 +64,7 @@ marketplacecommerceanalytics <- function(config = list()) {
   target_prefix = "MarketplaceCommerceAnalytics20150701"
 )
 
-.marketplacecommerceanalytics$handlers <- new_handlers("jsonrpc", "v4")
-
 .marketplacecommerceanalytics$service <- function(config = list()) {
-  new_service(.marketplacecommerceanalytics$metadata, .marketplacecommerceanalytics$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.marketplacecommerceanalytics$metadata, handlers, config)
 }

--- a/paws/R/marketplaceentitlementservice_service.R
+++ b/paws/R/marketplaceentitlementservice_service.R
@@ -74,8 +74,7 @@ marketplaceentitlementservice <- function(config = list()) {
   target_prefix = "AWSMPEntitlementService"
 )
 
-.marketplaceentitlementservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .marketplaceentitlementservice$service <- function(config = list()) {
-  new_service(.marketplaceentitlementservice$metadata, .marketplaceentitlementservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.marketplaceentitlementservice$metadata, handlers, config)
 }

--- a/paws/R/marketplacemetering_service.R
+++ b/paws/R/marketplacemetering_service.R
@@ -109,8 +109,7 @@ marketplacemetering <- function(config = list()) {
   target_prefix = "AWSMPMeteringService"
 )
 
-.marketplacemetering$handlers <- new_handlers("jsonrpc", "v4")
-
 .marketplacemetering$service <- function(config = list()) {
-  new_service(.marketplacemetering$metadata, .marketplacemetering$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.marketplacemetering$metadata, handlers, config)
 }

--- a/paws/R/mediaconnect_service.R
+++ b/paws/R/mediaconnect_service.R
@@ -79,8 +79,7 @@ mediaconnect <- function(config = list()) {
   target_prefix = ""
 )
 
-.mediaconnect$handlers <- new_handlers("restjson", "v4")
-
 .mediaconnect$service <- function(config = list()) {
-  new_service(.mediaconnect$metadata, .mediaconnect$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mediaconnect$metadata, handlers, config)
 }

--- a/paws/R/mediaconvert_service.R
+++ b/paws/R/mediaconvert_service.R
@@ -87,8 +87,7 @@ mediaconvert <- function(config = list()) {
   target_prefix = ""
 )
 
-.mediaconvert$handlers <- new_handlers("restjson", "v4")
-
 .mediaconvert$service <- function(config = list()) {
-  new_service(.mediaconvert$metadata, .mediaconvert$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mediaconvert$metadata, handlers, config)
 }

--- a/paws/R/medialive_service.R
+++ b/paws/R/medialive_service.R
@@ -105,8 +105,7 @@ medialive <- function(config = list()) {
   target_prefix = ""
 )
 
-.medialive$handlers <- new_handlers("restjson", "v4")
-
 .medialive$service <- function(config = list()) {
-  new_service(.medialive$metadata, .medialive$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.medialive$metadata, handlers, config)
 }

--- a/paws/R/mediapackage_service.R
+++ b/paws/R/mediapackage_service.R
@@ -80,8 +80,7 @@ mediapackage <- function(config = list()) {
   target_prefix = ""
 )
 
-.mediapackage$handlers <- new_handlers("restjson", "v4")
-
 .mediapackage$service <- function(config = list()) {
-  new_service(.mediapackage$metadata, .mediapackage$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mediapackage$metadata, handlers, config)
 }

--- a/paws/R/mediapackagevod_service.R
+++ b/paws/R/mediapackagevod_service.R
@@ -74,8 +74,7 @@ mediapackagevod <- function(config = list()) {
   target_prefix = ""
 )
 
-.mediapackagevod$handlers <- new_handlers("restjson", "v4")
-
 .mediapackagevod$service <- function(config = list()) {
-  new_service(.mediapackagevod$metadata, .mediapackagevod$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mediapackagevod$metadata, handlers, config)
 }

--- a/paws/R/mediastore_service.R
+++ b/paws/R/mediastore_service.R
@@ -82,8 +82,7 @@ mediastore <- function(config = list()) {
   target_prefix = "MediaStore_20170901"
 )
 
-.mediastore$handlers <- new_handlers("jsonrpc", "v4")
-
 .mediastore$service <- function(config = list()) {
-  new_service(.mediastore$metadata, .mediastore$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.mediastore$metadata, handlers, config)
 }

--- a/paws/R/mediastoredata_service.R
+++ b/paws/R/mediastoredata_service.R
@@ -69,8 +69,7 @@ mediastoredata <- function(config = list()) {
   target_prefix = ""
 )
 
-.mediastoredata$handlers <- new_handlers("restjson", "v4")
-
 .mediastoredata$service <- function(config = list()) {
-  new_service(.mediastoredata$metadata, .mediastoredata$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mediastoredata$metadata, handlers, config)
 }

--- a/paws/R/mediatailor_service.R
+++ b/paws/R/mediatailor_service.R
@@ -79,8 +79,7 @@ mediatailor <- function(config = list()) {
   target_prefix = ""
 )
 
-.mediatailor$handlers <- new_handlers("restjson", "v4")
-
 .mediatailor$service <- function(config = list()) {
-  new_service(.mediatailor$metadata, .mediatailor$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mediatailor$metadata, handlers, config)
 }

--- a/paws/R/migrationhub_service.R
+++ b/paws/R/migrationhub_service.R
@@ -85,8 +85,7 @@ migrationhub <- function(config = list()) {
   target_prefix = "AWSMigrationHub"
 )
 
-.migrationhub$handlers <- new_handlers("jsonrpc", "v4")
-
 .migrationhub$service <- function(config = list()) {
-  new_service(.migrationhub$metadata, .migrationhub$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.migrationhub$metadata, handlers, config)
 }

--- a/paws/R/migrationhubconfig_service.R
+++ b/paws/R/migrationhubconfig_service.R
@@ -86,8 +86,7 @@ migrationhubconfig <- function(config = list()) {
   target_prefix = "AWSMigrationHubMultiAccountService"
 )
 
-.migrationhubconfig$handlers <- new_handlers("jsonrpc", "v4")
-
 .migrationhubconfig$service <- function(config = list()) {
-  new_service(.migrationhubconfig$metadata, .migrationhubconfig$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.migrationhubconfig$metadata, handlers, config)
 }

--- a/paws/R/mobile_service.R
+++ b/paws/R/mobile_service.R
@@ -74,8 +74,7 @@ mobile <- function(config = list()) {
   target_prefix = ""
 )
 
-.mobile$handlers <- new_handlers("restjson", "v4")
-
 .mobile$service <- function(config = list()) {
-  new_service(.mobile$metadata, .mobile$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mobile$metadata, handlers, config)
 }

--- a/paws/R/mobileanalytics_service.R
+++ b/paws/R/mobileanalytics_service.R
@@ -64,8 +64,7 @@ mobileanalytics <- function(config = list()) {
   target_prefix = ""
 )
 
-.mobileanalytics$handlers <- new_handlers("restjson", "v4")
-
 .mobileanalytics$service <- function(config = list()) {
-  new_service(.mobileanalytics$metadata, .mobileanalytics$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mobileanalytics$metadata, handlers, config)
 }

--- a/paws/R/mq_service.R
+++ b/paws/R/mq_service.R
@@ -84,8 +84,7 @@ mq <- function(config = list()) {
   target_prefix = ""
 )
 
-.mq$handlers <- new_handlers("restjson", "v4")
-
 .mq$service <- function(config = list()) {
-  new_service(.mq$metadata, .mq$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.mq$metadata, handlers, config)
 }

--- a/paws/R/mturk_service.R
+++ b/paws/R/mturk_service.R
@@ -101,8 +101,7 @@ mturk <- function(config = list()) {
   target_prefix = "MTurkRequesterServiceV20170117"
 )
 
-.mturk$handlers <- new_handlers("jsonrpc", "v4")
-
 .mturk$service <- function(config = list()) {
-  new_service(.mturk$metadata, .mturk$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.mturk$metadata, handlers, config)
 }

--- a/paws/R/neptune_service.R
+++ b/paws/R/neptune_service.R
@@ -139,8 +139,7 @@ neptune <- function(config = list()) {
   target_prefix = ""
 )
 
-.neptune$handlers <- new_handlers("query", "v4")
-
 .neptune$service <- function(config = list()) {
-  new_service(.neptune$metadata, .neptune$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.neptune$metadata, handlers, config)
 }

--- a/paws/R/networkmanager_service.R
+++ b/paws/R/networkmanager_service.R
@@ -92,8 +92,7 @@ networkmanager <- function(config = list()) {
   target_prefix = ""
 )
 
-.networkmanager$handlers <- new_handlers("restjson", "v4")
-
 .networkmanager$service <- function(config = list()) {
-  new_service(.networkmanager$metadata, .networkmanager$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.networkmanager$metadata, handlers, config)
 }

--- a/paws/R/opsworks_service.R
+++ b/paws/R/opsworks_service.R
@@ -219,8 +219,7 @@ opsworks <- function(config = list()) {
   target_prefix = "OpsWorks_20130218"
 )
 
-.opsworks$handlers <- new_handlers("jsonrpc", "v4")
-
 .opsworks$service <- function(config = list()) {
-  new_service(.opsworks$metadata, .opsworks$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.opsworks$metadata, handlers, config)
 }

--- a/paws/R/opsworkscm_service.R
+++ b/paws/R/opsworkscm_service.R
@@ -145,8 +145,7 @@ opsworkscm <- function(config = list()) {
   target_prefix = "OpsWorksCM_V2016_11_01"
 )
 
-.opsworkscm$handlers <- new_handlers("jsonrpc", "v4")
-
 .opsworkscm$service <- function(config = list()) {
-  new_service(.opsworkscm$metadata, .opsworkscm$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.opsworkscm$metadata, handlers, config)
 }

--- a/paws/R/organizations_service.R
+++ b/paws/R/organizations_service.R
@@ -113,8 +113,7 @@ organizations <- function(config = list()) {
   target_prefix = "AWSOrganizationsV20161128"
 )
 
-.organizations$handlers <- new_handlers("jsonrpc", "v4")
-
 .organizations$service <- function(config = list()) {
-  new_service(.organizations$metadata, .organizations$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.organizations$metadata, handlers, config)
 }

--- a/paws/R/outposts_service.R
+++ b/paws/R/outposts_service.R
@@ -72,8 +72,7 @@ outposts <- function(config = list()) {
   target_prefix = ""
 )
 
-.outposts$handlers <- new_handlers("restjson", "v4")
-
 .outposts$service <- function(config = list()) {
-  new_service(.outposts$metadata, .outposts$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.outposts$metadata, handlers, config)
 }

--- a/paws/R/personalize_service.R
+++ b/paws/R/personalize_service.R
@@ -102,8 +102,7 @@ personalize <- function(config = list()) {
   target_prefix = "AmazonPersonalize"
 )
 
-.personalize$handlers <- new_handlers("jsonrpc", "v4")
-
 .personalize$service <- function(config = list()) {
-  new_service(.personalize$metadata, .personalize$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.personalize$metadata, handlers, config)
 }

--- a/paws/R/personalizeevents_service.R
+++ b/paws/R/personalizeevents_service.R
@@ -62,8 +62,7 @@ personalizeevents <- function(config = list()) {
   target_prefix = ""
 )
 
-.personalizeevents$handlers <- new_handlers("restjson", "v4")
-
 .personalizeevents$service <- function(config = list()) {
-  new_service(.personalizeevents$metadata, .personalizeevents$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.personalizeevents$metadata, handlers, config)
 }

--- a/paws/R/personalizeruntime_service.R
+++ b/paws/R/personalizeruntime_service.R
@@ -63,8 +63,7 @@ personalizeruntime <- function(config = list()) {
   target_prefix = ""
 )
 
-.personalizeruntime$handlers <- new_handlers("restjson", "v4")
-
 .personalizeruntime$service <- function(config = list()) {
-  new_service(.personalizeruntime$metadata, .personalizeruntime$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.personalizeruntime$metadata, handlers, config)
 }

--- a/paws/R/pi_service.R
+++ b/paws/R/pi_service.R
@@ -82,8 +82,7 @@ pi <- function(config = list()) {
   target_prefix = "PerformanceInsightsv20180227"
 )
 
-.pi$handlers <- new_handlers("jsonrpc", "v4")
-
 .pi$service <- function(config = list()) {
-  new_service(.pi$metadata, .pi$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.pi$metadata, handlers, config)
 }

--- a/paws/R/pinpoint_service.R
+++ b/paws/R/pinpoint_service.R
@@ -169,8 +169,7 @@ pinpoint <- function(config = list()) {
   target_prefix = ""
 )
 
-.pinpoint$handlers <- new_handlers("restjson", "v4")
-
 .pinpoint$service <- function(config = list()) {
-  new_service(.pinpoint$metadata, .pinpoint$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.pinpoint$metadata, handlers, config)
 }

--- a/paws/R/pinpointemail_service.R
+++ b/paws/R/pinpointemail_service.R
@@ -142,8 +142,7 @@ pinpointemail <- function(config = list()) {
   target_prefix = ""
 )
 
-.pinpointemail$handlers <- new_handlers("restjson", "v4")
-
 .pinpointemail$service <- function(config = list()) {
-  new_service(.pinpointemail$metadata, .pinpointemail$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.pinpointemail$metadata, handlers, config)
 }

--- a/paws/R/pinpointsmsvoice_service.R
+++ b/paws/R/pinpointsmsvoice_service.R
@@ -70,8 +70,7 @@ pinpointsmsvoice <- function(config = list()) {
   target_prefix = ""
 )
 
-.pinpointsmsvoice$handlers <- new_handlers("restjson", "v4")
-
 .pinpointsmsvoice$service <- function(config = list()) {
-  new_service(.pinpointsmsvoice$metadata, .pinpointsmsvoice$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.pinpointsmsvoice$metadata, handlers, config)
 }

--- a/paws/R/polly_service.R
+++ b/paws/R/polly_service.R
@@ -78,8 +78,7 @@ polly <- function(config = list()) {
   target_prefix = ""
 )
 
-.polly$handlers <- new_handlers("restjson", "v4")
-
 .polly$service <- function(config = list()) {
-  new_service(.polly$metadata, .polly$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.polly$metadata, handlers, config)
 }

--- a/paws/R/pricing_service.R
+++ b/paws/R/pricing_service.R
@@ -92,8 +92,7 @@ pricing <- function(config = list()) {
   target_prefix = "AWSPriceListService"
 )
 
-.pricing$handlers <- new_handlers("jsonrpc", "v4")
-
 .pricing$service <- function(config = list()) {
-  new_service(.pricing$metadata, .pricing$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.pricing$metadata, handlers, config)
 }

--- a/paws/R/qldb_service.R
+++ b/paws/R/qldb_service.R
@@ -77,8 +77,7 @@ qldb <- function(config = list()) {
   target_prefix = ""
 )
 
-.qldb$handlers <- new_handlers("restjson", "v4")
-
 .qldb$service <- function(config = list()) {
-  new_service(.qldb$metadata, .qldb$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.qldb$metadata, handlers, config)
 }

--- a/paws/R/qldbsession_service.R
+++ b/paws/R/qldbsession_service.R
@@ -63,8 +63,7 @@ qldbsession <- function(config = list()) {
   target_prefix = "QLDBSession"
 )
 
-.qldbsession$handlers <- new_handlers("jsonrpc", "v4")
-
 .qldbsession$service <- function(config = list()) {
-  new_service(.qldbsession$metadata, .qldbsession$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.qldbsession$metadata, handlers, config)
 }

--- a/paws/R/quicksight_service.R
+++ b/paws/R/quicksight_service.R
@@ -133,8 +133,7 @@ quicksight <- function(config = list()) {
   target_prefix = ""
 )
 
-.quicksight$handlers <- new_handlers("restjson", "v4")
-
 .quicksight$service <- function(config = list()) {
-  new_service(.quicksight$metadata, .quicksight$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.quicksight$metadata, handlers, config)
 }

--- a/paws/R/ram_service.R
+++ b/paws/R/ram_service.R
@@ -93,8 +93,7 @@ ram <- function(config = list()) {
   target_prefix = ""
 )
 
-.ram$handlers <- new_handlers("restjson", "v4")
-
 .ram$service <- function(config = list()) {
-  new_service(.ram$metadata, .ram$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.ram$metadata, handlers, config)
 }

--- a/paws/R/rds_service.R
+++ b/paws/R/rds_service.R
@@ -239,8 +239,7 @@ rds <- function(config = list()) {
   target_prefix = ""
 )
 
-.rds$handlers <- new_handlers("query", "v4")
-
 .rds$service <- function(config = list()) {
-  new_service(.rds$metadata, .rds$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.rds$metadata, handlers, config)
 }

--- a/paws/R/rdsdataservice_service.R
+++ b/paws/R/rdsdataservice_service.R
@@ -80,8 +80,7 @@ rdsdataservice <- function(config = list()) {
   target_prefix = ""
 )
 
-.rdsdataservice$handlers <- new_handlers("restjson", "v4")
-
 .rdsdataservice$service <- function(config = list()) {
-  new_service(.rdsdataservice$metadata, .rdsdataservice$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.rdsdataservice$metadata, handlers, config)
 }

--- a/paws/R/redshift_service.R
+++ b/paws/R/redshift_service.R
@@ -175,8 +175,7 @@ redshift <- function(config = list()) {
   target_prefix = ""
 )
 
-.redshift$handlers <- new_handlers("query", "v4")
-
 .redshift$service <- function(config = list()) {
-  new_service(.redshift$metadata, .redshift$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.redshift$metadata, handlers, config)
 }

--- a/paws/R/rekognition_service.R
+++ b/paws/R/rekognition_service.R
@@ -117,8 +117,7 @@ rekognition <- function(config = list()) {
   target_prefix = "RekognitionService"
 )
 
-.rekognition$handlers <- new_handlers("jsonrpc", "v4")
-
 .rekognition$service <- function(config = list()) {
-  new_service(.rekognition$metadata, .rekognition$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.rekognition$metadata, handlers, config)
 }

--- a/paws/R/resourcegroups_service.R
+++ b/paws/R/resourcegroups_service.R
@@ -109,8 +109,7 @@ resourcegroups <- function(config = list()) {
   target_prefix = ""
 )
 
-.resourcegroups$handlers <- new_handlers("restjson", "v4")
-
 .resourcegroups$service <- function(config = list()) {
-  new_service(.resourcegroups$metadata, .resourcegroups$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.resourcegroups$metadata, handlers, config)
 }

--- a/paws/R/resourcegroupstaggingapi_service.R
+++ b/paws/R/resourcegroupstaggingapi_service.R
@@ -297,8 +297,7 @@ resourcegroupstaggingapi <- function(config = list()) {
   target_prefix = "ResourceGroupsTaggingAPI_20170126"
 )
 
-.resourcegroupstaggingapi$handlers <- new_handlers("jsonrpc", "v4")
-
 .resourcegroupstaggingapi$service <- function(config = list()) {
-  new_service(.resourcegroupstaggingapi$metadata, .resourcegroupstaggingapi$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.resourcegroupstaggingapi$metadata, handlers, config)
 }

--- a/paws/R/robomaker_service.R
+++ b/paws/R/robomaker_service.R
@@ -99,8 +99,7 @@ robomaker <- function(config = list()) {
   target_prefix = ""
 )
 
-.robomaker$handlers <- new_handlers("restjson", "v4")
-
 .robomaker$service <- function(config = list()) {
-  new_service(.robomaker$metadata, .robomaker$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.robomaker$metadata, handlers, config)
 }

--- a/paws/R/route53_service.R
+++ b/paws/R/route53_service.R
@@ -126,8 +126,7 @@ route53 <- function(config = list()) {
   target_prefix = ""
 )
 
-.route53$handlers <- new_handlers("restxml", "v4")
-
 .route53$service <- function(config = list()) {
-  new_service(.route53$metadata, .route53$handlers, config)
+  handlers <- new_handlers("restxml", "v4")
+  new_service(.route53$metadata, handlers, config)
 }

--- a/paws/R/route53domains_service.R
+++ b/paws/R/route53domains_service.R
@@ -87,8 +87,7 @@ route53domains <- function(config = list()) {
   target_prefix = "Route53Domains_v20140515"
 )
 
-.route53domains$handlers <- new_handlers("jsonrpc", "v4")
-
 .route53domains$service <- function(config = list()) {
-  new_service(.route53domains$metadata, .route53domains$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.route53domains$metadata, handlers, config)
 }

--- a/paws/R/route53resolver_service.R
+++ b/paws/R/route53resolver_service.R
@@ -116,8 +116,7 @@ route53resolver <- function(config = list()) {
   target_prefix = "Route53Resolver"
 )
 
-.route53resolver$handlers <- new_handlers("jsonrpc", "v4")
-
 .route53resolver$service <- function(config = list()) {
-  new_service(.route53resolver$metadata, .route53resolver$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.route53resolver$metadata, handlers, config)
 }

--- a/paws/R/s3_service.R
+++ b/paws/R/s3_service.R
@@ -152,8 +152,7 @@ s3 <- function(config = list()) {
   target_prefix = ""
 )
 
-.s3$handlers <- new_handlers("restxml", "s3")
-
 .s3$service <- function(config = list()) {
-  new_service(.s3$metadata, .s3$handlers, config)
+  handlers <- new_handlers("restxml", "s3")
+  new_service(.s3$metadata, handlers, config)
 }

--- a/paws/R/s3control_service.R
+++ b/paws/R/s3control_service.R
@@ -78,8 +78,7 @@ s3control <- function(config = list()) {
   target_prefix = ""
 )
 
-.s3control$handlers <- new_handlers("restxml", "s3v4")
-
 .s3control$service <- function(config = list()) {
-  new_service(.s3control$metadata, .s3control$handlers, config)
+  handlers <- new_handlers("restxml", "s3v4")
+  new_service(.s3control$metadata, handlers, config)
 }

--- a/paws/R/sagemaker_service.R
+++ b/paws/R/sagemaker_service.R
@@ -193,8 +193,7 @@ sagemaker <- function(config = list()) {
   target_prefix = "SageMaker"
 )
 
-.sagemaker$handlers <- new_handlers("jsonrpc", "v4")
-
 .sagemaker$service <- function(config = list()) {
-  new_service(.sagemaker$metadata, .sagemaker$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.sagemaker$metadata, handlers, config)
 }

--- a/paws/R/sagemakerruntime_service.R
+++ b/paws/R/sagemakerruntime_service.R
@@ -63,8 +63,7 @@ sagemakerruntime <- function(config = list()) {
   target_prefix = ""
 )
 
-.sagemakerruntime$handlers <- new_handlers("restjson", "v4")
-
 .sagemakerruntime$service <- function(config = list()) {
-  new_service(.sagemakerruntime$metadata, .sagemakerruntime$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.sagemakerruntime$metadata, handlers, config)
 }

--- a/paws/R/savingsplans_service.R
+++ b/paws/R/savingsplans_service.R
@@ -75,8 +75,7 @@ savingsplans <- function(config = list()) {
   target_prefix = ""
 )
 
-.savingsplans$handlers <- new_handlers("restjson", "v4")
-
 .savingsplans$service <- function(config = list()) {
-  new_service(.savingsplans$metadata, .savingsplans$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.savingsplans$metadata, handlers, config)
 }

--- a/paws/R/schemas_service.R
+++ b/paws/R/schemas_service.R
@@ -91,8 +91,7 @@ schemas <- function(config = list()) {
   target_prefix = ""
 )
 
-.schemas$handlers <- new_handlers("restjson", "v4")
-
 .schemas$service <- function(config = list()) {
-  new_service(.schemas$metadata, .schemas$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.schemas$metadata, handlers, config)
 }

--- a/paws/R/secretsmanager_service.R
+++ b/paws/R/secretsmanager_service.R
@@ -154,8 +154,7 @@ secretsmanager <- function(config = list()) {
   target_prefix = "secretsmanager"
 )
 
-.secretsmanager$handlers <- new_handlers("jsonrpc", "v4")
-
 .secretsmanager$service <- function(config = list()) {
-  new_service(.secretsmanager$metadata, .secretsmanager$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.secretsmanager$metadata, handlers, config)
 }

--- a/paws/R/securityhub_service.R
+++ b/paws/R/securityhub_service.R
@@ -133,8 +133,7 @@ securityhub <- function(config = list()) {
   target_prefix = ""
 )
 
-.securityhub$handlers <- new_handlers("restjson", "v4")
-
 .securityhub$service <- function(config = list()) {
-  new_service(.securityhub$metadata, .securityhub$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.securityhub$metadata, handlers, config)
 }

--- a/paws/R/serverlessapplicationrepository_service.R
+++ b/paws/R/serverlessapplicationrepository_service.R
@@ -107,8 +107,7 @@ serverlessapplicationrepository <- function(config = list()) {
   target_prefix = ""
 )
 
-.serverlessapplicationrepository$handlers <- new_handlers("restjson", "v4")
-
 .serverlessapplicationrepository$service <- function(config = list()) {
-  new_service(.serverlessapplicationrepository$metadata, .serverlessapplicationrepository$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.serverlessapplicationrepository$metadata, handlers, config)
 }

--- a/paws/R/servicecatalog_service.R
+++ b/paws/R/servicecatalog_service.R
@@ -150,8 +150,7 @@ servicecatalog <- function(config = list()) {
   target_prefix = "AWS242ServiceCatalogService"
 )
 
-.servicecatalog$handlers <- new_handlers("jsonrpc", "v4")
-
 .servicecatalog$service <- function(config = list()) {
-  new_service(.servicecatalog$metadata, .servicecatalog$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.servicecatalog$metadata, handlers, config)
 }

--- a/paws/R/servicediscovery_service.R
+++ b/paws/R/servicediscovery_service.R
@@ -89,8 +89,7 @@ servicediscovery <- function(config = list()) {
   target_prefix = "Route53AutoNaming_v20170314"
 )
 
-.servicediscovery$handlers <- new_handlers("jsonrpc", "v4")
-
 .servicediscovery$service <- function(config = list()) {
-  new_service(.servicediscovery$metadata, .servicediscovery$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.servicediscovery$metadata, handlers, config)
 }

--- a/paws/R/servicequotas_service.R
+++ b/paws/R/servicequotas_service.R
@@ -91,8 +91,7 @@ servicequotas <- function(config = list()) {
   target_prefix = "ServiceQuotasV20190624"
 )
 
-.servicequotas$handlers <- new_handlers("jsonrpc", "v4")
-
 .servicequotas$service <- function(config = list()) {
-  new_service(.servicequotas$metadata, .servicequotas$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.servicequotas$metadata, handlers, config)
 }

--- a/paws/R/ses_operations.R
+++ b/paws/R/ses_operations.R
@@ -2567,9 +2567,9 @@ ses_send_bounce <- function(OriginalMessageId, BounceSender, Explanation = NULL,
 #' Guide](https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html).
 #' 
 #' Amazon SES does not support the SMTPUTF8 extension, as described in
-#' [RFC6531](https://tools.ietf.org/html/rfc6531). For this reason, the
-#' *local part* of a source email address (the part of the email address
-#' that precedes the @ sign) may only contain [7-bit ASCII
+#' RFC6531. For this reason, the *local part* of a source email address
+#' (the part of the email address that precedes the @ sign) may only
+#' contain [7-bit ASCII
 #' characters](https://en.wikipedia.org/wiki/Email_address#Local-part). If
 #' the *domain part* of an address (the part after the @ sign) contains
 #' non-ASCII characters, they must be encoded using Punycode, as described

--- a/paws/R/ses_service.R
+++ b/paws/R/ses_service.R
@@ -146,8 +146,7 @@ ses <- function(config = list()) {
   target_prefix = ""
 )
 
-.ses$handlers <- new_handlers("query", "v4")
-
 .ses$service <- function(config = list()) {
-  new_service(.ses$metadata, .ses$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.ses$metadata, handlers, config)
 }

--- a/paws/R/sesv2_service.R
+++ b/paws/R/sesv2_service.R
@@ -143,8 +143,7 @@ sesv2 <- function(config = list()) {
   target_prefix = ""
 )
 
-.sesv2$handlers <- new_handlers("restjson", "v4")
-
 .sesv2$service <- function(config = list()) {
-  new_service(.sesv2$metadata, .sesv2$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.sesv2$metadata, handlers, config)
 }

--- a/paws/R/sfn_service.R
+++ b/paws/R/sfn_service.R
@@ -104,8 +104,7 @@ sfn <- function(config = list()) {
   target_prefix = "AWSStepFunctions"
 )
 
-.sfn$handlers <- new_handlers("jsonrpc", "v4")
-
 .sfn$service <- function(config = list()) {
-  new_service(.sfn$metadata, .sfn$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.sfn$metadata, handlers, config)
 }

--- a/paws/R/shield_service.R
+++ b/paws/R/shield_service.R
@@ -88,8 +88,7 @@ shield <- function(config = list()) {
   target_prefix = "AWSShield_20160616"
 )
 
-.shield$handlers <- new_handlers("jsonrpc", "v4")
-
 .shield$service <- function(config = list()) {
-  new_service(.shield$metadata, .shield$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.shield$metadata, handlers, config)
 }

--- a/paws/R/signer_service.R
+++ b/paws/R/signer_service.R
@@ -86,8 +86,7 @@ signer <- function(config = list()) {
   target_prefix = ""
 )
 
-.signer$handlers <- new_handlers("restjson", "v4")
-
 .signer$service <- function(config = list()) {
-  new_service(.signer$metadata, .signer$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.signer$metadata, handlers, config)
 }

--- a/paws/R/simpledb_service.R
+++ b/paws/R/simpledb_service.R
@@ -72,8 +72,7 @@ simpledb <- function(config = list()) {
   target_prefix = ""
 )
 
-.simpledb$handlers <- new_handlers("query", "v2")
-
 .simpledb$service <- function(config = list()) {
-  new_service(.simpledb$metadata, .simpledb$handlers, config)
+  handlers <- new_handlers("query", "v2")
+  new_service(.simpledb$metadata, handlers, config)
 }

--- a/paws/R/sms_service.R
+++ b/paws/R/sms_service.R
@@ -109,8 +109,7 @@ sms <- function(config = list()) {
   target_prefix = "AWSServerMigrationService_V2016_10_24"
 )
 
-.sms$handlers <- new_handlers("jsonrpc", "v4")
-
 .sms$service <- function(config = list()) {
-  new_service(.sms$metadata, .sms$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.sms$metadata, handlers, config)
 }

--- a/paws/R/snowball_service.R
+++ b/paws/R/snowball_service.R
@@ -92,8 +92,7 @@ snowball <- function(config = list()) {
   target_prefix = "AWSIESnowballJobManagementService"
 )
 
-.snowball$handlers <- new_handlers("jsonrpc", "v4")
-
 .snowball$service <- function(config = list()) {
-  new_service(.snowball$metadata, .snowball$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.snowball$metadata, handlers, config)
 }

--- a/paws/R/sns_service.R
+++ b/paws/R/sns_service.R
@@ -110,8 +110,7 @@ sns <- function(config = list()) {
   target_prefix = ""
 )
 
-.sns$handlers <- new_handlers("query", "v4")
-
 .sns$service <- function(config = list()) {
-  new_service(.sns$metadata, .sns$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.sns$metadata, handlers, config)
 }

--- a/paws/R/sqs_service.R
+++ b/paws/R/sqs_service.R
@@ -120,8 +120,7 @@ sqs <- function(config = list()) {
   target_prefix = ""
 )
 
-.sqs$handlers <- new_handlers("query", "v4")
-
 .sqs$service <- function(config = list()) {
-  new_service(.sqs$metadata, .sqs$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.sqs$metadata, handlers, config)
 }

--- a/paws/R/ssm_service.R
+++ b/paws/R/ssm_service.R
@@ -207,8 +207,7 @@ ssm <- function(config = list()) {
   target_prefix = "AmazonSSM"
 )
 
-.ssm$handlers <- new_handlers("jsonrpc", "v4")
-
 .ssm$service <- function(config = list()) {
-  new_service(.ssm$metadata, .ssm$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.ssm$metadata, handlers, config)
 }

--- a/paws/R/sso_service.R
+++ b/paws/R/sso_service.R
@@ -84,8 +84,7 @@ sso <- function(config = list()) {
   target_prefix = ""
 )
 
-.sso$handlers <- new_handlers("restjson", "v4")
-
 .sso$service <- function(config = list()) {
-  new_service(.sso$metadata, .sso$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.sso$metadata, handlers, config)
 }

--- a/paws/R/ssooidc_service.R
+++ b/paws/R/ssooidc_service.R
@@ -86,8 +86,7 @@ ssooidc <- function(config = list()) {
   target_prefix = ""
 )
 
-.ssooidc$handlers <- new_handlers("restjson", "v4")
-
 .ssooidc$service <- function(config = list()) {
-  new_service(.ssooidc$metadata, .ssooidc$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.ssooidc$metadata, handlers, config)
 }

--- a/paws/R/storagegateway_service.R
+++ b/paws/R/storagegateway_service.R
@@ -207,8 +207,7 @@ storagegateway <- function(config = list()) {
   target_prefix = "StorageGateway_20130630"
 )
 
-.storagegateway$handlers <- new_handlers("jsonrpc", "v4")
-
 .storagegateway$service <- function(config = list()) {
-  new_service(.storagegateway$metadata, .storagegateway$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.storagegateway$metadata, handlers, config)
 }

--- a/paws/R/sts_service.R
+++ b/paws/R/sts_service.R
@@ -187,8 +187,7 @@ sts <- function(config = list()) {
   target_prefix = ""
 )
 
-.sts$handlers <- new_handlers("query", "v4")
-
 .sts$service <- function(config = list()) {
-  new_service(.sts$metadata, .sts$handlers, config)
+  handlers <- new_handlers("query", "v4")
+  new_service(.sts$metadata, handlers, config)
 }

--- a/paws/R/support_service.R
+++ b/paws/R/support_service.R
@@ -133,8 +133,7 @@ support <- function(config = list()) {
   target_prefix = "AWSSupport_20130415"
 )
 
-.support$handlers <- new_handlers("jsonrpc", "v4")
-
 .support$service <- function(config = list()) {
-  new_service(.support$metadata, .support$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.support$metadata, handlers, config)
 }

--- a/paws/R/swf_service.R
+++ b/paws/R/swf_service.R
@@ -113,8 +113,7 @@ swf <- function(config = list()) {
   target_prefix = "SimpleWorkflowService"
 )
 
-.swf$handlers <- new_handlers("jsonrpc", "v4")
-
 .swf$service <- function(config = list()) {
-  new_service(.swf$metadata, .swf$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.swf$metadata, handlers, config)
 }

--- a/paws/R/textract_service.R
+++ b/paws/R/textract_service.R
@@ -70,8 +70,7 @@ textract <- function(config = list()) {
   target_prefix = "Textract"
 )
 
-.textract$handlers <- new_handlers("jsonrpc", "v4")
-
 .textract$service <- function(config = list()) {
-  new_service(.textract$metadata, .textract$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.textract$metadata, handlers, config)
 }

--- a/paws/R/transcribeservice_service.R
+++ b/paws/R/transcribeservice_service.R
@@ -76,8 +76,7 @@ transcribeservice <- function(config = list()) {
   target_prefix = "Transcribe"
 )
 
-.transcribeservice$handlers <- new_handlers("jsonrpc", "v4")
-
 .transcribeservice$service <- function(config = list()) {
-  new_service(.transcribeservice$metadata, .transcribeservice$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.transcribeservice$metadata, handlers, config)
 }

--- a/paws/R/transfer_service.R
+++ b/paws/R/transfer_service.R
@@ -90,8 +90,7 @@ transfer <- function(config = list()) {
   target_prefix = "TransferService"
 )
 
-.transfer$handlers <- new_handlers("jsonrpc", "v4")
-
 .transfer$service <- function(config = list()) {
-  new_service(.transfer$metadata, .transfer$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.transfer$metadata, handlers, config)
 }

--- a/paws/R/translate_service.R
+++ b/paws/R/translate_service.R
@@ -72,8 +72,7 @@ translate <- function(config = list()) {
   target_prefix = "AWSShineFrontendService_20170701"
 )
 
-.translate$handlers <- new_handlers("jsonrpc", "v4")
-
 .translate$service <- function(config = list()) {
-  new_service(.translate$metadata, .translate$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.translate$metadata, handlers, config)
 }

--- a/paws/R/waf_service.R
+++ b/paws/R/waf_service.R
@@ -148,8 +148,7 @@ waf <- function(config = list()) {
   target_prefix = "AWSWAF_20150824"
 )
 
-.waf$handlers <- new_handlers("jsonrpc", "v4")
-
 .waf$service <- function(config = list()) {
-  new_service(.waf$metadata, .waf$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.waf$metadata, handlers, config)
 }

--- a/paws/R/wafregional_service.R
+++ b/paws/R/wafregional_service.R
@@ -154,8 +154,7 @@ wafregional <- function(config = list()) {
   target_prefix = "AWSWAF_Regional_20161128"
 )
 
-.wafregional$handlers <- new_handlers("jsonrpc", "v4")
-
 .wafregional$service <- function(config = list()) {
-  new_service(.wafregional$metadata, .wafregional$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.wafregional$metadata, handlers, config)
 }

--- a/paws/R/wafv2_service.R
+++ b/paws/R/wafv2_service.R
@@ -162,8 +162,7 @@ wafv2 <- function(config = list()) {
   target_prefix = "AWSWAF_20190729"
 )
 
-.wafv2$handlers <- new_handlers("jsonrpc", "v4")
-
 .wafv2$service <- function(config = list()) {
-  new_service(.wafv2$metadata, .wafv2$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.wafv2$metadata, handlers, config)
 }

--- a/paws/R/workdocs_service.R
+++ b/paws/R/workdocs_service.R
@@ -135,8 +135,7 @@ workdocs <- function(config = list()) {
   target_prefix = ""
 )
 
-.workdocs$handlers <- new_handlers("restjson", "v4")
-
 .workdocs$service <- function(config = list()) {
-  new_service(.workdocs$metadata, .workdocs$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.workdocs$metadata, handlers, config)
 }

--- a/paws/R/worklink_service.R
+++ b/paws/R/worklink_service.R
@@ -100,8 +100,7 @@ worklink <- function(config = list()) {
   target_prefix = ""
 )
 
-.worklink$handlers <- new_handlers("restjson", "v4")
-
 .worklink$service <- function(config = list()) {
-  new_service(.worklink$metadata, .worklink$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.worklink$metadata, handlers, config)
 }

--- a/paws/R/workmail_service.R
+++ b/paws/R/workmail_service.R
@@ -129,8 +129,7 @@ workmail <- function(config = list()) {
   target_prefix = "WorkMailService"
 )
 
-.workmail$handlers <- new_handlers("jsonrpc", "v4")
-
 .workmail$service <- function(config = list()) {
-  new_service(.workmail$metadata, .workmail$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.workmail$metadata, handlers, config)
 }

--- a/paws/R/workmailmessageflow_service.R
+++ b/paws/R/workmailmessageflow_service.R
@@ -64,8 +64,7 @@ workmailmessageflow <- function(config = list()) {
   target_prefix = ""
 )
 
-.workmailmessageflow$handlers <- new_handlers("restjson", "v4")
-
 .workmailmessageflow$service <- function(config = list()) {
-  new_service(.workmailmessageflow$metadata, .workmailmessageflow$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.workmailmessageflow$metadata, handlers, config)
 }

--- a/paws/R/workspaces_service.R
+++ b/paws/R/workspaces_service.R
@@ -106,8 +106,7 @@ workspaces <- function(config = list()) {
   target_prefix = "WorkspacesService"
 )
 
-.workspaces$handlers <- new_handlers("jsonrpc", "v4")
-
 .workspaces$service <- function(config = list()) {
-  new_service(.workspaces$metadata, .workspaces$handlers, config)
+  handlers <- new_handlers("jsonrpc", "v4")
+  new_service(.workspaces$metadata, handlers, config)
 }

--- a/paws/R/xray_service.R
+++ b/paws/R/xray_service.R
@@ -83,8 +83,7 @@ xray <- function(config = list()) {
   target_prefix = ""
 )
 
-.xray$handlers <- new_handlers("restjson", "v4")
-
 .xray$service <- function(config = list()) {
-  new_service(.xray$metadata, .xray$handlers, config)
+  handlers <- new_handlers("restjson", "v4")
+  new_service(.xray$metadata, handlers, config)
 }

--- a/paws/man/forecastservice_create_dataset.Rd
+++ b/paws/man/forecastservice_create_dataset.Rd
@@ -65,7 +65,8 @@ predictor. For more information, see howitworks-datasets-groups.
 
 To get a list of all your datasets, use the ListDatasets operation.
 
-For example Forecast datasets, see the \href{https://github.com/aws-samples/amazon-forecast-samples/tree/master/data}{Amazon Forecast Sample GitHub repository}.
+For example Forecast datasets, see the Amazon Forecast Sample GitHub
+repository.
 
 The \code{Status} of a dataset must be \code{ACTIVE} before you can import
 training data. Use the DescribeDataset operation to get the status.

--- a/paws/man/ses_send_bulk_templated_email.Rd
+++ b/paws/man/ses_send_bulk_templated_email.Rd
@@ -20,9 +20,9 @@ do so by a sending authorization policy, then you must also specify the
 see the \href{https://docs.aws.amazon.com/ses/latest/DeveloperGuide/sending-authorization.html}{Amazon SES Developer Guide}.
 
 Amazon SES does not support the SMTPUTF8 extension, as described in
-\href{https://tools.ietf.org/html/rfc6531}{RFC6531}. For this reason, the
-\emph{local part} of a source email address (the part of the email address
-that precedes the @ sign) may only contain \href{https://en.wikipedia.org/wiki/Email_address#Local-part}{7-bit ASCII characters}. If
+RFC6531. For this reason, the \emph{local part} of a source email address
+(the part of the email address that precedes the @ sign) may only
+contain \href{https://en.wikipedia.org/wiki/Email_address#Local-part}{7-bit ASCII characters}. If
 the \emph{domain part} of an address (the part after the @ sign) contains
 non-ASCII characters, they must be encoded using Punycode, as described
 in \href{https://tools.ietf.org/html/rfc3492.html}{RFC3492}. The sender name


### PR DESCRIPTION
* Regenerate Paws due to the updates in #255, which makes Paws get its handlers at run time instead of build time.  This allows updates to handlers in `paws.common` without updating all the `paws.foo` packages.