### PR TITLE
Do not run unmarshal handlers if the output shape is empty

### DIFF
--- a/paws.common/R/handlers.R
+++ b/paws.common/R/handlers.R
@@ -154,6 +154,7 @@ validate_response <- function(request) {
 }
 
 unmarshal <- function(request) {
+  if (length(request$data) == 0) return(request)
   request <- run(request, unmarshal)
   return(request)
 }

--- a/paws.common/tests/testthat/test_handlers_query.R
+++ b/paws.common/tests/testthat/test_handlers_query.R
@@ -701,6 +701,17 @@ test_that("unmarshal enums", {
   expect_equal(out$ListEnums, c("foo", "bar"))
 })
 
+op_output15 <- list()
+
+test_that("unmarshal empty output shape", {
+  req <- new_request(svc, op, NULL, op_output15)
+  req$http_response <- HttpResponse(
+    status_code = 200,
+    body = charToRaw("<OperationResponse xmlns=\"http://monitoring.amazonaws.com/doc/2010-08-01/\">\n  <ResponseMetadata>\n    <RequestId>123</RequestId>\n  </ResponseMetadata>\n</OperationResponse>\n")
+  )
+  expect_error(unmarshal(req), NA)
+})
+
 #-------------------------------------------------------------------------------
 
 # Unmarshal Error Tests


### PR DESCRIPTION
If the output shape is empty, i.e. it has no elements, then don't try to unmarshal the API response.

Addresses #271.

## Example

For example, in CloudWatch `PutMetricAlarm`, its output shape is empty -- it has no data elements -- but the API response contains some metadata. When its unmarshal handler gets called, the handler fails. With this update, it skips calling the unmarshal handler since there is nothing to unmarshal into.

### `PutMetricAlarm`'s output shape:

```
.cloudwatch$put_metric_alarm_output <- function(...) {
  list()
}
```

### `PutMetricAlarm` API response:

```
<PutMetricDataResponse xmlns=\"http://monitoring.amazonaws.com/doc/2010-08-01/\">
  <ResponseMetadata>
    <RequestId>317752ff-66e9-4f98-b643-661a35fff360</RequestId>
  </ResponseMetadata>
</PutMetricDataResponse>
```