### PR TITLE
Converts integers to numeric to allow for numbers larger than 2^31 - 1

### DIFF
--- a/paws.common/R/jsonutil.R
+++ b/paws.common/R/jsonutil.R
@@ -243,7 +243,7 @@ json_parse_scalar <- function(node, interface) {
     boolean = as.logical,
     double = as.numeric,
     float = as.numeric,
-    integer = as.integer,
+    integer = as.numeric,
     long = as.numeric,
     string = as.character,
     timestamp = unix_time,

--- a/paws.common/R/xmlutil.R
+++ b/paws.common/R/xmlutil.R
@@ -144,7 +144,7 @@ xml_build_scalar <- function(params) {
     boolean = convert_boolean,
     double = as.numeric,
     float = as.numeric,
-    integer = as.integer,
+    integer = as.numeric,
     long = as.numeric,
     timestamp = function(x) as_timestamp(x, format = "iso8601"),
     as.character
@@ -286,7 +286,7 @@ xml_parse_scalar <- function(node, interface) {
     boolean = as.logical,
     double = as.numeric,
     float = as.numeric,
-    integer = as.integer,
+    integer = as.numeric,
     long = as.numeric,
     timestamp = function(x) as_timestamp(x, format = "iso8601"),
     as.character


### PR DESCRIPTION
R uses 32 bit signed integers, but sometimes the api returns values larger than that. In order to parse those values, the xml and json utils have been updated to convert them to numerics instead of integers. Addresses #320.