### PR TITLE
Support S3's GetBucketLocation operation

### DIFF
--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -39,6 +39,8 @@ update_endpoint_for_s3_config <- function(request) {
 
   if (!host_compatible_bucket_name(bucket_name)) return(request)
 
+  if (request$operation$name %in% c("GetBucketLocation")) return(request)
+
   request$http_request$url <-
     move_bucket_to_host(request$http_request$url, bucket_name)
 

--- a/paws.common/tests/testthat/test_custom_s3.R
+++ b/paws.common/tests/testthat/test_custom_s3.R
@@ -1,13 +1,13 @@
 context("Custom S3")
 
-build_request <- function(bucket) {
+build_request <- function(bucket, operation) {
   metadata <- list(
     endpoints = list("*" = list(endpoint = "s3.amazonaws.com", global = FALSE)),
     service_name = "s3"
   )
   svc <- new_service(metadata, new_handlers("restxml", "s3"))
   op <- new_operation(
-    name = "ListObjects",
+    name = operation,
     http_method = "GET",
     http_path = "/{Bucket}",
     paginator = list()
@@ -19,15 +19,19 @@ build_request <- function(bucket) {
 }
 
 test_that("update_endpoint_for_s3_config", {
-  req <- build_request("foo")
+  req <- build_request(bucket = "foo", operation = "ListObjects")
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "foo.s3.amazonaws.com")
 
-  req <- build_request("foo-bar")
+  req <- build_request(bucket = "foo-bar", operation = "ListObjects")
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "foo-bar.s3.amazonaws.com")
 
-  req <- build_request("foo.bar")
+  req <- build_request(bucket = "foo.bar", operation = "ListObjects")
+  result <- update_endpoint_for_s3_config(req)
+  expect_equal(result$http_request$url$host, "s3.amazonaws.com")
+
+  req <- build_request(bucket = "foo-bar", operation = "GetBucketLocation")
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "s3.amazonaws.com")
 })


### PR DESCRIPTION
Addresses #257.

In general, S3 operations should use virtual-hosted-style URIs (e.g. `my-bucket.region.s3.amazonaws.com`). However, `GetBucketLocation` can't use these since you need to know the bucket region to use virtual-hosted-style URIs, but you don't necessarily know the bucket region when requesting it. We need to add an exception for this operation when creating the URI for the request.
