### PR TITLE
Use no timeout by default for HTTP requests

### DIFF
--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: paws.common
 Type: Package
 Title: Paws Low-Level Amazon Web Services API
-Version: 0.3.7
+Version: 0.3.8
 Authors@R: c(
         person("David", "Kretch", email = "david.kretch@gmail.com", role = c("aut", "cre")),
         person("Adam", "Banker", email = "adam.banker39@gmail.com", role = "aut"),

--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -1,3 +1,9 @@
+# paws.common 0.3.8
+
+* Use no timeout by default when making HTTP requests. The previous release set
+  the default timeout to 10 seconds, which prevented users from downloading
+  large files.
+
 # paws.common 0.3.7
 
 * `s3$put_object` will now read in files when given file paths for the `Body`

--- a/paws.common/R/net.R
+++ b/paws.common/R/net.R
@@ -23,7 +23,7 @@ HttpRequest <- struct(
   request_uri = "",
   tls = NULL,
   cancel = NULL,
-  timeout = 10,
+  timeout = NULL,
   response = NULL,
   ctx = list()
 )
@@ -47,7 +47,7 @@ HttpResponse <- struct(
 )
 
 # Returns an HTTP request given a method, URL, and an optional body.
-new_http_request <- function(method, url, body = NULL, timeout = 10) {
+new_http_request <- function(method, url, body = NULL, timeout = NULL) {
   if (method == "") {
     method <- "GET"
   }

--- a/paws.common/cran-comments.md
+++ b/paws.common/cran-comments.md
@@ -5,7 +5,8 @@
 
 ## R CMD check results
 
-There were no ERRORs or WARNINGs.
+This package was updated on CRAN less than 30 days ago. This release fixes a
+serious bug that was introduced in that release.
 
 ## Downstream dependencies
 


### PR DESCRIPTION
Use no timeout by default when making HTTP requests. The previous release set the default timeout to 10 seconds, which prevented users from downloading large files. Addresses #371.