### PR TITLE
Handle empty bodies in S3

### DIFF
--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -77,6 +77,7 @@ content_md5 <- function(request) {
                               "PutBucketReplication", "PutObject",
                               "UploadPart"))) {return(request)}
   body <- request$body
+  if (length(body) == 0) body <- raw(0)
   hash <- digest::digest(body, serialize = FALSE, raw = TRUE)
   base64_hash <- base64enc::base64encode(hash)
   request$http_request$header$`Content-Md5` <- base64_hash


### PR DESCRIPTION
* Previously, a `raw(0)` empty body would cause an error in `content_md5`. Because it has length 0, it is ignored and the HTTP request object would instead have a `body` set to `NULL`. In `content_md5`, which gets the body's MD5 digest using `digest`, a `NULL` causes an error. Now `content_md5` checks if the body is of length zero and if so, replaces it with `raw(0)`, which `digest` can handle. Addresses #318.