### PR TITLE
make_sdk() speedup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.Rcheck
 .vscode
 .DS_Store
+cache

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 IN_DIR := ./vendor/aws-sdk-js
 OUT_DIR := ./paws
 CRAN_DIR := ./cran
+CACHE_DIR := ./cache
 
 # Make R use the user's package library by setting the R user home path (R_USER)
 # to the folder containing their package library. On Windows, it is in
@@ -22,6 +23,7 @@ help:
 	@echo "  check              run R CMD check on packages"
 	@echo "  unit               run unit tests for common and codegen"
 	@echo "  integration        run integration tests for the AWS SDK"
+	@echo "  clean              clear the build cache"
 	@echo "  deps               get project dependencies"
 	@echo "  update-deps        update project dependencies"
 
@@ -33,7 +35,7 @@ install: build
 
 build-full: codegen
 	@echo "build the AWS SDK package"
-	@Rscript -e "library(make.paws); make_sdk('${IN_DIR}', '${OUT_DIR}')"
+	@Rscript -e "library(make.paws); make_sdk('${IN_DIR}', '${OUT_DIR}', '${CACHE_DIR}')"
 
 build-cran: codegen
 	@echo "build CRAN packages"
@@ -70,6 +72,9 @@ codegen: common
 test-codegen: codegen
 	@echo "run unit tests for the code generator"
 	@Rscript -e "devtools::test('make.paws')"
+
+clean:
+	@if [ -d "${CACHE_DIR}" ]; then rm -rf "${CACHE_DIR}"; fi
 
 deps:
 	@echo "get project dependencies"

--- a/make.paws/DESCRIPTION
+++ b/make.paws/DESCRIPTION
@@ -32,7 +32,8 @@ Imports:
 Suggests: 
     covr,
     formatR,
-    testthat
+    testthat,
+    withr
 Remotes:
     r-lib/cachem
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org

--- a/make.paws/DESCRIPTION
+++ b/make.paws/DESCRIPTION
@@ -13,6 +13,7 @@ URL: https://github.com/paws-r/paws
 Encoding: UTF-8
 LazyData: true
 Imports:
+    cachem,
     desc,
     devtools,
     glue,
@@ -30,10 +31,13 @@ Suggests:
     covr,
     formatR,
     testthat
+Remotes:
+    r-lib/cachem
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org
 Roxygen: list(markdown = TRUE, roclets = c("rd"))
 RoxygenNote: 7.1.0
 Collate: 
+    'cache.R'
     'docs.R'
     'templates.R'
     'interfaces.R'

--- a/make.paws/DESCRIPTION
+++ b/make.paws/DESCRIPTION
@@ -26,7 +26,9 @@ Imports:
     roxygen2,
     stringr,
     xml2,
-    yaml
+    yaml,
+    digest,
+    waldo
 Suggests: 
     covr,
     formatR,

--- a/make.paws/R/cache.R
+++ b/make.paws/R/cache.R
@@ -1,13 +1,31 @@
+# A place to hold a private, package-scoped variable
 .cache <- new.env(parent = emptyenv())
 
+#' Execute some code with a cache context
+#'
+#' Create a cachem cache using the `cache_dir` directory, and
+#' install it as the current cache during `expr`'s execution.
+#'
+#' @param cache_dir A relative or absolute directory path that may or may not
+#'   already exist; or `NULL` to disable caching.
+#' @param expr Something to evaluate; within this code or calls therein, calling
+#'   `current_cache()` will return a cachem cache.
+#' @return The value of `expr`.
+#'
+#' @noRd
 with_cache_dir <- function(cache_dir, expr) {
   cache <- if (!is.null(cache_dir)) {
-    cachem::cache_disk(cache_dir, max_size = 300 * 1024^2, missing = NULL)
+    # Create a disk-backed cache with max 500MB capacity. (Don't be afraid to
+    # increase the capacity if necessary.)
+    cachem::cache_disk(cache_dir, max_size = 500 * 1024^2, missing = NULL)
   } else {
-    # Equivalent of no cache
+    # Equivalent of no cache. cache$get() will always return NULL, even if you
+    # called cache$set().
     cachem::cache_layered()
   }
 
+  # Temporarily set .cache$current. Restore the old value, in case we're being
+  # called recursively.
   old <- .cache$current
   .cache$current <- cache
   on.exit(.cache$current <- old, add = TRUE)
@@ -15,6 +33,9 @@ with_cache_dir <- function(cache_dir, expr) {
   expr
 }
 
+# Returns the current cache, if one exists; if not, a no-op cache is returned.
+# Calling `current_cache()` outside of a `with_cache_dir()` is probably a bug,
+# so we warn.
 current_cache <- function() {
   if (is.null(.cache$current)) {
     warning(call. = TRUE, "current_cache called when no cache was set")
@@ -24,23 +45,92 @@ current_cache <- function() {
   }
 }
 
+#' Execute code or, preferably, retrieve a previous result from the cache
+#'
+#' Use `cached_expr` to speed up slow operations that are expected to always
+#' return exactly the same results for a given input. The `current_cache()`
+#' cache is used to persist the results, even across different R processes.
+#'
+#' @param key_expr A serializable R object (like atomic vectors and lists, but
+#'   not e.g. external pointers or sockets) that can serve as a cache key for
+#'   the `value_expr`. That is to say, if and only if a subsequent call to
+#'   `cached_expr` passes an identical `key_expr`, then the cached value of this
+#'   `value_expr` will be reused.
+#' @param value_expr A (potentially very slow) calculation that will only be
+#'   evaluated if the cache doesn't contain an entry for `key_expr`. This must
+#'   also resolve to a serializable R object (it's stored on disk in RDS
+#'   format). For convenience, this can also be a function; if so, it will be
+#'   evaluated; this is intended to make it easy to adapt existing logic that
+#'   contains `return` statements.
+#' @return Either `value_expr` (evaluated, of course) or a previously cached
+#'   value.
+#'
+#' @noRd
 cached_expr <- function(key_expr, value_expr) {
   force(key_expr)
   cache <- current_cache()
   cache_key <- as_cache_key(key_expr)
   cache_result <- cache$get(cache_key)
   if (!is.null(cache_result)) {
+    maybe_spot_check(cache_result, value_expr)
     return(cache_result)
   }
 
-  force(value_expr)
-  if (is.function(value_expr)) {
-    value_expr <- value_expr()
-  }
-  cache$set(cache_key, value_expr)
-  value_expr
+  value <- force_for_cache(value_expr)
+
+  cache$set(cache_key, value)
+  value
 }
 
 as_cache_key <- function(obj) {
   cache_key <- digest::digest(obj, algo = "md5")
+}
+
+#' Possibly verify that the cache_result and value_expr yield identical results
+#'
+#' @description This is a diagnostic check that verifies the key assumption
+#' behind caching: that the fast path (using a cached value) gives identical
+#' results to the slow path (actually calculating the value). Failing the spot
+#' check may indicate that the calculation logic has changed since the cache was
+#' populated, or perhaps a `key_expr` is being used that is not unique.
+#'
+#' Obviously, we can't spot-check every cache hit--the whole point of caching is
+#' to not calculate the value if we don't have to. Instead, we randomly decide
+#' to spot-check. By default, each call has a 1% chance of being spot-checked.
+#'
+#' @param cache_result The value that was retrieved from the cache.
+#' @param value_expr The `value_expr` passed through from `cached_expr`.
+#' @return Nothing is returned if the test was skipped or passed; an error is
+#'   raised if the test failed.
+maybe_spot_check <- function(cache_result, value_expr) {
+  if (getOption("cache.spotcheck.level", 0.01) > runif(1)) {
+    value <- force_for_cache(value_expr)
+
+    if (!identical(cache_result, value)) {
+      warning(
+        "Random cache spot-check failed! You may want to `make clean`!",
+        immediate. = TRUE, call. = FALSE
+      )
+      cat(file = stderr(),
+        paste0(collapse = "\n",
+          capture.output(print(waldo::compare(
+            cache_result, value,
+            x_arg = "cached", y_arg = "live"
+          )))
+        )
+      )
+      cat(file = stderr(), "\n")
+      stop("Stopping due to cache spot-check failure")
+    }
+  }
+}
+
+# See the docs for cached_expr() @param key_expr.
+force_for_cache <- function(expr) {
+  force(expr)
+  if (is.function(expr)) {
+    expr()
+  } else {
+    expr
+  }
 }

--- a/make.paws/R/cache.R
+++ b/make.paws/R/cache.R
@@ -102,6 +102,7 @@ as_cache_key <- function(obj) {
 #' @param value_expr The `value_expr` passed through from `cached_expr`.
 #' @return Nothing is returned if the test was skipped or passed; an error is
 #'   raised if the test failed.
+#' @noRd
 maybe_spot_check <- function(cache_result, value_expr) {
   if (getOption("cache.spotcheck.level", 0.01) > stats::runif(1)) {
     value <- force_for_cache(value_expr)

--- a/make.paws/R/cache.R
+++ b/make.paws/R/cache.R
@@ -1,0 +1,46 @@
+.cache <- new.env(parent = emptyenv())
+
+with_cache_dir <- function(cache_dir, expr) {
+  cache <- if (!is.null(cache_dir)) {
+    cachem::cache_disk(cache_dir, max_size = 300 * 1024^2, missing = NULL)
+  } else {
+    # Equivalent of no cache
+    cachem::cache_layered()
+  }
+
+  old <- .cache$current
+  .cache$current <- cache
+  on.exit(.cache$current <- old, add = TRUE)
+
+  expr
+}
+
+current_cache <- function() {
+  if (is.null(.cache$current)) {
+    warning(call. = TRUE, "current_cache called when no cache was set")
+    cachem::cache_layered()
+  } else {
+    .cache$current
+  }
+}
+
+cached_expr <- function(key_expr, value_expr) {
+  force(key_expr)
+  cache <- current_cache()
+  cache_key <- as_cache_key(key_expr)
+  cache_result <- cache$get(cache_key)
+  if (!is.null(cache_result)) {
+    return(cache_result)
+  }
+
+  force(value_expr)
+  if (is.function(value_expr)) {
+    value_expr <- value_expr()
+  }
+  cache$set(cache_key, value_expr)
+  value_expr
+}
+
+as_cache_key <- function(obj) {
+  cache_key <- digest::digest(obj, algo = "md5")
+}

--- a/make.paws/R/cache.R
+++ b/make.paws/R/cache.R
@@ -103,7 +103,7 @@ as_cache_key <- function(obj) {
 #' @return Nothing is returned if the test was skipped or passed; an error is
 #'   raised if the test failed.
 maybe_spot_check <- function(cache_result, value_expr) {
-  if (getOption("cache.spotcheck.level", 0.01) > runif(1)) {
+  if (getOption("cache.spotcheck.level", 0.01) > stats::runif(1)) {
     value <- force_for_cache(value_expr)
 
     if (!identical(cache_result, value)) {
@@ -113,7 +113,7 @@ maybe_spot_check <- function(cache_result, value_expr) {
       )
       cat(file = stderr(),
         paste0(collapse = "\n",
-          capture.output(print(waldo::compare(
+          utils::capture.output(print(waldo::compare(
             cache_result, value,
             x_arg = "cached", y_arg = "live"
           )))

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -217,14 +217,16 @@ comment <- function(s, char = "#") {
 # this avoids any changes that would otherwise be made by Pandoc.
 convert <- function(docs) {
   if (is.null(docs) || docs == "") return("")
-  if (grepl("^<", docs)) {
-    html <- clean_html(docs)
-    result <- html_to_markdown(html)
-  } else {
-    result <- strsplit(docs, "\n")[[1]]
-  }
-  result <- escape_special_chars(result)
-  result
+  cached_expr(list("convert", docs = docs), {
+    if (grepl("^<", docs)) {
+      html <- clean_html(docs)
+      result <- html_to_markdown(html)
+    } else {
+      result <- strsplit(docs, "\n")[[1]]
+    }
+    result <- escape_special_chars(result)
+    result
+  })
 }
 
 # Clean an HTML string to avoid issues that result in invalid Rd

--- a/make.paws/R/make_sdk.R
+++ b/make.paws/R/make_sdk.R
@@ -2,17 +2,23 @@
 #'
 #' @param in_dir Directory containing API files.
 #' @param out_dir Directory of the R package.
+#' @param cache_dir Directory to store cached artifacts. Providing a non-`NULL`
+#'   value will greatly speed up subsequent runs that use the same value.
 #'
 #' @export
-make_sdk <- function(in_dir, out_dir) {
-  clear_dir(out_dir)
-  write_skeleton(out_dir)
-  for (api in list_apis(file.path(in_dir, "apis"))) {
-    cat(paste0(api, "\n"))
-    write_sdk_for_api(api, in_dir, out_dir)
-  }
-  write_documentation(out_dir)
-  return(invisible(TRUE))
+make_sdk <- function(in_dir = "./vendor/aws-sdk-js", out_dir = "./paws",
+  cache_dir = "./cache") {
+
+  with_cache_dir(cache_dir, {
+    clear_dir(out_dir)
+    write_skeleton(out_dir)
+    for (api in list_apis(file.path(in_dir, "apis"))) {
+      cat(paste0(api, "\n"))
+      write_sdk_for_api(api, in_dir, out_dir)
+    }
+    write_documentation(out_dir)
+    return(invisible(TRUE))
+  })
 }
 
 # Clear out files from the output directory.

--- a/make.paws/R/templates.R
+++ b/make.paws/R/templates.R
@@ -11,6 +11,12 @@ template <- function(x) {
 # Returns a string by rendering a template, replacing variables enclosed with
 # ${} with corresponding named argument values in `...`.
 render <- function(template, ...) {
+
+  # makes str_interp much faster, due to underlying call to
+  # parse(keep.source=getOption("keep.source"))
+  op <- options(keep.source = FALSE)
+  on.exit(options(op), add = TRUE)
+
   as.character(stringr::str_interp(template, env = list(...)))
 }
 

--- a/make.paws/R/text.R
+++ b/make.paws/R/text.R
@@ -9,14 +9,17 @@ write_utf8 <- function(x, file) {
 # Convert HTML to other formats using Pandoc.
 html_to <- function(html, to) {
   if (is.null(html)) return("")
-  temp_in <- tempfile()
-  write_utf8(html, temp_in)
-  temp_out <- tempfile()
-  rmarkdown::pandoc_convert(temp_in, output = temp_out, from = "html", to = to)
-  result <- readLines(temp_out)
-  # Pandoc inappropriately escapes "%" and "*"; undo this escaping.
-  result <- gsub("\\\\(\\%|\\*)", "\\1", result)
-  result
+
+  cached_expr(list("html_to", html = html, to = to), {
+    temp_in <- tempfile()
+    write_utf8(html, temp_in)
+    temp_out <- tempfile()
+    rmarkdown::pandoc_convert(temp_in, output = temp_out, from = "html", to = to)
+    result <- readLines(temp_out)
+    # Pandoc inappropriately escapes "%" and "*"; undo this escaping.
+    result <- gsub("\\\\(\\%|\\*)", "\\1", result)
+    result
+  })
 }
 
 # Convert HTML to markdown

--- a/make.paws/R/utils.R
+++ b/make.paws/R/utils.R
@@ -89,14 +89,17 @@ url_ok <- function(url, tries = 3) {
   if (url == "") {
     return(FALSE)
   }
-  try <- 0
-  while (try < tries) {
-    resp <- tryCatch(
-      httr::status_code(httr::HEAD(url, httr::timeout(1))),
-      error = function(e) NA
-    )
-    if (!is.na(resp) && resp != 404) return(TRUE)
-    try <- try + 1
-  }
-  return(FALSE)
+
+  cached_expr(list("url_ok", url = url), function() {
+    try <- 0
+    while (try < tries) {
+      resp <- tryCatch(
+        httr::status_code(httr::HEAD(url, httr::timeout(1))),
+        error = function(e) NA
+      )
+      if (!is.na(resp) && resp != 404) return(TRUE)
+      try <- try + 1
+    }
+    return(FALSE)
+  })
 }

--- a/make.paws/man/make_sdk.Rd
+++ b/make.paws/man/make_sdk.Rd
@@ -4,12 +4,19 @@
 \alias{make_sdk}
 \title{Make the AWS SDK R package}
 \usage{
-make_sdk(in_dir, out_dir)
+make_sdk(
+  in_dir = "./vendor/aws-sdk-js",
+  out_dir = "./paws",
+  cache_dir = "./cache"
+)
 }
 \arguments{
 \item{in_dir}{Directory containing API files.}
 
 \item{out_dir}{Directory of the R package.}
+
+\item{cache_dir}{Directory to store cached artifacts. Providing a non-\code{NULL}
+value will greatly speed up subsequent runs that use the same value.}
 }
 \description{
 Make the AWS SDK R package

--- a/make.paws/tests/testthat/setup.R
+++ b/make.paws/tests/testthat/setup.R
@@ -1,0 +1,5 @@
+# Run before any tests
+op <- options(cache.disable = TRUE)
+
+# Run after all tests
+withr::defer(options(op), teardown_env())

--- a/make.paws/tests/testthat/test-cache.R
+++ b/make.paws/tests/testthat/test-cache.R
@@ -1,5 +1,8 @@
 context("cache")
 
+op <- options(cache.disable = NULL)
+on.exit(options(op), add = TRUE)
+
 slow_operation <- function(x) {
   cached_expr(x, {
     Sys.sleep(0.5)

--- a/make.paws/tests/testthat/test-cache.R
+++ b/make.paws/tests/testthat/test-cache.R
@@ -1,0 +1,65 @@
+context("cache")
+
+slow_operation <- function(x) {
+  cached_expr(x, {
+    Sys.sleep(0.5)
+    x
+  })
+}
+
+diff_secs <- function(time_x, time_y) {
+  as.double(time_x - time_y, units = "secs")
+}
+
+test_that("cache basics", {
+  # current_cache is only intended to be called within with_cache_dir
+  expect_warning(current_cache())
+
+  with_cache_dir(tempfile(), {
+    expect_warning(current_cache(), NA)
+
+    time1 <- Sys.time()
+    resultA <- slow_operation(10)
+    time2 <- Sys.time()
+    resultB <- slow_operation(10)
+    time3 <- Sys.time()
+
+    expect_identical(resultA, 10)
+    expect_identical(resultB, 10)
+    expect_gte(diff_secs(time2, time1), 0.5)
+    expect_lt(diff_secs(time3, time2), 0.1)
+
+    time4 <- Sys.time()
+    resultC <- slow_operation(5)
+    time5 <- Sys.time()
+    resultD <- slow_operation(5)
+    time6 <- Sys.time()
+
+    expect_identical(resultC, 5)
+    expect_identical(resultD, 5)
+    expect_gte(diff_secs(time5, time4), 0.5)
+    expect_lt(diff_secs(time6, time5), 0.1)
+  })
+})
+
+test_that("spot checking detects changing results", {
+
+  op <- options(cache.spotcheck.level = 1)
+  on.exit(options(op), add = TRUE)
+
+  with_cache_dir(tempfile(), {
+    cached_expr("key1", { 1 })
+
+    # This will fail spot checking because it re-uses the same
+    # key as slow_operation()
+    expect_error(
+      expect_warning(
+        cached_expr("key1", { 2 }),
+        "spot-check"),
+      "spot-check")
+
+    # This won't fail spot checking because the level is 0
+    options(cache.spotcheck.level = 0)
+    cached_expr("key1", { 3 })
+  })
+})


### PR DESCRIPTION
A great deal of time in `make_sdk()` is spent in two classes of operations:

1. `url_ok()`
2. Converting HTML to text or markdown using pandoc

These operations are pretty slow, not dependent on side effects, and their
implementations are pretty stable at this point (maybe?), so they're good
candidates for persistent caching.

This commit uses the cachem package to manage a ./cache subdirectory for
uses of `url_ok()` and `html_to()` (update: and `convert()`).

On my MBP15 from 2016, I got the following times for `make_sdk()`:

- Cache disabled:         62m17.732s
- With cache, first run:  43m11.440s
- With cache, second run: 10m0.548s (update: now down to 8m34.990s)

(The "first run" starts with the cache empty, but there are enough
duplicated `html_to()` calls that it still gets some cache hits.)

If the implementations of `url_ok()` or `html_to()` change, you'll need to
throw out the cached values by simply deleting the ./cache directory;
you can use `make clean` for this. I gave the caching logic a "spot
checking" feature to try to proactively detect this condition; by default
1% of cache hits are compared to the value that's yielded by running
the operation, and if the values are not identical, an error is thrown.

(I also added default arguments for `make_sdk()`; I didn't see a downside to
doing this, and it made iterative profiling a bit less annoying.)
