### PR TITLE
Cache credentials

### DIFF
--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -33,6 +33,7 @@ RoxygenNote: 7.1.1
 Collate: 
     'struct.R'
     'handlers.R'
+    'dateutil.R'
     'credential_sts.R'
     'url.R'
     'net.R'
@@ -48,7 +49,6 @@ Collate:
     'util.R'
     'stream.R'
     'custom_s3.R'
-    'dateutil.R'
     'error.R'
     'handlers_core.R'
     'handlers_ec2query.R'

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -30,6 +30,16 @@ get_config <- function() {
 
 #' Add configuration settings to a service object.
 #'
+#' `set_config` adds a given set of configuration settings in `cfgs` to a
+#' service object, i.e. the service object for S3. Configuration settings can
+#' include credentials, region, endpoint, etc. These configuration settings
+#' will be used whenever an operation is called from that service object.
+#'
+#' `set_config` explicitly makes the `credentials` property mutable, such that
+#' when the SDK retrieves credentials later on, it will save them in the
+#' service object. This means that credentials don't need to be fetched on each
+#' operation, only if and when the saved credentials expire.
+#'
 #' @param svc A service object containing service operations.
 #' @param cfgs A list of optional configuration settings.
 #'

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -69,6 +69,7 @@ get_config <- function() {
 set_config <- function(svc, cfgs = list()) {
   shape <- tag_annotate(Config())
   config <- populate(cfgs, shape)
+  config$credentials <- as.environment(config$credentials)
   svc$.internal <- list(config = config)
   return(svc)
 }

--- a/paws.common/R/credential_providers.R
+++ b/paws.common/R/credential_providers.R
@@ -7,8 +7,8 @@ Creds <- struct(
   access_key_id = "",
   secret_access_key = "",
   session_token = "",
-  provider_name = "",
-  expiration = Inf
+  expiration = Inf,
+  provider_name = ""
 )
 
 # Retrieve credentials stored in R environment variables.

--- a/paws.common/R/credential_providers.R
+++ b/paws.common/R/credential_providers.R
@@ -77,7 +77,7 @@ credentials_file_provider <- function(profile = "") {
       access_key_id = access_key_id,
       secret_access_key = secret_access_key,
       session_token = session_token,
-      expiration = Inf,
+      expiration = Inf
     )
   } else {
     creds <- NULL

--- a/paws.common/R/credential_providers.R
+++ b/paws.common/R/credential_providers.R
@@ -143,7 +143,7 @@ config_file_credential_process <- function(command) {
   if (is.null(session_token)) session_token <- ""
 
   expiration <- as_timestamp(data$Expiration, "iso8601")
-  if (length(expiration) == 0) expiration <- 0
+  if (length(expiration) == 0) expiration <- Inf
 
   creds <- Creds(
     access_key_id = access_key_id,

--- a/paws.common/R/credentials.R
+++ b/paws.common/R/credentials.R
@@ -42,7 +42,7 @@ is_credentials_provided <- function(creds){
   if (is.null(creds$secret_access_key) || creds$secret_access_key == "") {
     return(FALSE)
   }
-  if (length(creds$expiration) > 0 && Sys.time() > creds$expiration) {
+  if (length(creds$expiration) == 1 && !is.na(creds$expiration) && Sys.time() > creds$expiration) {
     return(FALSE)
   }
   return(TRUE)

--- a/paws.common/R/credentials.R
+++ b/paws.common/R/credentials.R
@@ -42,7 +42,7 @@ is_credentials_provided <- function(creds){
   if (is.null(creds$secret_access_key) || creds$secret_access_key == "") {
     return(FALSE)
   }
-  if (length(creds$expiration) == 1 && !is.na(creds$expiration) && Sys.time() > creds$expiration) {
+  if (length(creds$expiration) == 1 && is.finite(creds$expiration) && Sys.time() > creds$expiration) {
     return(FALSE)
   }
   return(TRUE)

--- a/paws.common/R/credentials.R
+++ b/paws.common/R/credentials.R
@@ -34,7 +34,7 @@ get_credentials <- function(credentials) {
 
 # Return whether a creds object has at least the minimum data needed to
 # authenticate.
-is_credentials_provided <- function(creds){
+is_credentials_provided <- function(creds, window = 5 * 60){
   if (is.null(creds)) return(FALSE)
   if (is.null(creds$access_key_id) || creds$access_key_id == "") {
     return(FALSE)
@@ -42,7 +42,7 @@ is_credentials_provided <- function(creds){
   if (is.null(creds$secret_access_key) || creds$secret_access_key == "") {
     return(FALSE)
   }
-  if (length(creds$expiration) == 1 && is.finite(creds$expiration) && Sys.time() > creds$expiration) {
+  if (length(creds$expiration) == 1 && is.finite(creds$expiration) && Sys.time() > creds$expiration - window) {
     return(FALSE)
   }
   return(TRUE)

--- a/paws.common/R/credentials.R
+++ b/paws.common/R/credentials.R
@@ -2,17 +2,10 @@
 #' @include credential_providers.R
 NULL
 
-Creds <- struct(
-  access_key_id = "",
-  secret_access_key = "",
-  session_token = "",
-  provider_name = ""
-)
-
 Credentials <- struct(
   creds = Creds(),
   profile = "",
-  force_refresh = TRUE,
+  force_refresh = FALSE,
   provider = list(
     r_env_provider,
     os_env_provider,
@@ -47,6 +40,9 @@ is_credentials_provided <- function(creds){
     return(FALSE)
   }
   if (is.null(creds$secret_access_key) || creds$secret_access_key == "") {
+    return(FALSE)
+  }
+  if (length(creds$expiration) > 0 && Sys.time() > creds$expiration) {
     return(FALSE)
   }
   return(TRUE)

--- a/paws.common/man/set_config.Rd
+++ b/paws.common/man/set_config.Rd
@@ -12,9 +12,17 @@ set_config(svc, cfgs = list())
 \item{cfgs}{A list of optional configuration settings.}
 }
 \description{
-Add configuration settings to a service object.
+\code{set_config} adds a given set of configuration settings in \code{cfgs} to a
+service object, i.e. the service object for S3. Configuration settings can
+include credentials, region, endpoint, etc. These configuration settings
+will be used whenever an operation is called from that service object.
 }
 \details{
+\code{set_config} explicitly makes the \code{credentials} property mutable, such that
+when the SDK retrieves credentials later on, it will save them in the
+service object. This means that credentials don't need to be fetched on each
+operation, only if and when the saved credentials expire.
+
 The optional configuration settings can include the following:\preformatted{list(
   credentials = list(
     creds = list(

--- a/paws.common/tests/testthat/test_credentials.R
+++ b/paws.common/tests/testthat/test_credentials.R
@@ -131,7 +131,7 @@ test_that("credentials refresh when expired", {
 
   expect_equal(expiration1, expiration2)
 
-  Sys.sleep(5) # credentials expire after 5 seconds
+  Sys.sleep(5) # these credentials are set to expire after 5 seconds
 
   f3 <- svc$get_credentials() # refresh the credentials
   expiration3 <- f3$credentials$creds$expiration

--- a/paws.common/tests/testthat/test_credentials.R
+++ b/paws.common/tests/testthat/test_credentials.R
@@ -14,26 +14,53 @@ test_that("credentials not provided", {
 
   expect_false(is_credentials_provided(creds))
 
-  creds <- list(
+  creds <- Creds(
     access_key_id = "",
     secret_access_key = "bar"
   )
 
   expect_false(is_credentials_provided(creds))
 
-  creds <- list(
+  creds <- Creds(
     access_key_id = "foo",
     secret_access_key = ""
   )
 
   expect_false(is_credentials_provided(creds))
 
-  creds <- list(
+  creds <- Creds(
     access_key_id = "",
     secret_access_key = ""
   )
 
   expect_false(is_credentials_provided(creds))
+})
+
+test_that("credentials expired", {
+  creds <- Creds(
+    access_key_id = "foo",
+    secret_access_key = "bar",
+    expiration = 0
+  )
+
+  expect_false(is_credentials_provided(creds))
+
+  creds <- Creds(
+    access_key_id = "foo",
+    secret_access_key = "bar",
+    expiration = Inf
+  )
+
+  expect_true(is_credentials_provided(creds))
+
+  creds <- Creds(
+    access_key_id = "foo",
+    secret_access_key = "bar",
+    expiration = NA
+  )
+
+  expect_true(is_credentials_provided(creds))
+
 })
 
 #-------------------------------------------------------------------------------

--- a/paws.common/tests/testthat/test_credentials.R
+++ b/paws.common/tests/testthat/test_credentials.R
@@ -69,7 +69,7 @@ test_that("credentials expired", {
 # returns the credentials.
 f_get_credentials <- function() {
   cfg <- get_config()
-  if (!is_credentials_provided(cfg$credentials$creds)) {
+  if (!is_credentials_provided(cfg$credentials$creds, window = 0)) {
     foo <- get_credentials(cfg$credentials)
   }
   return(cfg)
@@ -124,18 +124,20 @@ test_that("credentials are cached", {
 
 test_that("credentials refresh when expired", {
   svc <- service()
+
+  # get and then use cached credentials
   f1 <- svc$get_credentials() # get the credentials
   expiration1 <- f1$credentials$creds$expiration
+  Sys.sleep(1) # add a time gap between successive calls
   f2 <- svc$get_credentials() # access the credentials found above
   expiration2 <- f2$credentials$creds$expiration
 
   expect_equal(expiration1, expiration2)
 
+  # wait until credentials expire then refresh
   Sys.sleep(5) # these credentials are set to expire after 5 seconds
-
   f3 <- svc$get_credentials() # refresh the credentials
   expiration3 <- f3$credentials$creds$expiration
 
   expect_true(expiration1 != expiration3)
-
 })

--- a/paws.common/tests/testthat/test_credentials.R
+++ b/paws.common/tests/testthat/test_credentials.R
@@ -35,3 +35,80 @@ test_that("credentials not provided", {
 
   expect_false(is_credentials_provided(creds))
 })
+
+#-------------------------------------------------------------------------------
+
+# Example operation that gets credentials (if unavailable or expired) and
+# returns the credentials.
+f_get_credentials <- function() {
+  cfg <- get_config()
+  if (!is_credentials_provided(cfg$credentials$creds)) {
+    foo <- get_credentials(cfg$credentials)
+  }
+  return(cfg)
+}
+
+# Example operation that does NOT get credentials but returns any that were
+# previously found.
+g_dont_get_credentials <- function() {
+  cfg <- get_config()
+  return(cfg)
+}
+
+credential_provider <- function() {
+  list(
+    access_key_id = "AKID",
+    secret_access_key = "SECRET",
+    session_token = "SESSION",
+    expiration = Sys.time() + 5,
+    provider_name = "StaticProvider"
+  )
+}
+
+# Example service with two operations.
+service <- function(config = list()) {
+  svc <- list(
+    get_credentials = f_get_credentials,
+    dont_get_credentials = g_dont_get_credentials
+  )
+  svc <- set_config(svc, config)
+  svc$.internal$config$credentials$provider <- list(credential_provider)
+  return(svc)
+}
+
+test_that("credentials are cached", {
+
+  # Use provided credentials.
+  creds <- list(access_key_id = "foo", secret_access_key = "bar")
+  svc <- service(config = list(credentials = list(creds = creds)))
+  actual <- svc$get_credentials()
+
+  expect_equivalent(actual$credentials$creds$access_key_id, creds$access_key_id)
+  expect_equivalent(actual$credentials$creds$secret_access_key, creds$secret_access_key)
+
+  # Use cached credentials.
+  svc <- service()
+  foo <- svc$get_credentials() # get the credentials
+  actual <- svc$dont_get_credentials() # access the credentials found above
+
+  expect_equivalent(actual$credentials$creds$access_key_id, "AKID")
+  expect_equivalent(actual$credentials$creds$secret_access_key, "SECRET")
+})
+
+test_that("credentials refresh when expired", {
+  svc <- service()
+  f1 <- svc$get_credentials() # get the credentials
+  expiration1 <- f1$credentials$creds$expiration
+  f2 <- svc$get_credentials() # access the credentials found above
+  expiration2 <- f2$credentials$creds$expiration
+
+  expect_equal(expiration1, expiration2)
+
+  Sys.sleep(5) # credentials expire after 5 seconds
+
+  f3 <- svc$get_credentials() # refresh the credentials
+  expiration3 <- f3$credentials$creds$expiration
+
+  expect_true(expiration1 != expiration3)
+
+})

--- a/paws.common/tests/testthat/test_credentials.R
+++ b/paws.common/tests/testthat/test_credentials.R
@@ -70,7 +70,7 @@ test_that("credentials expired", {
 f_get_credentials <- function() {
   cfg <- get_config()
   if (!is_credentials_provided(cfg$credentials$creds, window = 0)) {
-    foo <- get_credentials(cfg$credentials)
+    get_credentials(cfg$credentials) # sets credentials in service object as a side effect.
   }
   return(cfg)
 }


### PR DESCRIPTION
* Cache credentials in the `.internal$config$credentials` object by making it an environment. Whenever an operation is run, the SDK will add credentials to the credentials environment when needed. These credentials will be cached and available in the service object, e.g. the object created by `paws::s3()`.
* Check for credential expiration by adding an expiration property to the `Creds` object.

TODO:
* [x] Test on AWS
    * ~~EC2 role~~
    * ~~container role~~
    * ~~assume role~~
    * ~~credential process~~
* [x] Add time windows to expiration timestamp?
* [x] Add unit tests