### PR TITLE
Fix integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,11 @@ unit: test-common test-codegen
 
 integration:
 	@echo "run integration tests"
-	@Rscript -e "options('testthat.summary.max_reports' = 1e6); devtools::test('${OUT_DIR}', reporter = 'summary')"
+	@for package in ${CRAN_DIR}/*/; do \
+		if [ "$$package" = "${CRAN_DIR}/paws/" ]; then continue; fi; \
+		echo "- $$(basename $$package)"; \
+		Rscript -e "options('testthat.summary.max_reports' = 1e6); devtools::test('$$package', reporter = 'summary')"; \
+	done;
 
 common:
 	@echo "build and install common functions"

--- a/make.paws/R/tests.R
+++ b/make.paws/R/tests.R
@@ -4,8 +4,6 @@ NULL
 
 test_file_template <- template(
   `
-  context("${service}")
-
   svc <- paws::${service}()
 
   ${tests}

--- a/make.paws/tests/testthat/test_tests.R
+++ b/make.paws/tests/testthat/test_tests.R
@@ -93,9 +93,7 @@ test_that("make_tests", {
   )
   a <- make_tests(api)
   e <-
-    'context("api")
-
-    svc <- paws::api()
+    'svc <- paws::api()
 
     test_that("describe_foo", {
       expect_error(svc$describe_foo(), NA)


### PR DESCRIPTION
* Fix the integration test make recipe

    Make the integration test recipe run tests on each of the CRAN category packages in the `cran` folder, rather than the legacy paws package in the `paws` folder. The tests in the legacy paws package no longer work because we no longer run the Roxygen2/document process on it.

* Fix duplicated lines in integration test output

    Delete the call to `context("svc")` in generated integration test files. `testthat` no longer needs `context()` and now it only results in a duplicated line in the output.