### PR TITLE
Updates s3 example to use the new simplified syntax

### DIFF
--- a/examples/s3.R
+++ b/examples/s3.R
@@ -18,6 +18,7 @@ s3$list_buckets()
 # Create a data.frame that we will upload to S3
 example_df <- data.frame(foo = c("hello", "world"), bar = c(1, 2))
 
+# Save it as an RDS file
 file_name <- "s3_example.rds"
 saveRDS(example_df, file = file_name)
 
@@ -32,7 +33,6 @@ saveRDS(example_df, file = file_name)
 # for versions greater or equal to 0.3.7.                                      #
 ################################################################################
 
-# Save it as an RDS file
 # Load the file as a raw binary
 read_file <- file(file_name, "rb")
 s3_example <- readBin(read_file, "raw", n = file.size(file_name))

--- a/examples/s3.R
+++ b/examples/s3.R
@@ -18,13 +18,25 @@ s3$list_buckets()
 # Create a data.frame that we will upload to S3
 example_df <- data.frame(foo = c("hello", "world"), bar = c(1, 2))
 
-# Save it as an RDS file
 file_name <- "s3_example.rds"
 saveRDS(example_df, file = file_name)
 
+################################################################################
+# The following section is only recommended if using paws.common               #
+# versions <= 0.3.6.                                                           #
+# For paws.common versions <= 0.3.6 put_object requires the Body parameter to  #
+# be a vector of raw bytes. Therefore if you are using an older version of     #
+# paws.common you must take the following steps to upload a file to s3. The    #
+# following code works for versions of paws.common >= 0.3.7 as well, but the   #
+# same task can be completed more easily as shown in the section further below #
+# for versions greater or equal to 0.3.7.                                      #
+################################################################################
+
+# Save it as an RDS file
 # Load the file as a raw binary
 read_file <- file(file_name, "rb")
 s3_example <- readBin(read_file, "raw", n = file.size(file_name))
+close(read_file)
 
 # Upload file to s3
 s3$put_object(
@@ -32,6 +44,21 @@ s3$put_object(
   Bucket = bucket_name,
   Key = file_name
 )
+
+################################################################################
+# For paws.common versions >= 0.3.7 we can pass a file path directly to the    #
+# Body parameter of put_object. This is the recommended way for users using    #
+# newer versions of paws.common.                                               #
+################################################################################
+
+# Upload file to s3
+s3$put_object(
+  Body = file_name,
+  Bucket = bucket_name,
+  Key = file_name
+)
+
+################################################################################
 
 # List objects in the bucket
 s3$list_objects(Bucket = bucket_name)
@@ -53,6 +80,5 @@ readRDS(file_name2)
 # Cleanup
 s3$delete_object(Bucket = bucket_name, Key = file_name)
 s3$delete_bucket(Bucket = bucket_name)
-close(read_file)
 file.remove(file_name)
 file.remove(file_name2)


### PR DESCRIPTION
Update the s3 example to show how to upload a file by just passing in the file path.