### PR TITLE
Fix decoding of blob API responses

### DIFF
--- a/paws.common/R/convert.R
+++ b/paws.common/R/convert.R
@@ -44,11 +44,10 @@ convert_timestamp <- function(timestamp, timestamp_format) {
 
 #-------------------------------------------------------------------------------
 
-# Convert a base64-encoded value to a string.
-# e.g. "Zm9v" -> "foo".
-base64_to_utf8 <- function(value) {
+# Convert a base64-encoded value to a raw vector.
+base64_to_raw <- function(value) {
   if (length(value) == 0) return(character(0))
-  return(intToUtf8(base64enc::base64decode(value)))
+  return(base64enc::base64decode(value))
 }
 
 # Convert a raw-encoded string to a base64-encoded value.

--- a/paws.common/R/handlers_rest.R
+++ b/paws.common/R/handlers_rest.R
@@ -193,7 +193,7 @@ rest_unmarshal_status_code <- function(status_code) {
 rest_unmarshal_header <- function(value, type) {
   convert <- switch(
     type,
-    blob = base64_to_utf8,
+    blob = base64_to_raw,
     boolean = as.logical,
     double = as.numeric,
     integer = as.integer,

--- a/paws.common/R/jsonutil.R
+++ b/paws.common/R/jsonutil.R
@@ -239,7 +239,7 @@ json_parse_scalar <- function(node, interface) {
   }
   convert <- switch(
     t,
-    blob = base64_to_utf8,
+    blob = base64_to_raw,
     boolean = as.logical,
     double = as.numeric,
     float = as.numeric,

--- a/paws.common/R/xmlutil.R
+++ b/paws.common/R/xmlutil.R
@@ -282,7 +282,7 @@ xml_parse_scalar <- function(node, interface) {
   t <- tag_get(interface, "type")
   convert <- switch(
     t,
-    blob = base64_to_utf8,
+    blob = base64_to_raw,
     boolean = as.logical,
     double = as.numeric,
     float = as.numeric,

--- a/paws.common/tests/testthat/test_convert.R
+++ b/paws.common/tests/testthat/test_convert.R
@@ -1,18 +1,18 @@
 context("convert")
 
-test_that("base64_to_utf8", {
-  expect_equal(base64_to_utf8("Zm9v"), "foo")
+test_that("base64_to_raw", {
+  expect_equal(base64_to_raw("Zm9v"), charToRaw("foo"))
   input <- "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBpbiByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xvcmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNhdCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lhIGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg=="
-  expected <- "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-  actual <- base64_to_utf8(input)
+  expected <- charToRaw("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")
+  actual <- base64_to_raw(input)
   expect_equal(actual, expected)
 })
 
 test_that("raw_to_base64", {
   expect_equal(raw_to_base64(charToRaw("foo")), "Zm9v")
-  input <- "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+  input <- charToRaw("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")
   expected <- "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEuIFV0IGVuaW0gYWQgbWluaW0gdmVuaWFtLCBxdWlzIG5vc3RydWQgZXhlcmNpdGF0aW9uIHVsbGFtY28gbGFib3JpcyBuaXNpIHV0IGFsaXF1aXAgZXggZWEgY29tbW9kbyBjb25zZXF1YXQuIER1aXMgYXV0ZSBpcnVyZSBkb2xvciBpbiByZXByZWhlbmRlcml0IGluIHZvbHVwdGF0ZSB2ZWxpdCBlc3NlIGNpbGx1bSBkb2xvcmUgZXUgZnVnaWF0IG51bGxhIHBhcmlhdHVyLiBFeGNlcHRldXIgc2ludCBvY2NhZWNhdCBjdXBpZGF0YXQgbm9uIHByb2lkZW50LCBzdW50IGluIGN1bHBhIHF1aSBvZmZpY2lhIGRlc2VydW50IG1vbGxpdCBhbmltIGlkIGVzdCBsYWJvcnVtLg=="
-  actual <- raw_to_base64(charToRaw(input))
+  actual <- raw_to_base64(input)
   expect_equal(actual, expected)
   expect_false(grepl("\n", actual))
 })

--- a/paws.common/tests/testthat/test_handlers_ec2query.R
+++ b/paws.common/tests/testthat/test_handlers_ec2query.R
@@ -266,7 +266,7 @@ test_that("unmarshal blob", {
   )
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$Blob, "value")
+  expect_equal(rawToChar(out$Blob), "value")
 })
 
 op_output3 <- Structure(

--- a/paws.common/tests/testthat/test_handlers_jsonrpc.R
+++ b/paws.common/tests/testthat/test_handlers_jsonrpc.R
@@ -504,8 +504,8 @@ test_that("unmarshal blobs", {
   )
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$BlobMember, "hi!")
-  expect_equal(out$StructMember$Foo, "there!")
+  expect_equal(rawToChar(out$BlobMember), "hi!")
+  expect_equal(rawToChar(out$StructMember$Foo), "there!")
 })
 
 op_output3 <- Structure(

--- a/paws.common/tests/testthat/test_handlers_query.R
+++ b/paws.common/tests/testthat/test_handlers_query.R
@@ -471,7 +471,7 @@ test_that("unmarshal blob", {
   )
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$Blob, "value")
+  expect_equal(rawToChar(out$Blob), "value")
 })
 
 op_output3 <- Structure(

--- a/paws.common/tests/testthat/test_handlers_restjson.R
+++ b/paws.common/tests/testthat/test_handlers_restjson.R
@@ -651,8 +651,8 @@ test_that("unmarshal blob member", {
   req <- unmarshal_meta(req)
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$BlobMember, "hi!")
-  expect_equal(out$StructMember$Foo, "there!")
+  expect_equal(rawToChar(out$BlobMember), "hi!")
+  expect_equal(rawToChar(out$StructMember$Foo), "there!")
 })
 
 test_that("unmarshal timestamp member", {

--- a/paws.common/tests/testthat/test_handlers_restxml.R
+++ b/paws.common/tests/testthat/test_handlers_restxml.R
@@ -536,7 +536,7 @@ test_that("unmarshal blob", {
   )
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(out$Blob, "value")
+  expect_equal(rawToChar(out$Blob), "value")
 })
 
 op_output3 <- Structure(


### PR DESCRIPTION
* Decode base64-encoded blobs to raw vectors. Previously, Paws decoded them to UTF-8 inappropriately, which would fail for any data other than text.