### PR TITLE
Remove extra escapes, fix overly long titles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ export R_USER
 
 help:
 	@echo "  build              build the AWS SDK package"
-	@echo "  install            build and install the AWS SDK package"
+	@echo "  rebuild            clear the build cache and build"
+	@echo "  install            build and install the AWS SDK packages"
 	@echo "  common             build and install common functions"
 	@echo "  codegen            build and install the code generator"
 	@echo "  check              run R CMD check on packages"
@@ -32,9 +33,18 @@ help:
 
 build: build-full build-cran
 
+rebuild: clean build
+
 install: build
-	@echo "install the AWS SDK package"
-	@Rscript -e "devtools::install('${OUT_DIR}', upgrade = FALSE, quiet = TRUE)"
+	@echo "install the AWS SDK packages"
+	@for package in ${CRAN_DIR}/*/; do \
+		if [ "$$package" = "${CRAN_DIR}/paws/" ]; then continue; fi; \
+		echo "- $$(basename $$package)"; \
+		Rscript -e "devtools::install('$$package', upgrade = FALSE, quiet = TRUE)"; \
+	done;
+	@echo "- paws"
+	@Rscript -e "devtools::install('${CRAN_DIR}/paws', upgrade = FALSE, quiet = TRUE)";
+	@echo "done"
 
 build-full: codegen
 	@echo "build the AWS SDK package"

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -240,6 +240,7 @@ convert <- function(docs, service = "", links = c()) {
     }
     result <- clean_html(docs, links)
     result <- html_to_markdown(result)
+    result <- clean_markdown(result)
     result <- escape_special_chars(result)
     result <- fix_internal_links(result)
     result
@@ -371,15 +372,15 @@ clean_html_dd <- function(node) {
 
 # Escape special characters % { }, and single \ not followed by another special
 # character. These cause problems in R documentation Rd files.
-# Do not escape \ when followed by:
-#   1. % { } \ ' " ` -- escaped special Rd or LaTeX characters
-#   2. * [ ] -- escaped markdown characters
-#   3. ~ -- ???
 # See https://developer.r-project.org/parseRd.pdf.
 escape_special_chars <- function(text) {
   result <- text
 
   # Single \ -- not following another \ and not preceding a special character
+  # Do not escape \ when followed by:
+  #   1. % { } \ ' " ` -- escaped special Rd or LaTeX characters
+  #   2. * [ ] -- escaped markdown characters
+  #   3. ~ -- ???
   result <- gsub("(?<!\\\\)\\\\(?![\\\\%{}'\"`\\*~\\[\\]])", "\\\\\\\\", result, perl = TRUE)
 
   # Special case: `\`

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -121,6 +121,7 @@ make_doc_example_args <- function(input) {
   if (length(input) == 0) return("")
   args <- paste(trimws(utils::capture.output(dput(input))), collapse = "")
   result <- gsub("^list\\((.*)\\)$", "\\1", args)
+  result <- gsub('\\\\+"', '"', result) # Delete escapes before quotes.
   return(result)
 }
 

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -403,7 +403,6 @@ clean_markdown <- function(markdown) {
 
   # Unicode character codes: \\uxxxx to `U+xxxx`
   result <- gsub("\\\\\\\\u([0-9a-fA-F]{4})", "`U+\\1`", result)
-  result
 
   # @ symbol, escaped for Roxygen.
   # See http://r-pkgs.had.co.nz/man.html#roxygen-comments.

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -461,9 +461,12 @@ list_to_string <- function(x, quote = TRUE) {
 
 # Returns the title of an operation (the first sentence of its description).
 get_operation_title <- function(operation) {
-  docs <- paste(html_to_text(operation$documentation), collapse = " ")
-  docs <- gsub(" +", " ", docs)
-  title <- first_sentence(docs)
+  docs <- html_to_text(operation$documentation)
+  blank_line <- which(docs == "")
+  first_paragraph <- ifelse(length(blank_line) >= 1, blank_line[1] - 1, length(docs))
+  paragraph <- paste(docs[1:first_paragraph], collapse = " ")
+  paragraph <- gsub(" +", " ", paragraph)
+  title <- first_sentence(paragraph)
   title <- mask(title, c("[" = "&#91;", "]" = "&#93;"))
   if (length(title) == 0 || title == "") {
     title <- gsub("_", " ", get_operation_name(operation))

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -233,6 +233,7 @@ comment <- function(s, char = "#") {
 #' @noRd
 convert <- function(docs, service = "", links = c()) {
   if (is.null(docs) || docs == "") return("")
+  docs <- trimws(docs)
   cached_expr(list("convert", docs = docs, service = service), {
     if (grepl("^<", docs)) {
       html <- clean_html(docs, links)

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -235,12 +235,11 @@ convert <- function(docs, service = "", links = c()) {
   if (is.null(docs) || docs == "") return("")
   docs <- trimws(docs)
   cached_expr(list("convert", docs = docs, service = service), {
-    if (grepl("^<", docs)) {
-      html <- clean_html(docs, links)
-      result <- html_to_markdown(html)
-    } else {
-      result <- strsplit(docs, "\n")[[1]]
+    if (!grepl("^<", docs)) {
+      docs <- sprintf("<body>%s</body>", docs)
     }
+    result <- clean_html(docs, links)
+    result <- html_to_markdown(result)
     result <- escape_special_chars(result)
     result <- fix_internal_links(result)
     result

--- a/make.paws/R/make_sdk.R
+++ b/make.paws/R/make_sdk.R
@@ -16,7 +16,6 @@ make_sdk <- function(in_dir = "./vendor/aws-sdk-js", out_dir = "./paws",
       cat(paste0(api, "\n"))
       write_sdk_for_api(api, in_dir, out_dir)
     }
-    write_documentation(out_dir)
     return(invisible(TRUE))
   })
 }

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -403,35 +403,6 @@ test_that("make_doc_examples", {
   expect_equal(actual, expected)
 })
 
-test_that("clean_markdown", {
-  text <- ""
-  expect_equal(clean_markdown(text), text)
-
-  text <- "foo"
-  expect_equal(clean_markdown(text), text)
-
-  text <- "\\[foo\\]"
-  expected <- "&#91;foo&#93;"
-  expect_equal(clean_markdown(text), expected)
-
-  text <- "[foo]"
-  expect_equal(clean_markdown(text), text)
-
-  lines <- ""
-  expect_equal(clean_markdown(lines), lines)
-
-  lines <- c("foo", "bar", "baz")
-  expect_equal(clean_markdown(lines), lines)
-
-  lines <- c("foo", "bar", "<!-- -->", "baz")
-  expected <- c("foo", "bar", "baz")
-  expect_equal(clean_markdown(lines), expected)
-
-  lines <- c("\\[foo\\]", "bar", "baz")
-  expected <- c("&#91;foo&#93;", "bar", "baz")
-  expect_equal(clean_markdown(lines), expected)
-})
-
 test_that("convert", {
   text <- NULL
   expected <- ""
@@ -450,9 +421,6 @@ test_that("convert", {
   text <- "<body><p>foo</p><p>bar</p></body>"
   expected <- c("foo", "", "bar")
   expect_equal(convert(text), expected)
-
-  text <- "`foo`"
-  expect_equal(convert(text), text)
 
   text <- "<body><code>'foo</code></body>"
   expected <- "`\\'foo`"
@@ -487,10 +455,6 @@ test_that("convert", {
 
   text <- "<body><p>foo</p><p>bar<code>'baz</code></p></body>"
   expected <- c("foo", "", "bar`\\'baz`")
-  expect_equal(convert(text), expected)
-
-  text <- "<p>foo \\a \\b</p>"
-  expected <- c("foo `\\\\a` `\\\\b`")
   expect_equal(convert(text), expected)
 
   text <- "<a href='http://www.example.com'>foo</a>"
@@ -533,6 +497,12 @@ test_that("convert", {
   expected <- c("### Description", "", "Definition.")
   expect_equal(convert(text), expected)
 
+  text <- "<p><code>{foo</code>}</p>"
+  expected <- "`{foo`\\}"
+  expect_equal(convert(text), expected)
+})
+
+test_that("convert package links", {
   text <- "<a>Foo</a>"
   links <- list(Foo = list(r_name = "foo", internal_r_name = "bar_foo"))
   expected <- c("[`foo`][bar_foo]")
@@ -580,26 +550,4 @@ test_that("escape_unmatched_quotes", {
   expect_equal(escape_unmatched_quotes("foo'"), "foo\\'")
   expect_equal(escape_unmatched_quotes("foo"), "foo")
   expect_equal(escape_unmatched_quotes(""), "")
-})
-
-test_that("clean_markdown", {
-  text <- ""
-  expect_equal(clean_markdown(text), text)
-
-  text <- "foo"
-  expect_equal(clean_markdown(text), text)
-
-  text <- "\\[foo\\]"
-  expected <- "&#91;foo&#93;"
-  expect_equal(clean_markdown(text), expected)
-
-  text <- "[foo]"
-  expect_equal(clean_markdown(text), text)
-
-  lines <- c("foo", "bar", "baz")
-  expect_equal(clean_markdown(lines), lines)
-
-  lines <- c("foo", "bar", "<!-- -->", "baz")
-  expected <- c("foo", "bar", "baz")
-  expect_equal(clean_markdown(lines), expected)
 })

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -422,6 +422,10 @@ test_that("convert", {
   expected <- c("foo", "", "bar")
   expect_equal(convert(text), expected)
 
+  text <- "<dt>Description</dt><dd>Definition.</dd>"
+  expected <- c("### Description", "", "Definition.")
+  expect_equal(convert(text), expected)
+
   text <- "<code>foo</foo>"
   expected <- "`foo`"
   expect_equal(convert(text), expected)
@@ -468,6 +472,10 @@ test_that("convert", {
   text <- "<body><p>foo</p><p>bar<code>'baz</code></p></body>"
   expected <- c("foo", "", "bar`\\'baz`")
   expect_equal(convert(text), expected)
+
+  text <- "<p><code>{foo</code>}</p>"
+  expected <- "`\\{foo`\\}"
+  expect_equal(convert(text), expected)
 })
 
 test_that("check links", {
@@ -505,14 +513,6 @@ test_that("check links", {
 
   text <- "<a href='https://httpbin.org/anything#foo?bar=baz'>foo</a>"
   expected <- c("[foo](https://httpbin.org/anything#foo?bar=baz)")
-  expect_equal(convert(text), expected)
-
-  text <- "<dt>Description</dt><dd>Definition.</dd>"
-  expected <- c("### Description", "", "Definition.")
-  expect_equal(convert(text), expected)
-
-  text <- "<p><code>{foo</code>}</p>"
-  expected <- "`\\{foo`\\}"
   expect_equal(convert(text), expected)
 })
 

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -20,6 +20,10 @@ test_that("make_doc_title", {
   operation <- list(documentation = "<p>A really long description which is over 80 characters wide and will get cut off by the automatic line wrapping when converted from HTML to Markdown. Here is another sentence.</p>")
   expected <- "#' A really long description which is over 80 characters wide and will get\n#' cut off by the automatic line wrapping when converted from HTML to\n#' Markdown"
   expect_equal(make_doc_title(operation), expected)
+
+  operation <- list(documentation = "<p>foo</p><p>bar</p><p>baz</p>")
+  expected <- "#' foo"
+  expect_equal(make_doc_title(operation), expected)
 })
 
 test_that("make_doc_desc", {

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -426,6 +426,10 @@ test_that("convert", {
   expected <- "`\\'foo`"
   expect_equal(convert(text), expected)
 
+  text <- "<body><code>{foo</code></body>"
+  expected <- "`\\{foo`"
+  expect_equal(convert(text), expected)
+
   text <- "<body>\\'{</body>"
   expected <- "\\\\'\\{"
   expect_equal(convert(text), expected)
@@ -442,6 +446,10 @@ test_that("convert", {
   expected <- "*"
   expect_equal(convert(text), expected)
 
+  text <- "<body>foo_bar</body>"
+  expected <- "foo_bar"
+  expect_equal(convert(text), expected)
+
   text <- "<body>foo \\bar { \\u0123 <code>baz'</code></body>"
   expected <- "foo \\\\bar \\{ `U+0123` `baz\\'`"
   expect_equal(convert(text), expected)
@@ -456,7 +464,9 @@ test_that("convert", {
   text <- "<body><p>foo</p><p>bar<code>'baz</code></p></body>"
   expected <- c("foo", "", "bar`\\'baz`")
   expect_equal(convert(text), expected)
+})
 
+test_that("check links", {
   text <- "<a href='http://www.example.com'>foo</a>"
   expected <- c("[foo](http://www.example.com/)")
   expect_equal(convert(text), expected)
@@ -498,11 +508,11 @@ test_that("convert", {
   expect_equal(convert(text), expected)
 
   text <- "<p><code>{foo</code>}</p>"
-  expected <- "`{foo`\\}"
+  expected <- "`\\{foo`\\}"
   expect_equal(convert(text), expected)
 })
 
-test_that("convert package links", {
+test_that("convert within-package links", {
   text <- "<a>Foo</a>"
   links <- list(Foo = list(r_name = "foo", internal_r_name = "bar_foo"))
   expected <- c("[`foo`][bar_foo]")
@@ -544,10 +554,16 @@ test_that("first_sentence", {
   expect_equal(first_sentence("foo. bar."), "foo")
 })
 
-test_that("escape_unmatched_quotes", {
-  expect_equal(escape_unmatched_quotes("'foo'"), "'foo'")
-  expect_equal(escape_unmatched_quotes("'foo"), "\\'foo")
-  expect_equal(escape_unmatched_quotes("foo'"), "foo\\'")
-  expect_equal(escape_unmatched_quotes("foo"), "foo")
-  expect_equal(escape_unmatched_quotes(""), "")
+test_that("escape_unmatched", {
+  chars <- c('"', "'", "`")
+  expect_equal(escape_unmatched_chars("'foo'", chars), "'foo'")
+  expect_equal(escape_unmatched_chars("'foo", chars), "\\'foo")
+  expect_equal(escape_unmatched_chars("foo'", chars), "foo\\'")
+  expect_equal(escape_unmatched_chars("foo", chars), "foo")
+  expect_equal(escape_unmatched_chars("", chars), "")
+
+  pairs <- c("{" = "}")
+  expect_equal(escape_unmatched_pairs("{foo}", pairs), "{foo}")
+  expect_equal(escape_unmatched_pairs("{foo", pairs), "\\{foo")
+  expect_equal(escape_unmatched_pairs("{{foo}", pairs), "\\{\\{foo\\}")
 })

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -334,7 +334,7 @@ test_that("make_doc_examples", {
     "#' svc$operation(",
     "#'   Foo = \"bar\",",
     "#'   Baz = list(",
-    "#'     Qux = \"\\{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[\\{\\\"Sid\\\":\\\"Stmt1\\\",\\\"Effect\\\":...\"",
+    "#'     Qux = \"\\{\"Version\":\"2012-10-17\",\"Statement\":[\\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Action\":\"s3...\"",
     "#'   )",
     "#' )",
     "#' }",
@@ -420,6 +420,10 @@ test_that("convert", {
 
   text <- "<body><p>foo</p><p>bar</p></body>"
   expected <- c("foo", "", "bar")
+  expect_equal(convert(text), expected)
+
+  text <- "<code>foo</foo>"
+  expected <- "`foo`"
   expect_equal(convert(text), expected)
 
   text <- "<body><code>'foo</code></body>"


### PR DESCRIPTION
* Remove most extra escapes. Now the only escaping done is for the following cases:
    * All `{` and `}` in plain text to avoid LaTeX errors.
    * Unmatched `{` and `}` in code fragments to avoid Roxygen errors.
    * Unmatched `"`, `'`, or ` in code fragments to avoid Roxygen errors.
* Explicitly remove extra escapes added by Pandoc for `_` and for `\` before `{` and `}`. Explicitly remove extra escapes in generated example code.
* Clean up the HTML-to-Markdown pipeline, which had a lot of extra complexity that is no longer needed since moving to Commonmark.
    * In `convert`, treat all provided documentation as HTML. Previously it would check for first character `<` and if not found, would treat as plain text. However, some documentation had extra whitespace before the HTML began. Now it trims whitespace, and if the text does not begin with an HTML tag, it wraps it in a `<body>` element.
* Fix long help page titles caused by documentation whose first paragraph doesn't end with a period. Previously it would include the next paragraph; now it does not.
* Do not run Roxygen for the original `paws` folder; only for the packages in the `cran` folder. This was not needed and avoiding it saves build time.