### PR TITLE
Support multifactor auth

### DIFF
--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -122,6 +122,14 @@ file. The profile, e.g. `my_profile`, should appear as follows.
     [profile my_profile]
     key1=value1
     key2=value2
+
+### Multifactor authentication
+
+You can use multifactor authentication by specifying the `mfa_serial` parameter
+along with `role_arn` and either `credential_source` or `source_profile`. Paws
+will prompt you to provide your MFA token code, and once you provide it the
+temporary credentials it retrieves will be valid for one hour.
+
     
 ## Region
 

--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     xml2
 Suggests:
     covr,
+    rstudioapi,
     testthat
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))

--- a/paws.common/R/credential_providers.R
+++ b/paws.common/R/credential_providers.R
@@ -184,7 +184,7 @@ config_file_source_profile <- function(role_arn, role_session_name, mfa_serial, 
   return(role_creds)
 }
 
-# Get credentials from assumed role `role_arn`, using credentials in `creds`.
+# Get credentials for assumed role `role_arn`, using credentials in `creds`.
 # If the role requires MFA, the MFA device's serial number must be provided in
 # `mfa_serial`, and the user will be prompted interactively to provide the
 # current MFA token code.

--- a/paws.common/R/credential_providers.R
+++ b/paws.common/R/credential_providers.R
@@ -218,7 +218,7 @@ get_assumed_role_creds <- function(role_arn, role_session_name, mfa_serial, cred
 # Use an RStudio prompt if running in RStudio.
 # Otherwise use a text prompt in the console.
 get_token_code <- function() {
-  if ("rstudioapi" %in% utils::installed.packages()[,1] && rstudioapi::isAvailable()) {
+  if (requireNamespace("rstudioapi", quietly = TRUE) && rstudioapi::isAvailable()) {
     token_code <- rstudioapi::showPrompt("MFA", "Enter MFA token code")
   } else {
     token_code <- readline("Enter MFA token code: ")


### PR DESCRIPTION
Support multifactor authentication, using the `mfa_serial` shared configuration file item.

Addresses #253

To do:
* [x] Add comments
* [x] Improve prompt?
* [x] Test on AWS
    + ~~EC2 IAM role~~
    + ~~config file credential process~~
    + ~~config file assume role: source profile~~
    + ~~config file assume role: credential source EC2 instance metadata~~
    + ~~config file assume role: source profile + MFA~~