### PR TITLE
Get credentials from a process as specified in AWS config

### DIFF
--- a/paws.common/R/credentials.R
+++ b/paws.common/R/credentials.R
@@ -17,6 +17,7 @@ Credentials <- struct(
     r_env_provider,
     os_env_provider,
     credentials_file_provider,
+    config_file_provider,
     container_credentials_provider,
     iam_credentials_provider,
     no_credentials


### PR DESCRIPTION
Get credentials from a process as specified in the AWS config file's `credential_process` item. See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html.

Addresses a part of #253.