### PR TITLE
Handle timestamps in API requests

### DIFF
--- a/paws.common/R/handlers_rest.R
+++ b/paws.common/R/handlers_rest.R
@@ -60,18 +60,18 @@ rest_build_header_map <- function(header, values) {
   prefix <- tag_get(values, "locationName")
   for (key in names(values)) {
     value <- values[[key]]
-    header[[paste0(prefix, key)]] <- convert_type(value)
+    header[[paste0(prefix, key)]] <- convert_type(value, timestamp_format = "unix")
   }
   return(header)
 }
 
 rest_build_header <- function(header, value, name) {
-  header[[name]] <- convert_type(value)
+  header[[name]] <- convert_type(value, timestamp_format = "rfc822")
   return(header)
 }
 
 rest_build_uri <- function(uri, value, name) {
-  str <- convert_type(value)
+  str <- convert_type(value, timestamp_format = "unix")
   uri$path <- sub(sprintf("{%s}", name), str, uri$path, fixed = TRUE)
   uri$path <- sub(sprintf("{%s+}", name), str, uri$path, fixed = TRUE)
   uri$raw_path <- sub(sprintf("{%s}", name), escape_path(str, TRUE), uri$raw_path, fixed = TRUE)
@@ -88,7 +88,7 @@ rest_build_query_string <- function(query, field, name) {
       query[[key]] <- field[[key]]
     }
   } else {
-    query[[name]] <- convert_type(field)
+    query[[name]] <- convert_type(field, timestamp_format = "iso8601")
   }
   return(query)
 }

--- a/paws.common/R/queryutil.R
+++ b/paws.common/R/queryutil.R
@@ -145,6 +145,6 @@ query_parse_map <- function(values, value, prefix, tag, is_ec2 = FALSE) {
 
 query_parse_scalar <- function(values, value, prefix, tag, is_ec2 = FALSE) {
   if (!is_valid(value)) return(values)
-  values[prefix] <- convert_type(value)
+  values[prefix] <- convert_type(value, timestamp_format = "iso8601")
   return(values)
 }

--- a/paws.common/tests/testthat/test_convert.R
+++ b/paws.common/tests/testthat/test_convert.R
@@ -16,3 +16,12 @@ test_that("raw_to_base64", {
   expect_equal(actual, expected)
   expect_false(grepl("\n", actual))
 })
+
+test_that("convert_type", {
+  value <- as.POSIXct("2010-01-01", tz = "UTC")
+  value <- tag_add(value, tags = list(type = "timestamp"))
+  expect_equal("2010-01-01T00:00:00Z", convert_type(value, timestamp_format = "iso8601"))
+  expect_equal("Fri, 01 Jan 2010 00:00:00 UTC", convert_type(value, timestamp_format = "rfc822"))
+  expect_equal("1262304000", convert_type(value, timestamp_format = "unix"))
+  expect_error(convert_type(value, timestamp_format = "invalid"))
+})

--- a/paws.common/tests/testthat/test_handlers_ec2query.R
+++ b/paws.common/tests/testthat/test_handlers_ec2query.R
@@ -152,7 +152,7 @@ test_that("build blob argument", {
 op_input8 <- function(TimeArg) {
   args <- list(TimeArg = TimeArg)
   interface <- Structure(
-    TimeArg = Scalar(type = "timestamp", .tags = list(timestampFormat = "iso8601"))
+    TimeArg = Scalar(type = "timestamp")
   )
   return(populate(args, interface))
 }

--- a/paws.common/tests/testthat/test_handlers_jsonrpc.R
+++ b/paws.common/tests/testthat/test_handlers_jsonrpc.R
@@ -37,7 +37,7 @@ test_that("build scalar members", {
 op_input2 <- function(TimeArg) {
   args <- list(TimeArg = TimeArg)
   interface <- Structure(
-    TimeArg = Scalar(type = "timestamp", .tags = list(timestampFormat = "unix"))
+    TimeArg = Scalar(type = "timestamp")
   )
   return(populate(args, interface))
 }
@@ -509,9 +509,9 @@ test_that("unmarshal blobs", {
 })
 
 op_output3 <- Structure(
-  TimeMember = Scalar(type = "timestamp", .tags = list(timestampFormat = "unix")),
+  TimeMember = Scalar(type = "timestamp"),
   StructMember = Structure(
-    Foo = Scalar(type = "timestamp", .tags = list(locationName = "foo", timestampFormat = "unix"))
+    Foo = Scalar(type = "timestamp", .tags = list(locationName = "foo"))
   )
 )
 

--- a/paws.common/tests/testthat/test_handlers_query.R
+++ b/paws.common/tests/testthat/test_handlers_query.R
@@ -266,7 +266,7 @@ test_that("build blob argument", {
 op_input12 <- function(TimeArg) {
   args <- list(TimeArg = TimeArg)
   interface <- Structure(
-    TimeArg = Scalar(type = "timestamp", .tags = list(timestampFormat = "iso8601"))
+    TimeArg = Scalar(type = "timestamp")
   )
   return(populate(args, interface))
 }

--- a/paws.common/tests/testthat/test_handlers_restjson.R
+++ b/paws.common/tests/testthat/test_handlers_restjson.R
@@ -469,7 +469,7 @@ test_that("timestamp value", {
   op_input18 <- function(TimeArg) {
     args <- list(TimeArg = TimeArg)
     interface <- Structure(
-      TimeArg = Scalar(type = "timestamp", .tags = list(timestampFormat = "unix"))
+      TimeArg = Scalar(type = "timestamp")
     )
     return(populate(args, interface))
   }
@@ -492,7 +492,7 @@ test_that("timestamp value in header", {
   op_input19 <- function(TimeArgInHeader) {
     args <- list(TimeArgInHeader = TimeArgInHeader)
     interface <- Structure(
-      TimeArgInHeader = Scalar(type = "timestamp", .tags = list(location = "header", locationName = "x-amz-timearg", timestampFormat = "rfc822"))
+      TimeArgInHeader = Scalar(type = "timestamp", .tags = list(location = "header", locationName = "x-amz-timearg"))
     )
     return(populate(args, interface))
   }
@@ -515,7 +515,7 @@ test_that("timestamp value in JSON body", {
   op_input20 <- function(TimeArg) {
     args <- list(TimeArg = TimeArg)
     interface <- Structure(
-      TimeArg = Scalar(type = "timestamp", .tags = list(locationName = "timestamp_location", timestampFormat = "unix"))
+      TimeArg = Scalar(type = "timestamp", .tags = list(locationName = "timestamp_location"))
     )
     return(populate(args, interface))
   }


### PR DESCRIPTION
AWS APIs expect timestamps in a format that is determined by the protocol that each service uses, e.g. S3 uses REST-XML, and expects timestamps in headers to be in RFC822 format.

In this update, explicitly specify what timestamp format to use in the build handlers.  The `convert_type` function, used in several places to convert R scalar values to API-acceptable strings, now accepts a `timestamp_format` argument which it uses to format the return value of timestamps.

Th timestamp formats now explicitly specified are below.

1. REST APIs (including REST-JSON and REST-XML):
    + Timestamp in header: RFC822
    + Timestamp in query string: ISO8601
    + All other locations: [Unix time](https://en.wikipedia.org/wiki/Unix_time)
2. Query APIs: ISO8601

Since timestamp formats are fixed by the API, this update also removes the explicit setting of `timestampFormat` in the tests for these protocols, since the protocol handlers should get them right without this additional `timestampFormat` metadata.

Some other build handlers also format timestamps but without using `convert_type`.  They are left unchanged.

With this update, we can now use timestamps in requests to some services where they previously did not work; e.g. CloudWatch:

```
cw <- paws::cloudwatch()
resp <- cw$put_metric_data(
  Namespace = "paws/test",
  MetricData = list(
    list(
      MetricName = "New Posts",
      Timestamp = as.POSIXct(
        "2020-04-10"
      ),
      Value = 0.50,
      Unit = "Count"
    )
  )
)
```