### PR TITLE
Remove warnings during make_sdk

### DIFF
--- a/make.paws/R/process_api.R
+++ b/make.paws/R/process_api.R
@@ -70,7 +70,7 @@ copy_custom_operations <- function(api, path) {
   package <- package_name(api)
   from <- system_file(sprintf("src/custom/%s.R", package), package = methods::getPackageName())
   to <- file.path(path, paste0(package, "_custom.R"))
-  if (file.exists(from)) {
+  if (from != "" && file.exists(from)) {
     file.copy(from, to)
   }
 }

--- a/make.paws/R/service.R
+++ b/make.paws/R/service.R
@@ -181,6 +181,9 @@ service_operations <- function(api) {
 get_custom_operations <- function(api) {
   package <- package_name(api)
   from <- system_file(sprintf("src/custom/%s.R", package), package = methods::getPackageName())
+  if (from == "") {
+    return(list())
+  }
   text <- readLines(from)
   operations <- parse_operations(text)
   return(operations)

--- a/make.paws/R/tests.R
+++ b/make.paws/R/tests.R
@@ -106,7 +106,14 @@ has_params <- function(operation, api, params) {
   input_shape <- operation$input$shape
   if (!is.null(input_shape)) {
     inputs <- api$shapes[[input_shape]]
-    operation_params <- names(inputs$member) # matches "member" or "members".
+
+    # matches "members" or "member".
+    operation_params <- if ("members" %in% names(inputs)) {
+      names(inputs$members)
+    } else {
+      names(inputs$member)
+    }
+
     if (all(params %in% operation_params)) {
       return(TRUE)
     }


### PR DESCRIPTION
* With options(warnPartialMatchDollar=TRUE), make_sdk was warning about
  "member" versus "members"
* Also warning about file("") (empty string), due to system.file()
  results being unconditionally readLines()'d
  (file("") only supports open = "w+" and open = "w+b": using the former)