### PR TITLE
Correctly unmarshal EC2 API error responses

### DIFF
--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -29,7 +29,7 @@ Suggests:
     testthat
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Collate: 
     'struct.R'
     'handlers.R'

--- a/paws.common/R/handlers_ec2query.R
+++ b/paws.common/R/handlers_ec2query.R
@@ -36,11 +36,9 @@ ec2query_unmarshal_meta <- function(request) {
 # Unmarshal errors from an EC2 protocol response.
 ec2query_unmarshal_error <- function(request) {
   body <- decode_xml(request$http_response$body)
-  data <- body[[1]]
-  error_response <- lapply(data$Error, unlist)
+  error_response <- lapply(body$Response$Errors[[1]], unlist)
   code <- error_response$Code
   message <- error_response$Message
-
   request$error <- Error(code, message, request$http_response$status_code, error_response)
   return(request)
 }

--- a/paws.common/tests/testthat/test_handlers_ec2query.R
+++ b/paws.common/tests/testthat/test_handlers_ec2query.R
@@ -417,7 +417,7 @@ test_that("unmarshal error", {
   req <- new_request(svc, op, NULL, op_output10)
   req$http_response <- HttpResponse(
     status_code = 404,
-    body = charToRaw("<Response><Error><Code>Foo</Code><Message>Bar</Message><RequestID>Baz</RequestID></Error></Response>")
+    body = charToRaw("<Response><Errors><Error><Code>Foo</Code><Message>Bar</Message><RequestID>Baz</RequestID></Error></Errors></Response>")
   )
 
   req <- unmarshal_error(req)

--- a/paws.common/tests/testthat/test_url.R
+++ b/paws.common/tests/testthat/test_url.R
@@ -1,3 +1,5 @@
+context("Parsing and building URLs")
+
 test_that("parsing and building URLs", {
   input <- "https://example.com/a%20path%20with%20spaces"
   actual <- build_url(parse_url(input))


### PR DESCRIPTION
Correctly unmarshal EC2 API error responses.

Addresses the bad error message part of #329, but not the lack of data in the error object's fields.