### PR TITLE
Use short timeout when requesting instance/container metadata

### DIFF
--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -115,9 +115,13 @@ get_profile_name <- function(profile = "") {
 get_container_credentials <- function() {
 
   credentials_uri <- Sys.getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+  if (nchar(credentials_uri) == 0) {
+    return(NULL)
+  }
+
   metadata_url <- file.path("http://169.254.170.2", credentials_uri)
   metadata_request <-
-    new_http_request("GET", metadata_url)
+    new_http_request("GET", metadata_url, timeout = 1)
 
   metadata_response <- tryCatch({
     issue(metadata_request)
@@ -138,7 +142,7 @@ get_instance_metadata <- function(query_path = "") {
   metadata_url <- file.path("http://169.254.169.254/latest/meta-data",
                            query_path)
   metadata_request <-
-    new_http_request("GET", metadata_url)
+    new_http_request("GET", metadata_url, timeout = 1)
 
   metadata_response <- tryCatch({
     issue(metadata_request)

--- a/paws.common/R/net.R
+++ b/paws.common/R/net.R
@@ -23,6 +23,7 @@ HttpRequest <- struct(
   request_uri = "",
   tls = NULL,
   cancel = NULL,
+  timeout = 10,
   response = NULL,
   ctx = list()
 )
@@ -46,7 +47,7 @@ HttpResponse <- struct(
 )
 
 # Returns an HTTP request given a method, URL, and an optional body.
-new_http_request <- function(method, url, body = NULL) {
+new_http_request <- function(method, url, body = NULL, timeout = 10) {
   if (method == "") {
     method <- "GET"
   }
@@ -62,7 +63,8 @@ new_http_request <- function(method, url, body = NULL) {
     proto_minor = 1,
     header = list(), # TODO
     body = body,
-    host = u$host
+    host = u$host,
+    timeout = timeout
   )
   return(req)
 }
@@ -88,6 +90,7 @@ issue <- function(http_request) {
   url <- build_url(http_request$url)
   headers <- unlist(http_request$header)
   body <- http_request$body
+  timeout <- if (!is.null(http_request$timeout)) httr::timeout(http_request$timeout)
 
   if (url == "") {
     stop("no url provided")
@@ -97,7 +100,8 @@ issue <- function(http_request) {
     method,
     url = url,
     config = httr::add_headers(.headers = headers),
-    body = body
+    body = body,
+    timeout
   )
 
   response <- HttpResponse(


### PR DESCRIPTION
These requests took several long seconds to fail when called from
non-AWS. The default in aws-sdk-js-v3, boto3, and aws-cli is 1
second, no retries.

Ref:
https://github.com/boto/botocore/blob/646c61a7065933e75bab545b785e6098bc94c081/botocore/utils.py#L273
https://github.com/aws/aws-sdk-js-v3/blob/47770fa493c3405f193069cd18319882529ff484/packages/credential-provider-imds/src/remoteProvider/RemoteProviderInit.ts#L1