### PR TITLE
Uses the provided endpoint prefix rather than the service name

### DIFF
--- a/make.paws/R/read_api.R
+++ b/make.paws/R/read_api.R
@@ -51,6 +51,7 @@ merge_examples <- function(api, examples) {
 # lists endpoints for each service and region, if different from the default.
 merge_region_config <- function(api, region_config) {
   service <- service_name(api)
+  endpoint_prefix <- api$metadata$endpointPrefix
   get_rule_names <- function(service) {
     grep(sprintf("/%s$", service), names(region_config$rules), value = TRUE)
   }
@@ -65,7 +66,7 @@ merge_region_config <- function(api, region_config) {
       rule <- region_config$patterns[[rule]]
     }
     rules[[region]] <- list(
-      endpoint = gsub("{service}", service, rule$endpoint, fixed = TRUE),
+      endpoint = gsub("{service}", endpoint_prefix, rule$endpoint, fixed = TRUE),
       global = isTRUE(rule$globalEndpoint)
     )
   }

--- a/make.paws/tests/testthat/test_read_api.R
+++ b/make.paws/tests/testthat/test_read_api.R
@@ -9,7 +9,7 @@ test_that("read_api", {
 
   write_json(list(foo = "examples"), file.path(api_path, "foo-2018-11-01.examples.json"))
   write_json(list(foo = "min"), file.path(api_path, "foo-2018-11-01.min.json"))
-  write_json(list(foo = "normal", name = "foo"), file.path(api_path, "foo-2018-11-01.normal.json"))
+  write_json(list(foo = "normal", name = "foo", metadata = list(endpointPrefix = "baz")), file.path(api_path, "foo-2018-11-01.normal.json"))
   write_json(list(foo = "paginators"), file.path(api_path, "foo-2018-11-01.paginators.json"))
 
   write_json(list(foo = "wrong1"), file.path(api_path, "foo-2017-11-01.examples.json"))
@@ -20,14 +20,14 @@ test_that("read_api", {
   region_path <- file.path(path, "lib")
   dir.create(region_path)
   write_json(
-    list(rules = list("*/*" = list(endpoint = "bar"), "*/foo" = list(endpoint = "baz", globalEndpoint = TRUE))),
+    list(rules = list("*/*" = list(endpoint = "bar"), "*/foo" = list(endpoint = "{service}.endpoint", globalEndpoint = TRUE))),
     file.path(region_path, "region_config_data.json")
   )
 
   api <- read_api("foo", path)
 
   expect_equal(api$name, "foo")
-  expect_equal(api$region_config$`*`, list(endpoint = "baz", global = TRUE))
+  expect_equal(api$region_config$`*`, list(endpoint = "baz.endpoint", global = TRUE))
 
   expect_error(read_api("bar", api_path))
 })


### PR DESCRIPTION
Previously we assumed that the endpoint prefix was the same as the service name. This is usually the case, but this update reads in the endpoint prefix from the api metadata. Addresses #385 and #62