### PR TITLE
Fix `make deps`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ deps:
 	@Rscript -e "if (!require(devtools)) install.packages('devtools', repos = 'https://cran.rstudio.com')"
 	@Rscript -e "devtools::install_dev_deps('make.paws')"
 	@Rscript -e "devtools::install_dev_deps('paws.common')"
-	@if [ ! -x "$(command -v pandoc)" ]; then echo "Please install Pandoc. See https://pandoc.org."; fi
-	@if [ ! -d ${IN_DIR} ]; then git submodule init && git submodule update; fi
+	@command -v pandoc >/dev/null 2>&1 || echo "Please install Pandoc. See https://pandoc.org." >&2
+	@if [ ! -d ${IN_DIR}/apis ]; then git submodule init && git submodule update; fi
 
 update-deps:
 	@echo "update project dependencies"


### PR DESCRIPTION
I saw two problems with `make deps` off a fresh git clone on macOS:

1. Always emits the message about installing pandoc, even though it's on my path.
   I don't actually know what was wrong with the old incantation, which worked
   correctly for me at the bash shell but not within the Makefile; anyway, the
   new one works reliably for me.

2. Submodule is not initialized; this is because vendor/aws-sdk-js/ exists on a
   fresh clone, it's just empty.