### PR TITLE
Use the escaped path when building a URL

### DIFF
--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -21,14 +21,16 @@ parse_url <- function(url) {
   if (is.null(p$scheme)) p$scheme <- ""
   if (is.null(p$host)) p$host <- ""
   if (!is.null(p$port)) p$host <- paste0(p$host, ":", p$port)
-  if (p$path == "") p$path <- "/"
-  if (substr(p$path, 1, 1) != "/") p$path <- paste0("/", p$path)
-  raw_path <- escape(p$path, "encodePath")
-  if (raw_path == p$path) raw_path <- ""
+  raw_path <- p$path
+  if (raw_path == "") raw_path <- "/"
+  else if (substr(raw_path, 1, 1) != "/") raw_path <- paste0("/", raw_path)
+  path <- unescape(raw_path)
+  escaped_path <- escape(raw_path, "encodePath")
+  if (escaped_path == raw_path) raw_path <- ""
   u <- Url(
     scheme = p$scheme,
     host = p$host,
-    path = p$path,
+    path = path,
     raw_path = raw_path,
     raw_query = build_query_string(p$query),
   )
@@ -43,7 +45,8 @@ build_url <- function(url) {
   } else {
     return("")
   }
-  if (url$path != "") l <- paste0(l, escaped_path(url))
+  if (url$raw_path != "") l <- paste0(l, url$raw_path)
+  else if (url$path != "") l <- paste0(l, url$path)
   if (url$raw_query != "") l <- paste(l, url$raw_query, sep = "?")
   if (url$fragment != "") l <- paste0(l, "#", url$fragment)
   return(l)
@@ -151,7 +154,7 @@ should_escape <- function(char, mode) {
   return(TRUE)
 }
 
-# unescape a string.
+# Un-escape a string.
 # TODO: Complete.
 unescape <- function(string) {
   return(utils::URLdecode(string))

--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -23,10 +23,13 @@ parse_url <- function(url) {
   if (!is.null(p$port)) p$host <- paste0(p$host, ":", p$port)
   if (p$path == "") p$path <- "/"
   if (substr(p$path, 1, 1) != "/") p$path <- paste0("/", p$path)
+  raw_path <- escape(p$path, "encodePath")
+  if (raw_path == p$path) raw_path <- ""
   u <- Url(
     scheme = p$scheme,
     host = p$host,
     path = p$path,
+    raw_path = raw_path,
     raw_query = build_query_string(p$query),
   )
   return(u)

--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -40,7 +40,7 @@ build_url <- function(url) {
   } else {
     return("")
   }
-  if (url$path != "") l <- paste0(l, url$path)
+  if (url$path != "") l <- paste0(l, escaped_path(url))
   if (url$raw_query != "") l <- paste(l, url$raw_query, sep = "?")
   if (url$fragment != "") l <- paste0(l, "#", url$fragment)
   return(l)

--- a/paws.common/tests/testthat/test_url.R
+++ b/paws.common/tests/testthat/test_url.R
@@ -1,0 +1,11 @@
+test_that("parsing and building URLs", {
+  input <- "https://example.com/a path with spaces"
+  actual <- build_url(parse_url(input))
+  expected <- "https://example.com/a%20path%20with%20spaces"
+  expect_equal(actual, expected)
+
+  input <- "https://example.com/a-path-without-spaces"
+  actual <- build_url(parse_url(input))
+  expected <- input
+  expect_equal(actual, expected)
+})

--- a/paws.common/tests/testthat/test_url.R
+++ b/paws.common/tests/testthat/test_url.R
@@ -1,5 +1,5 @@
 test_that("parsing and building URLs", {
-  input <- "https://example.com/a path with spaces"
+  input <- "https://example.com/a%20path%20with%20spaces"
   actual <- build_url(parse_url(input))
   expected <- "https://example.com/a%20path%20with%20spaces"
   expect_equal(actual, expected)

--- a/paws.common/tests/testthat/test_url.R
+++ b/paws.common/tests/testthat/test_url.R
@@ -1,7 +1,7 @@
 test_that("parsing and building URLs", {
   input <- "https://example.com/a%20path%20with%20spaces"
   actual <- build_url(parse_url(input))
-  expected <- "https://example.com/a%20path%20with%20spaces"
+  expected <- input
   expect_equal(actual, expected)
 
   input <- "https://example.com/a-path-without-spaces"


### PR DESCRIPTION
Support key names with spaces (#243) by using the escaped path when building the URL.