### PR TITLE
Decompress response bodies if not already decompressed

### DIFF
--- a/paws.common/tests/testthat/test_net.R
+++ b/paws.common/tests/testthat/test_net.R
@@ -10,3 +10,14 @@ test_that("issue", {
   expect_error(body <- jsonlite::fromJSON(rawToChar(resp$body)), NA)
   expect_equal(body$slideshow$title, "Sample Slide Show")
 })
+
+test_that("don't decompress the body when already decompressed", {
+  req <- HttpRequest(
+    method = "GET",
+    url = parse_url("https://httpbin.org/gzip")
+  )
+  expect_error(resp <- issue(req), NA)
+  expect_equal(resp$status_code, 200)
+  expect_error(body <- jsonlite::fromJSON(rawToChar(resp$body)), NA)
+  expect_equal(body$gzipped, TRUE)
+})


### PR DESCRIPTION
* In some cases, httr/curl do not decompress the response body. In these cases, check whether it looks compressed by checking for both of the following:

  1. The response has header Content-Encoding: "gzip".

  2. The response body looks like ZLIB compressed data, based on the first two bytes matching the ZLIB specification. These criteria are that the first four bits = 8 (i.e. compression method deflate), and the first sixteen bits are, as an unsigned integer, divisible by 31.