### PR TITLE
Passes the profile when reading the credentials file

### DIFF
--- a/paws.common/R/credential_providers.R
+++ b/paws.common/R/credential_providers.R
@@ -40,13 +40,13 @@ os_env_provider <- function() {
 }
 
 # Retrieve credentials stored in credentials file.
-credentials_file_provider <- function() {
+credentials_file_provider <- function(profile = "") {
 
   credentials_path <- file.path(get_aws_path(), "credentials")
 
   if (!file.exists(credentials_path)) return(NULL)
 
-  aws_profile <- get_profile_name()
+  aws_profile <- get_profile_name(profile)
 
   credentials <- ini::read.ini(credentials_path)
 


### PR DESCRIPTION
We were not passing in the profile that was passed in to the service when looking for credentials. As a result, it would use either the profile set with the "AWS_PROFILE" environment variable or the default profile. It was already using the right profile when selecting the region.