### PR TITLE
Disable byte compilation of paws

### DIFF
--- a/make.paws/R/make_sdk.R
+++ b/make.paws/R/make_sdk.R
@@ -58,7 +58,8 @@ use_description <- function(path) {
     `Authors@R` = make_authors(),
     Description = "An Amazon Web Services SDK for R.",
     License = "Apache License (>= 2.0)",
-    Encoding = "UTF-8"
+    Encoding = "UTF-8",
+    ByteCompile = "false"
   )
   for (key in names(contents)) {
     value <- contents[[key]]

--- a/paws/DESCRIPTION
+++ b/paws/DESCRIPTION
@@ -701,3 +701,4 @@ Collate:
     'xray_service.R'
     'xray_interfaces.R'
     'xray_operations.R'
+ByteCompile: false


### PR DESCRIPTION
On my MBP15, disabling byte compilation drops install time
from 5m58s to 1m34s. It seems unlikely this will affect
runtime performance, given the kind of R code that paws
contains.

Note that paws.common and cran packages are not affected.