### PR TITLE
Adds Response syntax section to the docs

### DIFF
--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -17,6 +17,7 @@ make_docs <- function(operation, api) {
       usage,
       params,
       request,
+      response,
       examples,
       "#' @keywords internal",
       rdname),
@@ -110,10 +111,22 @@ make_doc_request <- function(operation, api) {
 }
 
 # Return a string with a description of the operation's response.
-# TODO: Implement.
 make_doc_response <- function(operation, api) {
-  output <- operation$output
-  "#' @return"
+  func <- sprintf("svc$%s", get_operation_name(operation))
+  shape_name <- operation$output$shape
+  if (!is.null(shape_name)) {
+    shape <- make_shape(list(shape = shape_name), api)
+    args <- add_example_values(shape)
+    masks <- list("\\(" = "&#40;", "\\)" = "&#41;")
+    args <- mask(args, masks)
+    call <- list_to_string(args, quote = FALSE)
+    call <- unmask(clean_example(call), masks)
+    call <- paste("```", call, "```", sep = "\n")
+    accepted_params <- comment(paste(c("@section Response syntax:", call),
+                                     collapse = "\n"), "#'")
+    return(accepted_params)
+  }
+  return("")
 }
 
 # Return a string with an operation example's arguments.

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -7,8 +7,8 @@ make_docs <- function(operation, api) {
   description <- make_doc_desc(operation, api)
   usage <- make_doc_usage(operation, api)
   params <- make_doc_params(operation, api)
+  value <- make_doc_value(operation, api)
   request <- make_doc_request(operation, api)
-  response <- make_doc_response(operation, api)
   examples <- make_doc_examples(operation, api)
   rdname <- make_doc_rdname(operation, api)
   docs <- glue::glue_collapse(
@@ -16,8 +16,8 @@ make_docs <- function(operation, api) {
       description,
       usage,
       params,
+      value,
       request,
-      response,
       examples,
       "#' @keywords internal",
       rdname),
@@ -111,7 +111,7 @@ make_doc_request <- function(operation, api) {
 }
 
 # Return a string with a description of the operation's response.
-make_doc_response <- function(operation, api) {
+make_doc_value <- function(operation, api) {
   func <- sprintf("svc$%s", get_operation_name(operation))
   shape_name <- operation$output$shape
   if (!is.null(shape_name)) {
@@ -122,8 +122,9 @@ make_doc_response <- function(operation, api) {
     call <- list_to_string(args, quote = FALSE)
     call <- unmask(clean_example(call), masks)
     call <- paste("```", call, "```", sep = "\n")
-    accepted_params <- comment(paste(c("@section Response syntax:", call),
-                                     collapse = "\n"), "#'")
+    overview <- "A list with the following syntax:"
+    accepted_params <-
+      comment(paste(c("@return", overview, call), collapse = "\n"), "#'")
     return(accepted_params)
   }
   return("")

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -123,9 +123,9 @@ make_doc_value <- function(operation, api) {
     call <- unmask(clean_example(call), masks)
     call <- paste("```", call, "```", sep = "\n")
     overview <- "A list with the following syntax:"
-    accepted_params <-
+    response_value <-
       comment(paste(c("@return", overview, call), collapse = "\n"), "#'")
-    return(accepted_params)
+    return(response_value)
   }
   return("")
 }

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -132,7 +132,7 @@ test_that("make_doc_request", {
   expect_equal(actual, expected)
 })
 
-test_that("make_doc_response", {
+test_that("make_doc_value", {
   operation <- list(
     name = "operation",
     output = list(
@@ -193,9 +193,10 @@ test_that("make_doc_response", {
     )
   )
 
-  actual <- make_doc_response(operation, api)
+  actual <- make_doc_value(operation, api)
   expected <- paste(
-    "#' @section Response syntax:",
+    "#' @return",
+    "#' A list with the following syntax:",
     "#' ```",
     "#' list(",
     "#'   Foo = \"string\",",

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -132,6 +132,86 @@ test_that("make_doc_request", {
   expect_equal(actual, expected)
 })
 
+test_that("make_doc_response", {
+  operation <- list(
+    name = "operation",
+    output = list(
+      shape = "OperationShape"
+    )
+  )
+  api <- list(
+    metadata = list(
+      serviceAbbreviation = "api"
+    ),
+    shapes = list(
+      OperationShape = list(
+        type = "structure",
+        members = list(
+          Foo = list(
+            shape = "FooShape"
+          ),
+          Bar = list(
+            shape = "BarShape"
+          )
+        )
+      ),
+      FooShape = list(
+        type = "string"
+      ),
+      BarShape = list(
+        type = "structure",
+        members = list(
+          Baz = list(
+            shape = "BazShape"
+          ),
+          Qux = list(
+            shape = "QuxShape"
+          ),
+          Quux = list(
+            shape = "QuuxShape"
+          ),
+          Quuz = list(
+            shape = "QuuzShape"
+          )
+        )
+      ),
+      BazShape = list(
+        type = "integer"
+      ),
+      QuxShape = list(
+        type = "double"
+      ),
+      QuuxShape = list(
+        type = "boolean"
+      ),
+      QuuzShape = list(
+        type = "enum",
+        enum = list(
+          "a", "b", "c"
+        )
+      )
+    )
+  )
+
+  actual <- make_doc_response(operation, api)
+  expected <- paste(
+    "#' @section Response syntax:",
+    "#' ```",
+    "#' list(",
+    "#'   Foo = \"string\",",
+    "#'   Bar = list(",
+    "#'     Baz = 123,",
+    "#'     Qux = 123.0,",
+    "#'     Quux = TRUE|FALSE,",
+    "#'     Quuz = \"a\"|\"b\"|\"c\"",
+    "#'   )",
+    "#' )",
+    "#' ```",
+    sep = "\n"
+  )
+  expect_equal(actual, expected)
+})
+
 test_that("make_doc_params", {
   # Operation with no parameters.
   operation <- list()

--- a/make.paws/tests/testthat/test_operations.R
+++ b/make.paws/tests/testthat/test_operations.R
@@ -62,21 +62,22 @@ test_that("make_operation", {
     #' @param Input2
     #' @param Input3
     #'
+    #' @return
+    #' A list with the following syntax:
+    #' ```
+    #' list(
+    #'   Output1 = \"string\",
+    #'   Output2 = \"string\",
+    #'   Output3 = 123
+    #' )
+    #' ```
+    #'
     #' @section Request syntax:
     #' ```
     #' svc$operation(
     #'   Input1 = \"string\",
     #'   Input2 = \"string\",
     #'   Input3 = 123
-    #' )
-    #' ```
-    #'
-    #' @section Response syntax:
-    #' ```
-    #' list(
-    #'   Output1 = \"string\",
-    #'   Output2 = \"string\",
-    #'   Output3 = 123
     #' )
     #' ```
     #'

--- a/make.paws/tests/testthat/test_operations.R
+++ b/make.paws/tests/testthat/test_operations.R
@@ -10,6 +10,9 @@ test_that("make_operation", {
     input = list(
       shape = "InputShape"
     ),
+    output = list(
+      shape = "OutputShape"
+    ),
     documentation = "Foo."
   )
   api <- list(
@@ -28,7 +31,19 @@ test_that("make_operation", {
       ),
       Input1 = list(type = "string"),
       Input2 = list(type = "string"),
-      Input3 = list(type = "integer")
+      Input3 = list(type = "integer"),
+      OutputShape = list(
+        required = list(),
+        members = list(
+          Output1 = list(shape = "Output1"),
+          Output2 = list(shape = "Output2"),
+          Output3 = list(shape = "Output3")
+        ),
+        type = "structure"
+      ),
+      Output1 = list(type = "string"),
+      Output2 = list(type = "string"),
+      Output3 = list(type = "integer")
     )
   )
   a <- make_operation(operation, api)
@@ -53,6 +68,15 @@ test_that("make_operation", {
     #'   Input1 = \"string\",
     #'   Input2 = \"string\",
     #'   Input3 = 123
+    #' )
+    #' ```
+    #'
+    #' @section Response syntax:
+    #' ```
+    #' list(
+    #'   Output1 = \"string\",
+    #'   Output2 = \"string\",
+    #'   Output3 = 123
     #' )
     #' ```
     #'


### PR DESCRIPTION
Adds a section to the documentation for the response syntax similar to the section we already have for the request syntax. Checks off an item in issue #354.