### PR TITLE
Regenerate Paws

### DIFF
--- a/cran/paws.analytics/R/kinesisanalyticsv2_service.R
+++ b/cran/paws.analytics/R/kinesisanalyticsv2_service.R
@@ -87,7 +87,7 @@ kinesisanalyticsv2 <- function(config = list()) {
 
 .kinesisanalyticsv2$metadata <- list(
   service_name = "kinesisanalyticsv2",
-  endpoints = list("*" = list(endpoint = "kinesisanalyticsv2.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "kinesisanalyticsv2.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "kinesisanalyticsv2.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "kinesisanalyticsv2.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "kinesisanalytics.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "kinesisanalytics.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "kinesisanalytics.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "kinesisanalytics.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "Kinesis Analytics V2",
   api_version = "2018-05-23",
   signing_name = "kinesisanalytics",

--- a/cran/paws.analytics/tests/testthat/test_athena.R
+++ b/cran/paws.analytics/tests/testthat/test_athena.R
@@ -1,5 +1,3 @@
-context("athena")
-
 svc <- paws::athena()
 
 test_that("list_data_catalogs", {

--- a/cran/paws.analytics/tests/testthat/test_cloudsearch.R
+++ b/cran/paws.analytics/tests/testthat/test_cloudsearch.R
@@ -1,5 +1,3 @@
-context("cloudsearch")
-
 svc <- paws::cloudsearch()
 
 test_that("describe_domains", {

--- a/cran/paws.analytics/tests/testthat/test_cloudsearchdomain.R
+++ b/cran/paws.analytics/tests/testthat/test_cloudsearchdomain.R
@@ -1,5 +1,3 @@
-context("cloudsearchdomain")
-
 svc <- paws::cloudsearchdomain()
 
 

--- a/cran/paws.analytics/tests/testthat/test_datapipeline.R
+++ b/cran/paws.analytics/tests/testthat/test_datapipeline.R
@@ -1,5 +1,3 @@
-context("datapipeline")
-
 svc <- paws::datapipeline()
 
 test_that("list_pipelines", {

--- a/cran/paws.analytics/tests/testthat/test_elasticsearchservice.R
+++ b/cran/paws.analytics/tests/testthat/test_elasticsearchservice.R
@@ -1,5 +1,3 @@
-context("elasticsearchservice")
-
 svc <- paws::elasticsearchservice()
 
 test_that("describe_inbound_cross_cluster_search_connections", {

--- a/cran/paws.analytics/tests/testthat/test_emr.R
+++ b/cran/paws.analytics/tests/testthat/test_emr.R
@@ -1,5 +1,3 @@
-context("emr")
-
 svc <- paws::emr()
 
 test_that("list_clusters", {

--- a/cran/paws.analytics/tests/testthat/test_firehose.R
+++ b/cran/paws.analytics/tests/testthat/test_firehose.R
@@ -1,5 +1,3 @@
-context("firehose")
-
 svc <- paws::firehose()
 
 test_that("list_delivery_streams", {

--- a/cran/paws.analytics/tests/testthat/test_glue.R
+++ b/cran/paws.analytics/tests/testthat/test_glue.R
@@ -1,5 +1,3 @@
-context("glue")
-
 svc <- paws::glue()
 
 test_that("list_crawlers", {

--- a/cran/paws.analytics/tests/testthat/test_kafka.R
+++ b/cran/paws.analytics/tests/testthat/test_kafka.R
@@ -1,5 +1,3 @@
-context("kafka")
-
 svc <- paws::kafka()
 
 test_that("list_clusters", {

--- a/cran/paws.analytics/tests/testthat/test_kinesis.R
+++ b/cran/paws.analytics/tests/testthat/test_kinesis.R
@@ -1,5 +1,3 @@
-context("kinesis")
-
 svc <- paws::kinesis()
 
 test_that("describe_limits", {

--- a/cran/paws.analytics/tests/testthat/test_kinesisanalytics.R
+++ b/cran/paws.analytics/tests/testthat/test_kinesisanalytics.R
@@ -1,5 +1,3 @@
-context("kinesisanalytics")
-
 svc <- paws::kinesisanalytics()
 
 test_that("list_applications", {

--- a/cran/paws.analytics/tests/testthat/test_kinesisanalyticsv2.R
+++ b/cran/paws.analytics/tests/testthat/test_kinesisanalyticsv2.R
@@ -1,5 +1,3 @@
-context("kinesisanalyticsv2")
-
 svc <- paws::kinesisanalyticsv2()
 
 

--- a/cran/paws.analytics/tests/testthat/test_mturk.R
+++ b/cran/paws.analytics/tests/testthat/test_mturk.R
@@ -1,5 +1,3 @@
-context("mturk")
-
 svc <- paws::mturk()
 
 

--- a/cran/paws.analytics/tests/testthat/test_quicksight.R
+++ b/cran/paws.analytics/tests/testthat/test_quicksight.R
@@ -1,5 +1,3 @@
-context("quicksight")
-
 svc <- paws::quicksight()
 
 

--- a/cran/paws.application.integration/R/eventbridge_service.R
+++ b/cran/paws.application.integration/R/eventbridge_service.R
@@ -116,7 +116,7 @@ eventbridge <- function(config = list()) {
 
 .eventbridge$metadata <- list(
   service_name = "eventbridge",
-  endpoints = list("*" = list(endpoint = "eventbridge.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "eventbridge.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "eventbridge.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "eventbridge.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "events.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "events.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "events.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "events.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "EventBridge",
   api_version = "2015-10-07",
   signing_name = NULL,

--- a/cran/paws.application.integration/tests/testthat/test_eventbridge.R
+++ b/cran/paws.application.integration/tests/testthat/test_eventbridge.R
@@ -1,5 +1,3 @@
-context("eventbridge")
-
 svc <- paws::eventbridge()
 
 test_that("describe_event_bus", {

--- a/cran/paws.application.integration/tests/testthat/test_mq.R
+++ b/cran/paws.application.integration/tests/testthat/test_mq.R
@@ -1,5 +1,3 @@
-context("mq")
-
 svc <- paws::mq()
 
 test_that("describe_broker_engine_types", {

--- a/cran/paws.application.integration/tests/testthat/test_sfn.R
+++ b/cran/paws.application.integration/tests/testthat/test_sfn.R
@@ -1,5 +1,3 @@
-context("sfn")
-
 svc <- paws::sfn()
 
 test_that("list_activities", {

--- a/cran/paws.application.integration/tests/testthat/test_sns.R
+++ b/cran/paws.application.integration/tests/testthat/test_sns.R
@@ -1,5 +1,3 @@
-context("sns")
-
 svc <- paws::sns()
 
 test_that("list_phone_numbers_opted_out", {

--- a/cran/paws.application.integration/tests/testthat/test_sqs.R
+++ b/cran/paws.application.integration/tests/testthat/test_sqs.R
@@ -1,5 +1,3 @@
-context("sqs")
-
 svc <- paws::sqs()
 
 test_that("list_queues", {

--- a/cran/paws.application.integration/tests/testthat/test_swf.R
+++ b/cran/paws.application.integration/tests/testthat/test_swf.R
@@ -1,5 +1,3 @@
-context("swf")
-
 svc <- paws::swf()
 
 

--- a/cran/paws.business.applications/tests/testthat/test_alexaforbusiness.R
+++ b/cran/paws.business.applications/tests/testthat/test_alexaforbusiness.R
@@ -1,5 +1,3 @@
-context("alexaforbusiness")
-
 svc <- paws::alexaforbusiness()
 
 test_that("list_business_report_schedules", {

--- a/cran/paws.business.applications/tests/testthat/test_chime.R
+++ b/cran/paws.business.applications/tests/testthat/test_chime.R
@@ -1,5 +1,3 @@
-context("chime")
-
 svc <- paws::chime()
 
 test_that("list_accounts", {

--- a/cran/paws.business.applications/tests/testthat/test_workmail.R
+++ b/cran/paws.business.applications/tests/testthat/test_workmail.R
@@ -1,5 +1,3 @@
-context("workmail")
-
 svc <- paws::workmail()
 
 test_that("list_organizations", {

--- a/cran/paws.compute/R/ec2_operations.R
+++ b/cran/paws.compute/R/ec2_operations.R
@@ -10328,7 +10328,7 @@ ec2_create_vpc <- function(CidrBlock, AmazonProvidedIpv6CidrBlock = NULL, Ipv6Po
 #' to create a private connection between your VPC and the service. The
 #' service may be provided by AWS, an AWS Marketplace Partner, or another
 #' AWS account. For more information, see [VPC
-#' Endpoints](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints.html)
+#' Endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints.html)
 #' in the *Amazon Virtual Private Cloud User Guide*.
 #' 
 #' A `gateway` endpoint serves as a target for a route in your route table
@@ -10606,13 +10606,13 @@ ec2_create_vpc_endpoint_connection_notification <- function(DryRun = NULL, Servi
 #'     Balancer endpoint.
 #' 
 #' For more information, see [VPC Endpoint
-#' Services](https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-service.html)
+#' Services](https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-service.html)
 #' in the *Amazon Virtual Private Cloud User Guide*.
 #' 
 #' If you set the private DNS name, you must prove that you own the private
 #' DNS domain name. For more information, see [VPC Endpoint Service Private
 #' DNS Name
-#' Verification](https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-services-dns-validation.html)
+#' Verification](https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-services-dns-validation.html)
 #' in the *Amazon Virtual Private Cloud User Guide*.
 #'
 #' @usage
@@ -38612,7 +38612,7 @@ ec2_modify_vpc_attribute <- function(EnableDnsHostnames = NULL, EnableDnsSupport
 #' Modifies attributes of a specified VPC endpoint. The attributes that you
 #' can modify depend on the type of VPC endpoint (interface, gateway, or
 #' Gateway Load Balancer). For more information, see [VPC
-#' Endpoints](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints.html)
+#' Endpoints](https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints.html)
 #' in the *Amazon Virtual Private Cloud User Guide*.
 #'
 #' @usage
@@ -38776,7 +38776,7 @@ ec2_modify_vpc_endpoint_connection_notification <- function(DryRun = NULL, Conne
 #' If you set or modify the private DNS name, you must prove that you own
 #' the private DNS domain name. For more information, see [VPC Endpoint
 #' Service Private DNS Name
-#' Verification](https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-services-dns-validation.html)
+#' Verification](https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-services-dns-validation.html)
 #' in the *Amazon Virtual Private Cloud User Guide*.
 #'
 #' @usage
@@ -38860,7 +38860,7 @@ ec2_modify_vpc_endpoint_service_configuration <- function(DryRun = NULL, Service
 #'
 #' @description
 #' Modifies the permissions for your [VPC endpoint
-#' service](https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-service.html).
+#' service](https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-service.html).
 #' You can add or remove permissions for service consumers (IAM users, IAM
 #' roles, and AWS accounts) to connect to your endpoint service.
 #' 
@@ -45437,7 +45437,7 @@ ec2_start_network_insights_analysis <- function(NetworkInsightsPathId, FilterInA
 #' Before the service provider runs this command, they must add a record to
 #' the DNS server. For more information, see [Adding a TXT Record to Your
 #' Domain's DNS
-#' Server](https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-services-dns-validation.html#add-dns-txt-record)
+#' Server](https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-services-dns-validation.html#add-dns-txt-record)
 #' in the *Amazon VPC User Guide*.
 #'
 #' @usage

--- a/cran/paws.compute/R/ec2instanceconnect_service.R
+++ b/cran/paws.compute/R/ec2instanceconnect_service.R
@@ -65,7 +65,7 @@ ec2instanceconnect <- function(config = list()) {
 
 .ec2instanceconnect$metadata <- list(
   service_name = "ec2instanceconnect",
-  endpoints = list("*" = list(endpoint = "ec2instanceconnect.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "ec2instanceconnect.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "ec2instanceconnect.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "ec2instanceconnect.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "ec2-instance-connect.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "ec2-instance-connect.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "ec2-instance-connect.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "ec2-instance-connect.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "EC2 Instance Connect",
   api_version = "2018-04-02",
   signing_name = NULL,

--- a/cran/paws.compute/R/ecr_service.R
+++ b/cran/paws.compute/R/ecr_service.R
@@ -105,7 +105,7 @@ ecr <- function(config = list()) {
 
 .ecr$metadata <- list(
   service_name = "ecr",
-  endpoints = list("*" = list(endpoint = "ecr.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "ecr.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "ecr.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "ecr.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "api.ecr.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "api.ecr.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "api.ecr.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "api.ecr.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "ECR",
   api_version = "2015-09-21",
   signing_name = "ecr",

--- a/cran/paws.compute/man/ec2_create_vpc_endpoint.Rd
+++ b/cran/paws.compute/man/ec2_create_vpc_endpoint.Rd
@@ -114,7 +114,7 @@ A list with the following syntax:\preformatted{list(
 Creates a VPC endpoint for a specified service. An endpoint enables you
 to create a private connection between your VPC and the service. The
 service may be provided by AWS, an AWS Marketplace Partner, or another
-AWS account. For more information, see \href{https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints.html}{VPC Endpoints}
+AWS account. For more information, see \href{https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints.html}{VPC Endpoints}
 in the \emph{Amazon Virtual Private Cloud User Guide}.
 
 A \code{gateway} endpoint serves as a target for a route in your route table

--- a/cran/paws.compute/man/ec2_create_vpc_endpoint_service_configuration.Rd
+++ b/cran/paws.compute/man/ec2_create_vpc_endpoint_service_configuration.Rd
@@ -90,11 +90,11 @@ Service consumers connect to your service using a Gateway Load
 Balancer endpoint.
 }
 
-For more information, see \href{https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-service.html}{VPC Endpoint Services}
+For more information, see \href{https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-service.html}{VPC Endpoint Services}
 in the \emph{Amazon Virtual Private Cloud User Guide}.
 
 If you set the private DNS name, you must prove that you own the private
-DNS domain name. For more information, see \href{https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-services-dns-validation.html}{VPC Endpoint Service Private DNS Name Verification}
+DNS domain name. For more information, see \href{https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-services-dns-validation.html}{VPC Endpoint Service Private DNS Name Verification}
 in the \emph{Amazon Virtual Private Cloud User Guide}.
 }
 \section{Request syntax}{

--- a/cran/paws.compute/man/ec2_modify_vpc_endpoint.Rd
+++ b/cran/paws.compute/man/ec2_modify_vpc_endpoint.Rd
@@ -55,7 +55,7 @@ A list with the following syntax:\preformatted{list(
 \description{
 Modifies attributes of a specified VPC endpoint. The attributes that you
 can modify depend on the type of VPC endpoint (interface, gateway, or
-Gateway Load Balancer). For more information, see \href{https://docs.aws.amazon.com/vpc/latest/userguide/vpc-endpoints.html}{VPC Endpoints}
+Gateway Load Balancer). For more information, see \href{https://docs.aws.amazon.com/vpc/latest/privatelink/vpc-endpoints.html}{VPC Endpoints}
 in the \emph{Amazon Virtual Private Cloud User Guide}.
 }
 \section{Request syntax}{

--- a/cran/paws.compute/man/ec2_modify_vpc_endpoint_service_configuration.Rd
+++ b/cran/paws.compute/man/ec2_modify_vpc_endpoint_service_configuration.Rd
@@ -51,7 +51,7 @@ service, and you can specify whether acceptance is required for requests
 to connect to your endpoint service through an interface VPC endpoint.
 
 If you set or modify the private DNS name, you must prove that you own
-the private DNS domain name. For more information, see \href{https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-services-dns-validation.html}{VPC Endpoint Service Private DNS Name Verification}
+the private DNS domain name. For more information, see \href{https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-services-dns-validation.html}{VPC Endpoint Service Private DNS Name Verification}
 in the \emph{Amazon Virtual Private Cloud User Guide}.
 }
 \section{Request syntax}{

--- a/cran/paws.compute/man/ec2_modify_vpc_endpoint_service_permissions.Rd
+++ b/cran/paws.compute/man/ec2_modify_vpc_endpoint_service_permissions.Rd
@@ -29,7 +29,7 @@ A list with the following syntax:\preformatted{list(
 }
 }
 \description{
-Modifies the permissions for your \href{https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-service.html}{VPC endpoint service}.
+Modifies the permissions for your \href{https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-service.html}{VPC endpoint service}.
 You can add or remove permissions for service consumers (IAM users, IAM
 roles, and AWS accounts) to connect to your endpoint service.
 

--- a/cran/paws.compute/man/ec2_start_vpc_endpoint_service_private_dns_verification.Rd
+++ b/cran/paws.compute/man/ec2_start_vpc_endpoint_service_private_dns_verification.Rd
@@ -30,7 +30,7 @@ The service provider must successfully perform the verification before
 the consumer can use the name to access the service.
 
 Before the service provider runs this command, they must add a record to
-the DNS server. For more information, see \href{https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-services-dns-validation.html#add-dns-txt-record}{Adding a TXT Record to Your Domain's DNS Server}
+the DNS server. For more information, see \href{https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-services-dns-validation.html#add-dns-txt-record}{Adding a TXT Record to Your Domain's DNS Server}
 in the \emph{Amazon VPC User Guide}.
 }
 \section{Request syntax}{

--- a/cran/paws.compute/tests/testthat/test_batch.R
+++ b/cran/paws.compute/tests/testthat/test_batch.R
@@ -1,5 +1,3 @@
-context("batch")
-
 svc <- paws::batch()
 
 test_that("describe_compute_environments", {

--- a/cran/paws.compute/tests/testthat/test_ec2.R
+++ b/cran/paws.compute/tests/testthat/test_ec2.R
@@ -1,5 +1,3 @@
-context("ec2")
-
 svc <- paws::ec2()
 
 test_that("describe_account_attributes", {

--- a/cran/paws.compute/tests/testthat/test_ec2instanceconnect.R
+++ b/cran/paws.compute/tests/testthat/test_ec2instanceconnect.R
@@ -1,5 +1,3 @@
-context("ec2instanceconnect")
-
 svc <- paws::ec2instanceconnect()
 
 

--- a/cran/paws.compute/tests/testthat/test_ecr.R
+++ b/cran/paws.compute/tests/testthat/test_ecr.R
@@ -1,5 +1,3 @@
-context("ecr")
-
 svc <- paws::ecr()
 
 test_that("describe_registry", {

--- a/cran/paws.compute/tests/testthat/test_ecs.R
+++ b/cran/paws.compute/tests/testthat/test_ecs.R
@@ -1,5 +1,3 @@
-context("ecs")
-
 svc <- paws::ecs()
 
 test_that("describe_capacity_providers", {

--- a/cran/paws.compute/tests/testthat/test_eks.R
+++ b/cran/paws.compute/tests/testthat/test_eks.R
@@ -1,5 +1,3 @@
-context("eks")
-
 svc <- paws::eks()
 
 test_that("describe_addon_versions", {

--- a/cran/paws.compute/tests/testthat/test_elasticbeanstalk.R
+++ b/cran/paws.compute/tests/testthat/test_elasticbeanstalk.R
@@ -1,5 +1,3 @@
-context("elasticbeanstalk")
-
 svc <- paws::elasticbeanstalk()
 
 test_that("describe_account_attributes", {

--- a/cran/paws.compute/tests/testthat/test_lambda.R
+++ b/cran/paws.compute/tests/testthat/test_lambda.R
@@ -1,5 +1,3 @@
-context("lambda")
-
 svc <- paws::lambda()
 
 test_that("list_code_signing_configs", {

--- a/cran/paws.compute/tests/testthat/test_lightsail.R
+++ b/cran/paws.compute/tests/testthat/test_lightsail.R
@@ -1,5 +1,3 @@
-context("lightsail")
-
 svc <- paws::lightsail()
 
 

--- a/cran/paws.compute/tests/testthat/test_serverlessapplicationrepository.R
+++ b/cran/paws.compute/tests/testthat/test_serverlessapplicationrepository.R
@@ -1,5 +1,3 @@
-context("serverlessapplicationrepository")
-
 svc <- paws::serverlessapplicationrepository()
 
 test_that("list_applications", {

--- a/cran/paws.cost.management/tests/testthat/test_budgets.R
+++ b/cran/paws.cost.management/tests/testthat/test_budgets.R
@@ -1,5 +1,3 @@
-context("budgets")
-
 svc <- paws::budgets()
 
 

--- a/cran/paws.cost.management/tests/testthat/test_costandusagereportservice.R
+++ b/cran/paws.cost.management/tests/testthat/test_costandusagereportservice.R
@@ -1,5 +1,3 @@
-context("costandusagereportservice")
-
 svc <- paws::costandusagereportservice()
 
 

--- a/cran/paws.cost.management/tests/testthat/test_costexplorer.R
+++ b/cran/paws.cost.management/tests/testthat/test_costexplorer.R
@@ -1,5 +1,3 @@
-context("costexplorer")
-
 svc <- paws::costexplorer()
 
 test_that("list_cost_category_definitions", {

--- a/cran/paws.cost.management/tests/testthat/test_marketplacecommerceanalytics.R
+++ b/cran/paws.cost.management/tests/testthat/test_marketplacecommerceanalytics.R
@@ -1,5 +1,3 @@
-context("marketplacecommerceanalytics")
-
 svc <- paws::marketplacecommerceanalytics()
 
 

--- a/cran/paws.cost.management/tests/testthat/test_marketplaceentitlementservice.R
+++ b/cran/paws.cost.management/tests/testthat/test_marketplaceentitlementservice.R
@@ -1,5 +1,3 @@
-context("marketplaceentitlementservice")
-
 svc <- paws::marketplaceentitlementservice()
 
 

--- a/cran/paws.cost.management/tests/testthat/test_marketplacemetering.R
+++ b/cran/paws.cost.management/tests/testthat/test_marketplacemetering.R
@@ -1,5 +1,3 @@
-context("marketplacemetering")
-
 svc <- paws::marketplacemetering()
 
 

--- a/cran/paws.cost.management/tests/testthat/test_pricing.R
+++ b/cran/paws.cost.management/tests/testthat/test_pricing.R
@@ -1,5 +1,3 @@
-context("pricing")
-
 svc <- paws::pricing()
 
 test_that("describe_services", {

--- a/cran/paws.customer.engagement/R/pinpointemail_service.R
+++ b/cran/paws.customer.engagement/R/pinpointemail_service.R
@@ -136,7 +136,7 @@ pinpointemail <- function(config = list()) {
 
 .pinpointemail$metadata <- list(
   service_name = "pinpointemail",
-  endpoints = list("*" = list(endpoint = "pinpointemail.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "pinpointemail.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "pinpointemail.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "pinpointemail.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "email.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "email.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "email.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "email.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "Pinpoint Email",
   api_version = "2018-07-26",
   signing_name = "ses",

--- a/cran/paws.customer.engagement/R/pinpointsmsvoice_service.R
+++ b/cran/paws.customer.engagement/R/pinpointsmsvoice_service.R
@@ -64,7 +64,7 @@ pinpointsmsvoice <- function(config = list()) {
 
 .pinpointsmsvoice$metadata <- list(
   service_name = "pinpointsmsvoice",
-  endpoints = list("*" = list(endpoint = "pinpointsmsvoice.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "pinpointsmsvoice.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "pinpointsmsvoice.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "pinpointsmsvoice.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "sms-voice.pinpoint.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "sms-voice.pinpoint.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "sms-voice.pinpoint.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "sms-voice.pinpoint.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "Pinpoint SMS Voice",
   api_version = "2018-09-05",
   signing_name = "sms-voice",

--- a/cran/paws.customer.engagement/tests/testthat/test_connect.R
+++ b/cran/paws.customer.engagement/tests/testthat/test_connect.R
@@ -1,5 +1,3 @@
-context("connect")
-
 svc <- paws::connect()
 
 test_that("list_instances", {

--- a/cran/paws.customer.engagement/tests/testthat/test_pinpoint.R
+++ b/cran/paws.customer.engagement/tests/testthat/test_pinpoint.R
@@ -1,5 +1,3 @@
-context("pinpoint")
-
 svc <- paws::pinpoint()
 
 test_that("list_templates", {

--- a/cran/paws.customer.engagement/tests/testthat/test_pinpointemail.R
+++ b/cran/paws.customer.engagement/tests/testthat/test_pinpointemail.R
@@ -1,5 +1,3 @@
-context("pinpointemail")
-
 svc <- paws::pinpointemail()
 
 

--- a/cran/paws.customer.engagement/tests/testthat/test_pinpointsmsvoice.R
+++ b/cran/paws.customer.engagement/tests/testthat/test_pinpointsmsvoice.R
@@ -1,5 +1,3 @@
-context("pinpointsmsvoice")
-
 svc <- paws::pinpointsmsvoice()
 
 

--- a/cran/paws.customer.engagement/tests/testthat/test_ses.R
+++ b/cran/paws.customer.engagement/tests/testthat/test_ses.R
@@ -1,5 +1,3 @@
-context("ses")
-
 svc <- paws::ses()
 
 test_that("describe_active_receipt_rule_set", {

--- a/cran/paws.database/R/rdsdataservice_service.R
+++ b/cran/paws.database/R/rdsdataservice_service.R
@@ -74,7 +74,7 @@ rdsdataservice <- function(config = list()) {
 
 .rdsdataservice$metadata <- list(
   service_name = "rdsdataservice",
-  endpoints = list("*" = list(endpoint = "rdsdataservice.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "rdsdataservice.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "rdsdataservice.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "rdsdataservice.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "rds-data.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "rds-data.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "rds-data.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "rds-data.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "RDS Data",
   api_version = "2018-08-01",
   signing_name = "rds-data",

--- a/cran/paws.database/tests/testthat/test_dax.R
+++ b/cran/paws.database/tests/testthat/test_dax.R
@@ -1,5 +1,3 @@
-context("dax")
-
 svc <- paws::dax()
 
 test_that("describe_clusters", {

--- a/cran/paws.database/tests/testthat/test_docdb.R
+++ b/cran/paws.database/tests/testthat/test_docdb.R
@@ -1,5 +1,3 @@
-context("docdb")
-
 svc <- paws::docdb()
 
 test_that("describe_certificates", {

--- a/cran/paws.database/tests/testthat/test_dynamodb.R
+++ b/cran/paws.database/tests/testthat/test_dynamodb.R
@@ -1,5 +1,3 @@
-context("dynamodb")
-
 svc <- paws::dynamodb()
 
 test_that("describe_endpoints", {

--- a/cran/paws.database/tests/testthat/test_dynamodbstreams.R
+++ b/cran/paws.database/tests/testthat/test_dynamodbstreams.R
@@ -1,5 +1,3 @@
-context("dynamodbstreams")
-
 svc <- paws::dynamodbstreams()
 
 test_that("list_streams", {

--- a/cran/paws.database/tests/testthat/test_elasticache.R
+++ b/cran/paws.database/tests/testthat/test_elasticache.R
@@ -1,5 +1,3 @@
-context("elasticache")
-
 svc <- paws::elasticache()
 
 test_that("describe_cache_clusters", {

--- a/cran/paws.database/tests/testthat/test_neptune.R
+++ b/cran/paws.database/tests/testthat/test_neptune.R
@@ -1,5 +1,3 @@
-context("neptune")
-
 svc <- paws::neptune()
 
 test_that("describe_db_cluster_endpoints", {

--- a/cran/paws.database/tests/testthat/test_rds.R
+++ b/cran/paws.database/tests/testthat/test_rds.R
@@ -1,5 +1,3 @@
-context("rds")
-
 svc <- paws::rds()
 
 test_that("describe_account_attributes", {

--- a/cran/paws.database/tests/testthat/test_rdsdataservice.R
+++ b/cran/paws.database/tests/testthat/test_rdsdataservice.R
@@ -1,5 +1,3 @@
-context("rdsdataservice")
-
 svc <- paws::rdsdataservice()
 
 

--- a/cran/paws.database/tests/testthat/test_redshift.R
+++ b/cran/paws.database/tests/testthat/test_redshift.R
@@ -1,5 +1,3 @@
-context("redshift")
-
 svc <- paws::redshift()
 
 test_that("describe_account_attributes", {

--- a/cran/paws.database/tests/testthat/test_simpledb.R
+++ b/cran/paws.database/tests/testthat/test_simpledb.R
@@ -1,5 +1,3 @@
-context("simpledb")
-
 svc <- paws::simpledb()
 
 test_that("list_domains", {

--- a/cran/paws.developer.tools/tests/testthat/test_cloud9.R
+++ b/cran/paws.developer.tools/tests/testthat/test_cloud9.R
@@ -1,5 +1,3 @@
-context("cloud9")
-
 svc <- paws::cloud9()
 
 test_that("describe_environment_memberships", {

--- a/cran/paws.developer.tools/tests/testthat/test_codebuild.R
+++ b/cran/paws.developer.tools/tests/testthat/test_codebuild.R
@@ -1,5 +1,3 @@
-context("codebuild")
-
 svc <- paws::codebuild()
 
 test_that("list_build_batches", {

--- a/cran/paws.developer.tools/tests/testthat/test_codecommit.R
+++ b/cran/paws.developer.tools/tests/testthat/test_codecommit.R
@@ -1,5 +1,3 @@
-context("codecommit")
-
 svc <- paws::codecommit()
 
 test_that("list_approval_rule_templates", {

--- a/cran/paws.developer.tools/tests/testthat/test_codedeploy.R
+++ b/cran/paws.developer.tools/tests/testthat/test_codedeploy.R
@@ -1,5 +1,3 @@
-context("codedeploy")
-
 svc <- paws::codedeploy()
 
 test_that("list_applications", {

--- a/cran/paws.developer.tools/tests/testthat/test_codepipeline.R
+++ b/cran/paws.developer.tools/tests/testthat/test_codepipeline.R
@@ -1,5 +1,3 @@
-context("codepipeline")
-
 svc <- paws::codepipeline()
 
 test_that("list_action_types", {

--- a/cran/paws.developer.tools/tests/testthat/test_codestar.R
+++ b/cran/paws.developer.tools/tests/testthat/test_codestar.R
@@ -1,5 +1,3 @@
-context("codestar")
-
 svc <- paws::codestar()
 
 test_that("list_projects", {

--- a/cran/paws.developer.tools/tests/testthat/test_xray.R
+++ b/cran/paws.developer.tools/tests/testthat/test_xray.R
@@ -1,5 +1,3 @@
-context("xray")
-
 svc <- paws::xray()
 
 

--- a/cran/paws.end.user.computing/tests/testthat/test_appstream.R
+++ b/cran/paws.end.user.computing/tests/testthat/test_appstream.R
@@ -1,5 +1,3 @@
-context("appstream")
-
 svc <- paws::appstream()
 
 test_that("describe_directory_configs", {

--- a/cran/paws.end.user.computing/tests/testthat/test_workdocs.R
+++ b/cran/paws.end.user.computing/tests/testthat/test_workdocs.R
@@ -1,5 +1,3 @@
-context("workdocs")
-
 svc <- paws::workdocs()
 
 

--- a/cran/paws.end.user.computing/tests/testthat/test_worklink.R
+++ b/cran/paws.end.user.computing/tests/testthat/test_worklink.R
@@ -1,5 +1,3 @@
-context("worklink")
-
 svc <- paws::worklink()
 
 test_that("list_fleets", {

--- a/cran/paws.end.user.computing/tests/testthat/test_workspaces.R
+++ b/cran/paws.end.user.computing/tests/testthat/test_workspaces.R
@@ -1,5 +1,3 @@
-context("workspaces")
-
 svc <- paws::workspaces()
 
 

--- a/cran/paws.game.development/tests/testthat/test_gamelift.R
+++ b/cran/paws.game.development/tests/testthat/test_gamelift.R
@@ -1,5 +1,3 @@
-context("gamelift")
-
 svc <- paws::gamelift()
 
 test_that("describe_ec2_instance_limits", {

--- a/cran/paws.internet.of.things/tests/testthat/test_greengrass.R
+++ b/cran/paws.internet.of.things/tests/testthat/test_greengrass.R
@@ -1,5 +1,3 @@
-context("greengrass")
-
 svc <- paws::greengrass()
 
 test_that("list_bulk_deployments", {

--- a/cran/paws.internet.of.things/tests/testthat/test_iot.R
+++ b/cran/paws.internet.of.things/tests/testthat/test_iot.R
@@ -1,5 +1,3 @@
-context("iot")
-
 svc <- paws::iot()
 
 test_that("describe_account_audit_configuration", {

--- a/cran/paws.internet.of.things/tests/testthat/test_iot1clickdevicesservice.R
+++ b/cran/paws.internet.of.things/tests/testthat/test_iot1clickdevicesservice.R
@@ -1,5 +1,3 @@
-context("iot1clickdevicesservice")
-
 svc <- paws::iot1clickdevicesservice()
 
 

--- a/cran/paws.internet.of.things/tests/testthat/test_iot1clickprojects.R
+++ b/cran/paws.internet.of.things/tests/testthat/test_iot1clickprojects.R
@@ -1,5 +1,3 @@
-context("iot1clickprojects")
-
 svc <- paws::iot1clickprojects()
 
 test_that("list_projects", {

--- a/cran/paws.internet.of.things/tests/testthat/test_iotanalytics.R
+++ b/cran/paws.internet.of.things/tests/testthat/test_iotanalytics.R
@@ -1,5 +1,3 @@
-context("iotanalytics")
-
 svc <- paws::iotanalytics()
 
 test_that("list_channels", {

--- a/cran/paws.internet.of.things/tests/testthat/test_iotdataplane.R
+++ b/cran/paws.internet.of.things/tests/testthat/test_iotdataplane.R
@@ -1,5 +1,3 @@
-context("iotdataplane")
-
 svc <- paws::iotdataplane()
 
 

--- a/cran/paws.internet.of.things/tests/testthat/test_iotjobsdataplane.R
+++ b/cran/paws.internet.of.things/tests/testthat/test_iotjobsdataplane.R
@@ -1,5 +1,3 @@
-context("iotjobsdataplane")
-
 svc <- paws::iotjobsdataplane()
 
 

--- a/cran/paws.internet.of.things/tests/testthat/test_signer.R
+++ b/cran/paws.internet.of.things/tests/testthat/test_signer.R
@@ -1,5 +1,3 @@
-context("signer")
-
 svc <- paws::signer()
 
 test_that("list_signing_jobs", {

--- a/cran/paws.machine.learning/R/personalizeevents_service.R
+++ b/cran/paws.machine.learning/R/personalizeevents_service.R
@@ -62,7 +62,7 @@ personalizeevents <- function(config = list()) {
 
 .personalizeevents$metadata <- list(
   service_name = "personalizeevents",
-  endpoints = list("*" = list(endpoint = "personalizeevents.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "personalizeevents.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "personalizeevents.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "personalizeevents.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "personalize-events.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "personalize-events.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "personalize-events.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "personalize-events.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "Personalize Events",
   api_version = "2018-03-22",
   signing_name = "personalize",

--- a/cran/paws.machine.learning/R/personalizeruntime_service.R
+++ b/cran/paws.machine.learning/R/personalizeruntime_service.R
@@ -57,7 +57,7 @@ personalizeruntime <- function(config = list()) {
 
 .personalizeruntime$metadata <- list(
   service_name = "personalizeruntime",
-  endpoints = list("*" = list(endpoint = "personalizeruntime.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "personalizeruntime.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "personalizeruntime.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "personalizeruntime.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "personalize-runtime.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "personalize-runtime.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "personalize-runtime.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "personalize-runtime.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "Personalize Runtime",
   api_version = "2018-05-22",
   signing_name = "personalize",

--- a/cran/paws.machine.learning/R/sagemaker_service.R
+++ b/cran/paws.machine.learning/R/sagemaker_service.R
@@ -297,7 +297,7 @@ sagemaker <- function(config = list()) {
 
 .sagemaker$metadata <- list(
   service_name = "sagemaker",
-  endpoints = list("*" = list(endpoint = "sagemaker.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "sagemaker.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "sagemaker.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "sagemaker.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "api.sagemaker.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "api.sagemaker.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "api.sagemaker.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "api.sagemaker.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "SageMaker",
   api_version = "2017-07-24",
   signing_name = "sagemaker",

--- a/cran/paws.machine.learning/tests/testthat/test_comprehend.R
+++ b/cran/paws.machine.learning/tests/testthat/test_comprehend.R
@@ -1,5 +1,3 @@
-context("comprehend")
-
 svc <- paws::comprehend()
 
 test_that("list_document_classification_jobs", {

--- a/cran/paws.machine.learning/tests/testthat/test_comprehendmedical.R
+++ b/cran/paws.machine.learning/tests/testthat/test_comprehendmedical.R
@@ -1,5 +1,3 @@
-context("comprehendmedical")
-
 svc <- paws::comprehendmedical()
 
 test_that("list_entities_detection_v2_jobs", {

--- a/cran/paws.machine.learning/tests/testthat/test_lexmodelbuildingservice.R
+++ b/cran/paws.machine.learning/tests/testthat/test_lexmodelbuildingservice.R
@@ -1,5 +1,3 @@
-context("lexmodelbuildingservice")
-
 svc <- paws::lexmodelbuildingservice()
 
 

--- a/cran/paws.machine.learning/tests/testthat/test_lexruntimeservice.R
+++ b/cran/paws.machine.learning/tests/testthat/test_lexruntimeservice.R
@@ -1,5 +1,3 @@
-context("lexruntimeservice")
-
 svc <- paws::lexruntimeservice()
 
 

--- a/cran/paws.machine.learning/tests/testthat/test_machinelearning.R
+++ b/cran/paws.machine.learning/tests/testthat/test_machinelearning.R
@@ -1,5 +1,3 @@
-context("machinelearning")
-
 svc <- paws::machinelearning()
 
 

--- a/cran/paws.machine.learning/tests/testthat/test_personalize.R
+++ b/cran/paws.machine.learning/tests/testthat/test_personalize.R
@@ -1,5 +1,3 @@
-context("personalize")
-
 svc <- paws::personalize()
 
 test_that("list_batch_inference_jobs", {

--- a/cran/paws.machine.learning/tests/testthat/test_personalizeevents.R
+++ b/cran/paws.machine.learning/tests/testthat/test_personalizeevents.R
@@ -1,5 +1,3 @@
-context("personalizeevents")
-
 svc <- paws::personalizeevents()
 
 

--- a/cran/paws.machine.learning/tests/testthat/test_personalizeruntime.R
+++ b/cran/paws.machine.learning/tests/testthat/test_personalizeruntime.R
@@ -1,5 +1,3 @@
-context("personalizeruntime")
-
 svc <- paws::personalizeruntime()
 
 

--- a/cran/paws.machine.learning/tests/testthat/test_polly.R
+++ b/cran/paws.machine.learning/tests/testthat/test_polly.R
@@ -1,5 +1,3 @@
-context("polly")
-
 svc <- paws::polly()
 
 test_that("describe_voices", {

--- a/cran/paws.machine.learning/tests/testthat/test_rekognition.R
+++ b/cran/paws.machine.learning/tests/testthat/test_rekognition.R
@@ -1,5 +1,3 @@
-context("rekognition")
-
 svc <- paws::rekognition()
 
 test_that("describe_projects", {

--- a/cran/paws.machine.learning/tests/testthat/test_sagemaker.R
+++ b/cran/paws.machine.learning/tests/testthat/test_sagemaker.R
@@ -1,5 +1,3 @@
-context("sagemaker")
-
 svc <- paws::sagemaker()
 
 test_that("list_actions", {

--- a/cran/paws.machine.learning/tests/testthat/test_sagemakerruntime.R
+++ b/cran/paws.machine.learning/tests/testthat/test_sagemakerruntime.R
@@ -1,5 +1,3 @@
-context("sagemakerruntime")
-
 svc <- paws::sagemakerruntime()
 
 

--- a/cran/paws.machine.learning/tests/testthat/test_textract.R
+++ b/cran/paws.machine.learning/tests/testthat/test_textract.R
@@ -1,5 +1,3 @@
-context("textract")
-
 svc <- paws::textract()
 
 

--- a/cran/paws.machine.learning/tests/testthat/test_transcribeservice.R
+++ b/cran/paws.machine.learning/tests/testthat/test_transcribeservice.R
@@ -1,5 +1,3 @@
-context("transcribeservice")
-
 svc <- paws::transcribeservice()
 
 test_that("list_language_models", {

--- a/cran/paws.machine.learning/tests/testthat/test_translate.R
+++ b/cran/paws.machine.learning/tests/testthat/test_translate.R
@@ -1,5 +1,3 @@
-context("translate")
-
 svc <- paws::translate()
 
 test_that("list_parallel_data", {

--- a/cran/paws.management/R/applicationautoscaling_service.R
+++ b/cran/paws.management/R/applicationautoscaling_service.R
@@ -127,7 +127,7 @@ applicationautoscaling <- function(config = list()) {
 
 .applicationautoscaling$metadata <- list(
   service_name = "autoscaling",
-  endpoints = list("*" = list(endpoint = "autoscaling.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "autoscaling.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "autoscaling.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "autoscaling.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "application-autoscaling.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "application-autoscaling.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "application-autoscaling.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "application-autoscaling.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "Application Auto Scaling",
   api_version = "2016-02-06",
   signing_name = "application-autoscaling",

--- a/cran/paws.management/R/autoscalingplans_service.R
+++ b/cran/paws.management/R/autoscalingplans_service.R
@@ -90,7 +90,7 @@ autoscalingplans <- function(config = list()) {
 
 .autoscalingplans$metadata <- list(
   service_name = "autoscaling",
-  endpoints = list("*" = list(endpoint = "autoscaling.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "autoscaling.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "autoscaling.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "autoscaling.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "autoscaling-plans.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "autoscaling-plans.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "autoscaling-plans.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "autoscaling-plans.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "Auto Scaling Plans",
   api_version = "2018-01-06",
   signing_name = "autoscaling-plans",

--- a/cran/paws.management/R/cloudformation_operations.R
+++ b/cran/paws.management/R/cloudformation_operations.R
@@ -1990,9 +1990,8 @@ cloudformation_describe_stack_resource <- function(StackName, LogicalResourceId)
 #' resource that has been checked for drift. Resources that have not yet
 #' been checked for drift are not included. Resources that do not currently
 #' support drift detection are not checked, and so not included. For a list
-#' of resources that support drift detection, see [Resources that Support
-#' Drift
-#' Detection](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html).
+#' of resources that support drift detection, see Resources that Support
+#' Drift Detection.
 #' 
 #' Use
 #' [`detect_stack_resource_drift`][cloudformation_detect_stack_resource_drift]
@@ -2118,9 +2117,8 @@ cloudformation_describe_stack_resource_drifts <- function(StackName, StackResour
 #' You must specify either `StackName` or `PhysicalResourceId`, but not
 #' both. In addition, you can specify `LogicalResourceId` to filter the
 #' returned result. For more information about resources, the
-#' `LogicalResourceId` and `PhysicalResourceId`, go to the [AWS
-#' CloudFormation User
-#' Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/).
+#' `LogicalResourceId` and `PhysicalResourceId`, go to the AWS
+#' CloudFormation User Guide.
 #' 
 #' A `ValidationError` is returned if you specify both `StackName` and
 #' `PhysicalResourceId` in the same request.
@@ -2710,8 +2708,7 @@ cloudformation_describe_type_registration <- function(RegistrationToken) {
 #' to detect drift on individual resources.
 #' 
 #' For a list of stack resources that currently support drift detection,
-#' see [Resources that Support Drift
-#' Detection](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html).
+#' see Resources that Support Drift Detection.
 #' 
 #' [`detect_stack_drift`][cloudformation_detect_stack_drift] can take up to
 #' several minutes, depending on the number of resources contained within
@@ -2794,8 +2791,7 @@ cloudformation_detect_stack_drift <- function(StackName, LogicalResourceIds = NU
 #' 
 #' Resources that do not currently support drift detection cannot be
 #' checked. For a list of resources that support drift detection, see
-#' [Resources that Support Drift
-#' Detection](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html).
+#' Resources that Support Drift Detection.
 #'
 #' @usage
 #' cloudformation_detect_stack_resource_drift(StackName, LogicalResourceId)
@@ -2874,8 +2870,8 @@ cloudformation_detect_stack_resource_drift <- function(StackName, LogicalResourc
 #' Detect drift on a stack set. When CloudFormation performs drift
 #' detection on a stack set, it performs drift detection on the stack
 #' associated with each stack instance in the stack set. For more
-#' information, see [How CloudFormation Performs Drift Detection on a Stack
-#' Set](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-drift.html).
+#' information, see How CloudFormation Performs Drift Detection on a Stack
+#' Set.
 #' 
 #' [`detect_stack_set_drift`][cloudformation_detect_stack_set_drift]
 #' returns the `OperationId` of the stack set drift detection operation.

--- a/cran/paws.management/R/licensemanager_service.R
+++ b/cran/paws.management/R/licensemanager_service.R
@@ -97,7 +97,7 @@ licensemanager <- function(config = list()) {
 
 .licensemanager$metadata <- list(
   service_name = "licensemanager",
-  endpoints = list("*" = list(endpoint = "licensemanager.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "licensemanager.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "licensemanager.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "licensemanager.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "license-manager.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "license-manager.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "license-manager.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "license-manager.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "License Manager",
   api_version = "2018-08-01",
   signing_name = NULL,

--- a/cran/paws.management/R/resourcegroupstaggingapi_operations.R
+++ b/cran/paws.management/R/resourcegroupstaggingapi_operations.R
@@ -86,12 +86,15 @@ resourcegroupstaggingapi_describe_report_creation <- function() {
 #' embedded in a resource's Amazon Resource Name (ARN). Consult the *AWS
 #' General Reference* for the following:
 #' 
-#' -   For a list of service name strings, see AWS Service Namespaces.
+#' -   For a list of service name strings, see [AWS Service
+#'     Namespaces](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces).
 #' 
-#' -   For resource type strings, see Example ARNs.
+#' -   For resource type strings, see [Example
+#'     ARNs](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax).
 #' 
-#' -   For more information about ARNs, see Amazon Resource Names (ARNs)
-#'     and AWS Service Namespaces.
+#' -   For more information about ARNs, see [Amazon Resource Names (ARNs)
+#'     and AWS Service
+#'     Namespaces](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
 #' 
 #' You can specify multiple resource types by using an array. The array can
 #' include up to 100 items. Note that the length constraint requirement
@@ -275,12 +278,15 @@ resourcegroupstaggingapi_get_compliance_summary <- function(TargetIdFilters = NU
 #' embedded in a resource's Amazon Resource Name (ARN). Consult the *AWS
 #' General Reference* for the following:
 #' 
-#' -   For a list of service name strings, see AWS Service Namespaces.
+#' -   For a list of service name strings, see [AWS Service
+#'     Namespaces](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces).
 #' 
-#' -   For resource type strings, see Example ARNs.
+#' -   For resource type strings, see [Example
+#'     ARNs](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax).
 #' 
-#' -   For more information about ARNs, see Amazon Resource Names (ARNs)
-#'     and AWS Service Namespaces.
+#' -   For more information about ARNs, see [Amazon Resource Names (ARNs)
+#'     and AWS Service
+#'     Namespaces](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
 #' 
 #' You can specify multiple resource types by using an array. The array can
 #' include up to 100 items. Note that the length constraint requirement
@@ -535,10 +541,13 @@ resourcegroupstaggingapi_start_report_creation <- function(S3Bucket) {
 #' Applies one or more tags to the specified resources. Note the following:
 #' 
 #' -   Not all resources can have tags. For a list of services that support
-#'     tagging, see this list.
+#'     tagging, see [this
+#'     list](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/).
 #' 
-#' -   Each resource can have up to 50 tags. For other limits, see Tag
-#'     Naming and Usage Conventions in the *AWS General Reference.*
+#' -   Each resource can have up to 50 tags. For other limits, see [Tag
+#'     Naming and Usage
+#'     Conventions](https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions)
+#'     in the *AWS General Reference.*
 #' 
 #' -   You can only tag resources that are located in the specified Region
 #'     for the AWS account.

--- a/cran/paws.management/man/cloudformation_describe_stack_resource_drifts.Rd
+++ b/cran/paws.management/man/cloudformation_describe_stack_resource_drifts.Rd
@@ -79,7 +79,8 @@ For a given stack, there will be one \code{StackResourceDrift} for each stack
 resource that has been checked for drift. Resources that have not yet
 been checked for drift are not included. Resources that do not currently
 support drift detection are not checked, and so not included. For a list
-of resources that support drift detection, see \href{https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html}{Resources that Support Drift Detection}.
+of resources that support drift detection, see Resources that Support
+Drift Detection.
 
 Use
 \code{\link[=cloudformation_detect_stack_resource_drift]{detect_stack_resource_drift}}

--- a/cran/paws.management/man/cloudformation_describe_stack_resources.Rd
+++ b/cran/paws.management/man/cloudformation_describe_stack_resources.Rd
@@ -89,7 +89,8 @@ deleted.
 You must specify either \code{StackName} or \code{PhysicalResourceId}, but not
 both. In addition, you can specify \code{LogicalResourceId} to filter the
 returned result. For more information about resources, the
-\code{LogicalResourceId} and \code{PhysicalResourceId}, go to the \href{https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/}{AWS CloudFormation User Guide}.
+\code{LogicalResourceId} and \code{PhysicalResourceId}, go to the AWS
+CloudFormation User Guide.
 
 A \code{ValidationError} is returned if you specify both \code{StackName} and
 \code{PhysicalResourceId} in the same request.

--- a/cran/paws.management/man/cloudformation_detect_stack_drift.Rd
+++ b/cran/paws.management/man/cloudformation_detect_stack_drift.Rd
@@ -36,7 +36,7 @@ drift on all supported resources for a given stack, or
 to detect drift on individual resources.
 
 For a list of stack resources that currently support drift detection,
-see \href{https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html}{Resources that Support Drift Detection}.
+see Resources that Support Drift Detection.
 
 \code{\link[=cloudformation_detect_stack_drift]{detect_stack_drift}} can take up to
 several minutes, depending on the number of resources contained within

--- a/cran/paws.management/man/cloudformation_detect_stack_resource_drift.Rd
+++ b/cran/paws.management/man/cloudformation_detect_stack_resource_drift.Rd
@@ -66,7 +66,7 @@ drift on all resources in a given stack that support drift detection.
 
 Resources that do not currently support drift detection cannot be
 checked. For a list of resources that support drift detection, see
-\href{https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html}{Resources that Support Drift Detection}.
+Resources that Support Drift Detection.
 }
 \section{Request syntax}{
 \preformatted{svc$detect_stack_resource_drift(

--- a/cran/paws.management/man/cloudformation_detect_stack_set_drift.Rd
+++ b/cran/paws.management/man/cloudformation_detect_stack_set_drift.Rd
@@ -25,7 +25,8 @@ A list with the following syntax:\preformatted{list(
 Detect drift on a stack set. When CloudFormation performs drift
 detection on a stack set, it performs drift detection on the stack
 associated with each stack instance in the stack set. For more
-information, see \href{https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-drift.html}{How CloudFormation Performs Drift Detection on a Stack Set}.
+information, see How CloudFormation Performs Drift Detection on a Stack
+Set.
 
 \code{\link[=cloudformation_detect_stack_set_drift]{detect_stack_set_drift}}
 returns the \code{OperationId} of the stack set drift detection operation.

--- a/cran/paws.management/man/resourcegroupstaggingapi_get_compliance_summary.Rd
+++ b/cran/paws.management/man/resourcegroupstaggingapi_get_compliance_summary.Rd
@@ -28,10 +28,9 @@ The string for each service name and resource type is the same as that
 embedded in a resource's Amazon Resource Name (ARN). Consult the \emph{AWS
 General Reference} for the following:
 \itemize{
-\item For a list of service name strings, see AWS Service Namespaces.
-\item For resource type strings, see Example ARNs.
-\item For more information about ARNs, see Amazon Resource Names (ARNs)
-and AWS Service Namespaces.
+\item For a list of service name strings, see \href{https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces}{AWS Service Namespaces}.
+\item For resource type strings, see \href{https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax}{Example ARNs}.
+\item For more information about ARNs, see \href{https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html}{Amazon Resource Names (ARNs) and AWS Service Namespaces}.
 }
 
 You can specify multiple resource types by using an array. The array can

--- a/cran/paws.management/man/resourcegroupstaggingapi_get_resources.Rd
+++ b/cran/paws.management/man/resourcegroupstaggingapi_get_resources.Rd
@@ -87,10 +87,9 @@ The string for each service name and resource type is the same as that
 embedded in a resource's Amazon Resource Name (ARN). Consult the \emph{AWS
 General Reference} for the following:
 \itemize{
-\item For a list of service name strings, see AWS Service Namespaces.
-\item For resource type strings, see Example ARNs.
-\item For more information about ARNs, see Amazon Resource Names (ARNs)
-and AWS Service Namespaces.
+\item For a list of service name strings, see \href{https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces}{AWS Service Namespaces}.
+\item For resource type strings, see \href{https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax}{Example ARNs}.
+\item For more information about ARNs, see \href{https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html}{Amazon Resource Names (ARNs) and AWS Service Namespaces}.
 }
 
 You can specify multiple resource types by using an array. The array can

--- a/cran/paws.management/man/resourcegroupstaggingapi_tag_resources.Rd
+++ b/cran/paws.management/man/resourcegroupstaggingapi_tag_resources.Rd
@@ -30,9 +30,9 @@ A list with the following syntax:\preformatted{list(
 Applies one or more tags to the specified resources. Note the following:
 \itemize{
 \item Not all resources can have tags. For a list of services that support
-tagging, see this list.
-\item Each resource can have up to 50 tags. For other limits, see Tag
-Naming and Usage Conventions in the \emph{AWS General Reference.}
+tagging, see \href{https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/}{this list}.
+\item Each resource can have up to 50 tags. For other limits, see \href{https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions}{Tag Naming and Usage Conventions}
+in the \emph{AWS General Reference.}
 \item You can only tag resources that are located in the specified Region
 for the AWS account.
 \item To add tags to a resource, you need the necessary permissions for

--- a/cran/paws.management/tests/testthat/test_applicationautoscaling.R
+++ b/cran/paws.management/tests/testthat/test_applicationautoscaling.R
@@ -1,5 +1,3 @@
-context("applicationautoscaling")
-
 svc <- paws::applicationautoscaling()
 
 

--- a/cran/paws.management/tests/testthat/test_applicationinsights.R
+++ b/cran/paws.management/tests/testthat/test_applicationinsights.R
@@ -1,5 +1,3 @@
-context("applicationinsights")
-
 svc <- paws::applicationinsights()
 
 test_that("list_applications", {

--- a/cran/paws.management/tests/testthat/test_autoscaling.R
+++ b/cran/paws.management/tests/testthat/test_autoscaling.R
@@ -1,5 +1,3 @@
-context("autoscaling")
-
 svc <- paws::autoscaling()
 
 test_that("describe_account_limits", {

--- a/cran/paws.management/tests/testthat/test_autoscalingplans.R
+++ b/cran/paws.management/tests/testthat/test_autoscalingplans.R
@@ -1,5 +1,3 @@
-context("autoscalingplans")
-
 svc <- paws::autoscalingplans()
 
 test_that("describe_scaling_plans", {

--- a/cran/paws.management/tests/testthat/test_cloudformation.R
+++ b/cran/paws.management/tests/testthat/test_cloudformation.R
@@ -1,5 +1,3 @@
-context("cloudformation")
-
 svc <- paws::cloudformation()
 
 test_that("describe_account_limits", {

--- a/cran/paws.management/tests/testthat/test_cloudtrail.R
+++ b/cran/paws.management/tests/testthat/test_cloudtrail.R
@@ -1,5 +1,3 @@
-context("cloudtrail")
-
 svc <- paws::cloudtrail()
 
 test_that("describe_trails", {

--- a/cran/paws.management/tests/testthat/test_cloudwatch.R
+++ b/cran/paws.management/tests/testthat/test_cloudwatch.R
@@ -1,5 +1,3 @@
-context("cloudwatch")
-
 svc <- paws::cloudwatch()
 
 test_that("describe_alarm_history", {

--- a/cran/paws.management/tests/testthat/test_cloudwatchevents.R
+++ b/cran/paws.management/tests/testthat/test_cloudwatchevents.R
@@ -1,5 +1,3 @@
-context("cloudwatchevents")
-
 svc <- paws::cloudwatchevents()
 
 test_that("describe_event_bus", {

--- a/cran/paws.management/tests/testthat/test_cloudwatchlogs.R
+++ b/cran/paws.management/tests/testthat/test_cloudwatchlogs.R
@@ -1,5 +1,3 @@
-context("cloudwatchlogs")
-
 svc <- paws::cloudwatchlogs()
 
 test_that("describe_destinations", {

--- a/cran/paws.management/tests/testthat/test_configservice.R
+++ b/cran/paws.management/tests/testthat/test_configservice.R
@@ -1,5 +1,3 @@
-context("configservice")
-
 svc <- paws::configservice()
 
 test_that("describe_aggregation_authorizations", {

--- a/cran/paws.management/tests/testthat/test_health.R
+++ b/cran/paws.management/tests/testthat/test_health.R
@@ -1,5 +1,3 @@
-context("health")
-
 svc <- paws::health()
 
 

--- a/cran/paws.management/tests/testthat/test_licensemanager.R
+++ b/cran/paws.management/tests/testthat/test_licensemanager.R
@@ -1,5 +1,3 @@
-context("licensemanager")
-
 svc <- paws::licensemanager()
 
 

--- a/cran/paws.management/tests/testthat/test_opsworks.R
+++ b/cran/paws.management/tests/testthat/test_opsworks.R
@@ -1,5 +1,3 @@
-context("opsworks")
-
 svc <- paws::opsworks()
 
 test_that("describe_my_user_profile", {

--- a/cran/paws.management/tests/testthat/test_opsworkscm.R
+++ b/cran/paws.management/tests/testthat/test_opsworkscm.R
@@ -1,5 +1,3 @@
-context("opsworkscm")
-
 svc <- paws::opsworkscm()
 
 test_that("describe_account_attributes", {

--- a/cran/paws.management/tests/testthat/test_organizations.R
+++ b/cran/paws.management/tests/testthat/test_organizations.R
@@ -1,5 +1,3 @@
-context("organizations")
-
 svc <- paws::organizations()
 
 

--- a/cran/paws.management/tests/testthat/test_pi.R
+++ b/cran/paws.management/tests/testthat/test_pi.R
@@ -1,5 +1,3 @@
-context("pi")
-
 svc <- paws::pi()
 
 

--- a/cran/paws.management/tests/testthat/test_resourcegroups.R
+++ b/cran/paws.management/tests/testthat/test_resourcegroups.R
@@ -1,5 +1,3 @@
-context("resourcegroups")
-
 svc <- paws::resourcegroups()
 
 test_that("list_group_resources", {

--- a/cran/paws.management/tests/testthat/test_resourcegroupstaggingapi.R
+++ b/cran/paws.management/tests/testthat/test_resourcegroupstaggingapi.R
@@ -1,5 +1,3 @@
-context("resourcegroupstaggingapi")
-
 svc <- paws::resourcegroupstaggingapi()
 
 test_that("describe_report_creation", {

--- a/cran/paws.management/tests/testthat/test_servicecatalog.R
+++ b/cran/paws.management/tests/testthat/test_servicecatalog.R
@@ -1,5 +1,3 @@
-context("servicecatalog")
-
 svc <- paws::servicecatalog()
 
 test_that("describe_product", {

--- a/cran/paws.management/tests/testthat/test_servicequotas.R
+++ b/cran/paws.management/tests/testthat/test_servicequotas.R
@@ -1,5 +1,3 @@
-context("servicequotas")
-
 svc <- paws::servicequotas()
 
 test_that("list_requested_service_quota_change_history", {

--- a/cran/paws.management/tests/testthat/test_ssm.R
+++ b/cran/paws.management/tests/testthat/test_ssm.R
@@ -1,5 +1,3 @@
-context("ssm")
-
 svc <- paws::ssm()
 
 test_that("describe_activations", {

--- a/cran/paws.management/tests/testthat/test_support.R
+++ b/cran/paws.management/tests/testthat/test_support.R
@@ -1,5 +1,3 @@
-context("support")
-
 svc <- paws::support()
 
 

--- a/cran/paws.media.services/R/kinesisvideoarchivedmedia_operations.R
+++ b/cran/paws.media.services/R/kinesisvideoarchivedmedia_operations.R
@@ -30,9 +30,9 @@ NULL
 #' 
 #' -   The video track of each fragment must contain codec private data in
 #'     the Advanced Video Coding (AVC) for H.264 format and HEVC for H.265
-#'     format. For more information, see [MPEG-4 specification ISO/IEC
-#'     14496-15](https://www.iso.org/standard/55980.html). For information
-#'     about adapting stream data to a given format, see [NAL Adaptation
+#'     format. For more information, see MPEG-4 specification ISO/IEC
+#'     14496-15. For information about adapting stream data to a given
+#'     format, see [NAL Adaptation
 #'     Flags](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html).
 #' 
 #' -   The audio track (if present) of each fragment must contain codec

--- a/cran/paws.media.services/R/mediastore_operations.R
+++ b/cran/paws.media.services/R/mediastore_operations.R
@@ -22,8 +22,9 @@ NULL
 #' (such as "environment") and the tag value represents a specific value
 #' within that category (such as "test," "development," or "production").
 #' You can add up to 50 tags to each container. For more information about
-#' tagging, including naming and usage conventions, see Tagging Resources
-#' in MediaStore.
+#' tagging, including naming and usage conventions, see [Tagging Resources
+#' in
+#' MediaStore](https://docs.aws.amazon.com/mediastore/latest/ug/tagging.html).
 #'
 #' @return
 #' A list with the following syntax:

--- a/cran/paws.media.services/man/kinesisvideoarchivedmedia_get_clip.Rd
+++ b/cran/paws.media.services/man/kinesisvideoarchivedmedia_get_clip.Rd
@@ -49,8 +49,9 @@ AAC) or A_MS/ACM (for G.711).
 \item Data retention must be greater than 0.
 \item The video track of each fragment must contain codec private data in
 the Advanced Video Coding (AVC) for H.264 format and HEVC for H.265
-format. For more information, see \href{https://www.iso.org/standard/55980.html}{MPEG-4 specification ISO/IEC 14496-15}. For information
-about adapting stream data to a given format, see \href{https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html}{NAL Adaptation Flags}.
+format. For more information, see MPEG-4 specification ISO/IEC
+14496-15. For information about adapting stream data to a given
+format, see \href{https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html}{NAL Adaptation Flags}.
 \item The audio track (if present) of each fragment must contain codec
 private data in the AAC format (\href{https://www.iso.org/standard/43345.html}{AAC specification ISO/IEC 13818-7}) or the \href{http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html}{MS Wave format}.
 }

--- a/cran/paws.media.services/man/mediastore_create_container.Rd
+++ b/cran/paws.media.services/man/mediastore_create_container.Rd
@@ -18,8 +18,7 @@ anything that you want. Typically, the tag key represents a category
 (such as "environment") and the tag value represents a specific value
 within that category (such as "test," "development," or "production").
 You can add up to 50 tags to each container. For more information about
-tagging, including naming and usage conventions, see Tagging Resources
-in MediaStore.}
+tagging, including naming and usage conventions, see \href{https://docs.aws.amazon.com/mediastore/latest/ug/tagging.html}{Tagging Resources in MediaStore}.}
 }
 \value{
 A list with the following syntax:\preformatted{list(

--- a/cran/paws.media.services/tests/testthat/test_elastictranscoder.R
+++ b/cran/paws.media.services/tests/testthat/test_elastictranscoder.R
@@ -1,5 +1,3 @@
-context("elastictranscoder")
-
 svc <- paws::elastictranscoder()
 
 test_that("list_pipelines", {

--- a/cran/paws.media.services/tests/testthat/test_kinesisvideo.R
+++ b/cran/paws.media.services/tests/testthat/test_kinesisvideo.R
@@ -1,5 +1,3 @@
-context("kinesisvideo")
-
 svc <- paws::kinesisvideo()
 
 test_that("describe_signaling_channel", {

--- a/cran/paws.media.services/tests/testthat/test_kinesisvideoarchivedmedia.R
+++ b/cran/paws.media.services/tests/testthat/test_kinesisvideoarchivedmedia.R
@@ -1,5 +1,3 @@
-context("kinesisvideoarchivedmedia")
-
 svc <- paws::kinesisvideoarchivedmedia()
 
 

--- a/cran/paws.media.services/tests/testthat/test_kinesisvideomedia.R
+++ b/cran/paws.media.services/tests/testthat/test_kinesisvideomedia.R
@@ -1,5 +1,3 @@
-context("kinesisvideomedia")
-
 svc <- paws::kinesisvideomedia()
 
 

--- a/cran/paws.media.services/tests/testthat/test_mediaconnect.R
+++ b/cran/paws.media.services/tests/testthat/test_mediaconnect.R
@@ -1,5 +1,3 @@
-context("mediaconnect")
-
 svc <- paws::mediaconnect()
 
 test_that("list_entitlements", {

--- a/cran/paws.media.services/tests/testthat/test_mediaconvert.R
+++ b/cran/paws.media.services/tests/testthat/test_mediaconvert.R
@@ -1,5 +1,3 @@
-context("mediaconvert")
-
 svc <- paws::mediaconvert()
 
 

--- a/cran/paws.media.services/tests/testthat/test_medialive.R
+++ b/cran/paws.media.services/tests/testthat/test_medialive.R
@@ -1,5 +1,3 @@
-context("medialive")
-
 svc <- paws::medialive()
 
 test_that("list_channels", {

--- a/cran/paws.media.services/tests/testthat/test_mediapackage.R
+++ b/cran/paws.media.services/tests/testthat/test_mediapackage.R
@@ -1,5 +1,3 @@
-context("mediapackage")
-
 svc <- paws::mediapackage()
 
 test_that("list_channels", {

--- a/cran/paws.media.services/tests/testthat/test_mediastore.R
+++ b/cran/paws.media.services/tests/testthat/test_mediastore.R
@@ -1,5 +1,3 @@
-context("mediastore")
-
 svc <- paws::mediastore()
 
 test_that("list_containers", {

--- a/cran/paws.media.services/tests/testthat/test_mediastoredata.R
+++ b/cran/paws.media.services/tests/testthat/test_mediastoredata.R
@@ -1,5 +1,3 @@
-context("mediastoredata")
-
 svc <- paws::mediastoredata()
 
 

--- a/cran/paws.media.services/tests/testthat/test_mediatailor.R
+++ b/cran/paws.media.services/tests/testthat/test_mediatailor.R
@@ -1,5 +1,3 @@
-context("mediatailor")
-
 svc <- paws::mediatailor()
 
 test_that("list_playback_configurations", {

--- a/cran/paws.migration/R/datasync_operations.R
+++ b/cran/paws.migration/R/datasync_operations.R
@@ -105,7 +105,7 @@ datasync_cancel_task_execution <- function(TaskExecutionArn) {
 #' access to. This is the client-side VPC endpoint, also called a
 #' PrivateLink. If you don't have a PrivateLink VPC endpoint, see [Creating
 #' a VPC Endpoint Service
-#' Configuration](https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-service.html#create-endpoint-service)
+#' Configuration](https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-service.html#create-endpoint-service)
 #' in the Amazon VPC User Guide.
 #' 
 #' VPC endpoint ID looks like this: `vpce-01234d5aff67890e1`.

--- a/cran/paws.migration/man/datasync_create_agent.Rd
+++ b/cran/paws.migration/man/datasync_create_agent.Rd
@@ -35,7 +35,7 @@ representable in UTF-8 format, and the following special characters: + -
 
 \item{VpcEndpointId}{The ID of the VPC (virtual private cloud) endpoint that the agent has
 access to. This is the client-side VPC endpoint, also called a
-PrivateLink. If you don't have a PrivateLink VPC endpoint, see \href{https://docs.aws.amazon.com/vpc/latest/userguide/endpoint-service.html#create-endpoint-service}{Creating a VPC Endpoint Service Configuration}
+PrivateLink. If you don't have a PrivateLink VPC endpoint, see \href{https://docs.aws.amazon.com/vpc/latest/privatelink/endpoint-service.html#create-endpoint-service}{Creating a VPC Endpoint Service Configuration}
 in the Amazon VPC User Guide.
 
 VPC endpoint ID looks like this: \verb{vpce-01234d5aff67890e1}.}

--- a/cran/paws.migration/tests/testthat/test_applicationdiscoveryservice.R
+++ b/cran/paws.migration/tests/testthat/test_applicationdiscoveryservice.R
@@ -1,5 +1,3 @@
-context("applicationdiscoveryservice")
-
 svc <- paws::applicationdiscoveryservice()
 
 

--- a/cran/paws.migration/tests/testthat/test_databasemigrationservice.R
+++ b/cran/paws.migration/tests/testthat/test_databasemigrationservice.R
@@ -1,5 +1,3 @@
-context("databasemigrationservice")
-
 svc <- paws::databasemigrationservice()
 
 test_that("describe_account_attributes", {

--- a/cran/paws.migration/tests/testthat/test_datasync.R
+++ b/cran/paws.migration/tests/testthat/test_datasync.R
@@ -1,5 +1,3 @@
-context("datasync")
-
 svc <- paws::datasync()
 
 test_that("list_agents", {

--- a/cran/paws.migration/tests/testthat/test_importexport.R
+++ b/cran/paws.migration/tests/testthat/test_importexport.R
@@ -1,5 +1,3 @@
-context("importexport")
-
 svc <- paws::importexport()
 
 test_that("list_jobs", {

--- a/cran/paws.migration/tests/testthat/test_migrationhub.R
+++ b/cran/paws.migration/tests/testthat/test_migrationhub.R
@@ -1,5 +1,3 @@
-context("migrationhub")
-
 svc <- paws::migrationhub()
 
 

--- a/cran/paws.migration/tests/testthat/test_sms.R
+++ b/cran/paws.migration/tests/testthat/test_sms.R
@@ -1,5 +1,3 @@
-context("sms")
-
 svc <- paws::sms()
 
 test_that("list_apps", {

--- a/cran/paws.migration/tests/testthat/test_snowball.R
+++ b/cran/paws.migration/tests/testthat/test_snowball.R
@@ -1,5 +1,3 @@
-context("snowball")
-
 svc <- paws::snowball()
 
 test_that("describe_addresses", {

--- a/cran/paws.migration/tests/testthat/test_transfer.R
+++ b/cran/paws.migration/tests/testthat/test_transfer.R
@@ -1,5 +1,3 @@
-context("transfer")
-
 svc <- paws::transfer()
 
 test_that("list_security_policies", {

--- a/cran/paws.mobile/tests/testthat/test_amplify.R
+++ b/cran/paws.mobile/tests/testthat/test_amplify.R
@@ -1,5 +1,3 @@
-context("amplify")
-
 svc <- paws::amplify()
 
 test_that("list_apps", {

--- a/cran/paws.mobile/tests/testthat/test_appsync.R
+++ b/cran/paws.mobile/tests/testthat/test_appsync.R
@@ -1,5 +1,3 @@
-context("appsync")
-
 svc <- paws::appsync()
 
 test_that("list_graphql_apis", {

--- a/cran/paws.mobile/tests/testthat/test_devicefarm.R
+++ b/cran/paws.mobile/tests/testthat/test_devicefarm.R
@@ -1,5 +1,3 @@
-context("devicefarm")
-
 svc <- paws::devicefarm()
 
 

--- a/cran/paws.mobile/tests/testthat/test_mobile.R
+++ b/cran/paws.mobile/tests/testthat/test_mobile.R
@@ -1,5 +1,3 @@
-context("mobile")
-
 svc <- paws::mobile()
 
 test_that("list_bundles", {

--- a/cran/paws.mobile/tests/testthat/test_mobileanalytics.R
+++ b/cran/paws.mobile/tests/testthat/test_mobileanalytics.R
@@ -1,5 +1,3 @@
-context("mobileanalytics")
-
 svc <- paws::mobileanalytics()
 
 

--- a/cran/paws.networking/R/apigatewaymanagementapi_service.R
+++ b/cran/paws.networking/R/apigatewaymanagementapi_service.R
@@ -65,7 +65,7 @@ apigatewaymanagementapi <- function(config = list()) {
 
 .apigatewaymanagementapi$metadata <- list(
   service_name = "apigatewaymanagementapi",
-  endpoints = list("*" = list(endpoint = "apigatewaymanagementapi.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "apigatewaymanagementapi.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "apigatewaymanagementapi.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "apigatewaymanagementapi.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "execute-api.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "execute-api.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "execute-api.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "execute-api.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "ApiGatewayManagementApi",
   api_version = "2018-11-29",
   signing_name = "execute-api",

--- a/cran/paws.networking/R/apigatewayv2_service.R
+++ b/cran/paws.networking/R/apigatewayv2_service.R
@@ -128,7 +128,7 @@ apigatewayv2 <- function(config = list()) {
 
 .apigatewayv2$metadata <- list(
   service_name = "apigatewayv2",
-  endpoints = list("*" = list(endpoint = "apigatewayv2.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "apigatewayv2.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "apigatewayv2.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "apigatewayv2.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "apigateway.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "apigateway.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "apigateway.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "apigateway.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "ApiGatewayV2",
   api_version = "2018-11-29",
   signing_name = "apigateway",

--- a/cran/paws.networking/tests/testthat/test_apigateway.R
+++ b/cran/paws.networking/tests/testthat/test_apigateway.R
@@ -1,5 +1,3 @@
-context("apigateway")
-
 svc <- paws::apigateway()
 
 

--- a/cran/paws.networking/tests/testthat/test_apigatewaymanagementapi.R
+++ b/cran/paws.networking/tests/testthat/test_apigatewaymanagementapi.R
@@ -1,5 +1,3 @@
-context("apigatewaymanagementapi")
-
 svc <- paws::apigatewaymanagementapi()
 
 

--- a/cran/paws.networking/tests/testthat/test_apigatewayv2.R
+++ b/cran/paws.networking/tests/testthat/test_apigatewayv2.R
@@ -1,5 +1,3 @@
-context("apigatewayv2")
-
 svc <- paws::apigatewayv2()
 
 

--- a/cran/paws.networking/tests/testthat/test_appmesh.R
+++ b/cran/paws.networking/tests/testthat/test_appmesh.R
@@ -1,5 +1,3 @@
-context("appmesh")
-
 svc <- paws::appmesh()
 
 test_that("list_meshes", {

--- a/cran/paws.networking/tests/testthat/test_cloudfront.R
+++ b/cran/paws.networking/tests/testthat/test_cloudfront.R
@@ -1,5 +1,3 @@
-context("cloudfront")
-
 svc <- paws::cloudfront()
 
 test_that("list_cache_policies", {

--- a/cran/paws.networking/tests/testthat/test_directconnect.R
+++ b/cran/paws.networking/tests/testthat/test_directconnect.R
@@ -1,5 +1,3 @@
-context("directconnect")
-
 svc <- paws::directconnect()
 
 

--- a/cran/paws.networking/tests/testthat/test_elb.R
+++ b/cran/paws.networking/tests/testthat/test_elb.R
@@ -1,5 +1,3 @@
-context("elb")
-
 svc <- paws::elb()
 
 test_that("describe_account_limits", {

--- a/cran/paws.networking/tests/testthat/test_elbv2.R
+++ b/cran/paws.networking/tests/testthat/test_elbv2.R
@@ -1,5 +1,3 @@
-context("elbv2")
-
 svc <- paws::elbv2()
 
 test_that("describe_account_limits", {

--- a/cran/paws.networking/tests/testthat/test_globalaccelerator.R
+++ b/cran/paws.networking/tests/testthat/test_globalaccelerator.R
@@ -1,5 +1,3 @@
-context("globalaccelerator")
-
 svc <- paws::globalaccelerator()
 
 

--- a/cran/paws.networking/tests/testthat/test_route53.R
+++ b/cran/paws.networking/tests/testthat/test_route53.R
@@ -1,5 +1,3 @@
-context("route53")
-
 svc <- paws::route53()
 
 test_that("list_geo_locations", {

--- a/cran/paws.networking/tests/testthat/test_route53domains.R
+++ b/cran/paws.networking/tests/testthat/test_route53domains.R
@@ -1,5 +1,3 @@
-context("route53domains")
-
 svc <- paws::route53domains()
 
 test_that("list_domains", {

--- a/cran/paws.networking/tests/testthat/test_route53resolver.R
+++ b/cran/paws.networking/tests/testthat/test_route53resolver.R
@@ -1,5 +1,3 @@
-context("route53resolver")
-
 svc <- paws::route53resolver()
 
 test_that("list_resolver_dnssec_configs", {

--- a/cran/paws.networking/tests/testthat/test_servicediscovery.R
+++ b/cran/paws.networking/tests/testthat/test_servicediscovery.R
@@ -1,5 +1,3 @@
-context("servicediscovery")
-
 svc <- paws::servicediscovery()
 
 test_that("list_namespaces", {

--- a/cran/paws.robotics/tests/testthat/test_robomaker.R
+++ b/cran/paws.robotics/tests/testthat/test_robomaker.R
@@ -1,5 +1,3 @@
-context("robomaker")
-
 svc <- paws::robomaker()
 
 test_that("list_deployment_jobs", {

--- a/cran/paws.security.identity/R/acm_operations.R
+++ b/cran/paws.security.identity/R/acm_operations.R
@@ -797,10 +797,9 @@ acm_renew_certificate <- function(CertificateArn) {
 #' required. If you are requesting a public certificate, each domain name
 #' that you specify must be validated to verify that you own or control the
 #' domain. You can use [DNS
-#' validation](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate-dns.html)
-#' or [email
-#' validation](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate-email.html).
-#' We recommend that you use DNS validation. ACM issues public certificates
+#' validation](https://docs.aws.amazon.com/acm/latest/userguide/) or [email
+#' validation](https://docs.aws.amazon.com/acm/latest/userguide/). We
+#' recommend that you use DNS validation. ACM issues public certificates
 #' after receiving approval from the domain owner.
 #'
 #' @usage
@@ -819,10 +818,9 @@ acm_renew_certificate <- function(CertificateArn) {
 #' up to 253 octets in length.
 #' @param ValidationMethod The method you want to use if you are requesting a public certificate to
 #' validate that you own or control domain. You can [validate with
-#' DNS](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate-dns.html)
-#' or [validate with
-#' email](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate-email.html).
-#' We recommend that you use DNS validation.
+#' DNS](https://docs.aws.amazon.com/acm/latest/userguide/) or [validate
+#' with email](https://docs.aws.amazon.com/acm/latest/userguide/). We
+#' recommend that you use DNS validation.
 #' @param SubjectAlternativeNames Additional FQDNs to be included in the Subject Alternative Name
 #' extension of the ACM certificate. For example, add the name
 #' www.example.net to a certificate for which the `DomainName` field is

--- a/cran/paws.security.identity/man/acm_request_certificate.Rd
+++ b/cran/paws.security.identity/man/acm_request_certificate.Rd
@@ -20,9 +20,8 @@ periods. Each subsequent Subject Alternative Name (SAN), however, can be
 up to 253 octets in length.}
 
 \item{ValidationMethod}{The method you want to use if you are requesting a public certificate to
-validate that you own or control domain. You can \href{https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate-dns.html}{validate with DNS}
-or \href{https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate-email.html}{validate with email}.
-We recommend that you use DNS validation.}
+validate that you own or control domain. You can \href{https://docs.aws.amazon.com/acm/latest/userguide/}{validate with DNS} or \href{https://docs.aws.amazon.com/acm/latest/userguide/}{validate with email}. We
+recommend that you use DNS validation.}
 
 \item{SubjectAlternativeNames}{Additional FQDNs to be included in the Subject Alternative Name
 extension of the ACM certificate. For example, add the name
@@ -94,9 +93,8 @@ FQDNs in the \code{SubjectAlternativeNames} parameter.
 If you are requesting a private certificate, domain validation is not
 required. If you are requesting a public certificate, each domain name
 that you specify must be validated to verify that you own or control the
-domain. You can use \href{https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate-dns.html}{DNS validation}
-or \href{https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate-email.html}{email validation}.
-We recommend that you use DNS validation. ACM issues public certificates
+domain. You can use \href{https://docs.aws.amazon.com/acm/latest/userguide/}{DNS validation} or \href{https://docs.aws.amazon.com/acm/latest/userguide/}{email validation}. We
+recommend that you use DNS validation. ACM issues public certificates
 after receiving approval from the domain owner.
 }
 \section{Request syntax}{

--- a/cran/paws.security.identity/tests/testthat/test_acm.R
+++ b/cran/paws.security.identity/tests/testthat/test_acm.R
@@ -1,5 +1,3 @@
-context("acm")
-
 svc <- paws::acm()
 
 test_that("list_certificates", {

--- a/cran/paws.security.identity/tests/testthat/test_acmpca.R
+++ b/cran/paws.security.identity/tests/testthat/test_acmpca.R
@@ -1,5 +1,3 @@
-context("acmpca")
-
 svc <- paws::acmpca()
 
 test_that("list_certificate_authorities", {

--- a/cran/paws.security.identity/tests/testthat/test_clouddirectory.R
+++ b/cran/paws.security.identity/tests/testthat/test_clouddirectory.R
@@ -1,5 +1,3 @@
-context("clouddirectory")
-
 svc <- paws::clouddirectory()
 
 test_that("list_development_schema_arns", {

--- a/cran/paws.security.identity/tests/testthat/test_cloudhsm.R
+++ b/cran/paws.security.identity/tests/testthat/test_cloudhsm.R
@@ -1,5 +1,3 @@
-context("cloudhsm")
-
 svc <- paws::cloudhsm()
 
 

--- a/cran/paws.security.identity/tests/testthat/test_cloudhsmv2.R
+++ b/cran/paws.security.identity/tests/testthat/test_cloudhsmv2.R
@@ -1,5 +1,3 @@
-context("cloudhsmv2")
-
 svc <- paws::cloudhsmv2()
 
 test_that("describe_backups", {

--- a/cran/paws.security.identity/tests/testthat/test_cognitoidentity.R
+++ b/cran/paws.security.identity/tests/testthat/test_cognitoidentity.R
@@ -1,5 +1,3 @@
-context("cognitoidentity")
-
 svc <- paws::cognitoidentity()
 
 

--- a/cran/paws.security.identity/tests/testthat/test_cognitoidentityprovider.R
+++ b/cran/paws.security.identity/tests/testthat/test_cognitoidentityprovider.R
@@ -1,5 +1,3 @@
-context("cognitoidentityprovider")
-
 svc <- paws::cognitoidentityprovider()
 
 

--- a/cran/paws.security.identity/tests/testthat/test_cognitosync.R
+++ b/cran/paws.security.identity/tests/testthat/test_cognitosync.R
@@ -1,5 +1,3 @@
-context("cognitosync")
-
 svc <- paws::cognitosync()
 
 test_that("list_identity_pool_usage", {

--- a/cran/paws.security.identity/tests/testthat/test_directoryservice.R
+++ b/cran/paws.security.identity/tests/testthat/test_directoryservice.R
@@ -1,5 +1,3 @@
-context("directoryservice")
-
 svc <- paws::directoryservice()
 
 test_that("describe_directories", {

--- a/cran/paws.security.identity/tests/testthat/test_fms.R
+++ b/cran/paws.security.identity/tests/testthat/test_fms.R
@@ -1,5 +1,3 @@
-context("fms")
-
 svc <- paws::fms()
 
 

--- a/cran/paws.security.identity/tests/testthat/test_guardduty.R
+++ b/cran/paws.security.identity/tests/testthat/test_guardduty.R
@@ -1,5 +1,3 @@
-context("guardduty")
-
 svc <- paws::guardduty()
 
 test_that("list_detectors", {

--- a/cran/paws.security.identity/tests/testthat/test_iam.R
+++ b/cran/paws.security.identity/tests/testthat/test_iam.R
@@ -1,5 +1,3 @@
-context("iam")
-
 svc <- paws::iam()
 
 test_that("list_access_keys", {

--- a/cran/paws.security.identity/tests/testthat/test_inspector.R
+++ b/cran/paws.security.identity/tests/testthat/test_inspector.R
@@ -1,5 +1,3 @@
-context("inspector")
-
 svc <- paws::inspector()
 
 test_that("describe_cross_account_access_role", {

--- a/cran/paws.security.identity/tests/testthat/test_kms.R
+++ b/cran/paws.security.identity/tests/testthat/test_kms.R
@@ -1,5 +1,3 @@
-context("kms")
-
 svc <- paws::kms()
 
 test_that("describe_custom_key_stores", {

--- a/cran/paws.security.identity/tests/testthat/test_macie.R
+++ b/cran/paws.security.identity/tests/testthat/test_macie.R
@@ -1,5 +1,3 @@
-context("macie")
-
 svc <- paws::macie()
 
 

--- a/cran/paws.security.identity/tests/testthat/test_ram.R
+++ b/cran/paws.security.identity/tests/testthat/test_ram.R
@@ -1,5 +1,3 @@
-context("ram")
-
 svc <- paws::ram()
 
 test_that("list_permissions", {

--- a/cran/paws.security.identity/tests/testthat/test_secretsmanager.R
+++ b/cran/paws.security.identity/tests/testthat/test_secretsmanager.R
@@ -1,5 +1,3 @@
-context("secretsmanager")
-
 svc <- paws::secretsmanager()
 
 test_that("list_secrets", {

--- a/cran/paws.security.identity/tests/testthat/test_securityhub.R
+++ b/cran/paws.security.identity/tests/testthat/test_securityhub.R
@@ -1,5 +1,3 @@
-context("securityhub")
-
 svc <- paws::securityhub()
 
 test_that("describe_action_targets", {

--- a/cran/paws.security.identity/tests/testthat/test_shield.R
+++ b/cran/paws.security.identity/tests/testthat/test_shield.R
@@ -1,5 +1,3 @@
-context("shield")
-
 svc <- paws::shield()
 
 test_that("describe_attack_statistics", {

--- a/cran/paws.security.identity/tests/testthat/test_sts.R
+++ b/cran/paws.security.identity/tests/testthat/test_sts.R
@@ -1,5 +1,3 @@
-context("sts")
-
 svc <- paws::sts()
 
 

--- a/cran/paws.security.identity/tests/testthat/test_waf.R
+++ b/cran/paws.security.identity/tests/testthat/test_waf.R
@@ -1,5 +1,3 @@
-context("waf")
-
 svc <- paws::waf()
 
 test_that("list_byte_match_sets", {

--- a/cran/paws.security.identity/tests/testthat/test_wafregional.R
+++ b/cran/paws.security.identity/tests/testthat/test_wafregional.R
@@ -1,5 +1,3 @@
-context("wafregional")
-
 svc <- paws::wafregional()
 
 test_that("list_byte_match_sets", {

--- a/cran/paws.storage/R/s3control_service.R
+++ b/cran/paws.storage/R/s3control_service.R
@@ -95,7 +95,7 @@ s3control <- function(config = list()) {
 
 .s3control$metadata <- list(
   service_name = "s3control",
-  endpoints = list("*" = list(endpoint = "s3control.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "s3control.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "s3control.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "s3control.{region}.sc2s.sgov.gov", global = FALSE)),
+  endpoints = list("*" = list(endpoint = "s3-control.{region}.amazonaws.com", global = FALSE), "cn-*" = list(endpoint = "s3-control.{region}.amazonaws.com.cn", global = FALSE), "us-iso-*" = list(endpoint = "s3-control.{region}.c2s.ic.gov", global = FALSE), "us-isob-*" = list(endpoint = "s3-control.{region}.sc2s.sgov.gov", global = FALSE)),
   service_id = "S3 Control",
   api_version = "2018-08-20",
   signing_name = "s3",

--- a/cran/paws.storage/tests/testthat/test_backup.R
+++ b/cran/paws.storage/tests/testthat/test_backup.R
@@ -1,5 +1,3 @@
-context("backup")
-
 svc <- paws::backup()
 
 test_that("describe_global_settings", {

--- a/cran/paws.storage/tests/testthat/test_dlm.R
+++ b/cran/paws.storage/tests/testthat/test_dlm.R
@@ -1,5 +1,3 @@
-context("dlm")
-
 svc <- paws::dlm()
 
 

--- a/cran/paws.storage/tests/testthat/test_efs.R
+++ b/cran/paws.storage/tests/testthat/test_efs.R
@@ -1,5 +1,3 @@
-context("efs")
-
 svc <- paws::efs()
 
 test_that("describe_access_points", {

--- a/cran/paws.storage/tests/testthat/test_fsx.R
+++ b/cran/paws.storage/tests/testthat/test_fsx.R
@@ -1,5 +1,3 @@
-context("fsx")
-
 svc <- paws::fsx()
 
 test_that("describe_backups", {

--- a/cran/paws.storage/tests/testthat/test_glacier.R
+++ b/cran/paws.storage/tests/testthat/test_glacier.R
@@ -1,5 +1,3 @@
-context("glacier")
-
 svc <- paws::glacier()
 
 

--- a/cran/paws.storage/tests/testthat/test_s3.R
+++ b/cran/paws.storage/tests/testthat/test_s3.R
@@ -1,5 +1,3 @@
-context("s3")
-
 svc <- paws::s3()
 
 test_that("list_buckets", {

--- a/cran/paws.storage/tests/testthat/test_s3control.R
+++ b/cran/paws.storage/tests/testthat/test_s3control.R
@@ -1,5 +1,3 @@
-context("s3control")
-
 svc <- paws::s3control()
 
 

--- a/cran/paws.storage/tests/testthat/test_storagegateway.R
+++ b/cran/paws.storage/tests/testthat/test_storagegateway.R
@@ -1,5 +1,3 @@
-context("storagegateway")
-
 svc <- paws::storagegateway()
 
 test_that("describe_tape_archives", {


### PR DESCRIPTION
* Fix API endpoint URLs in some cases.
* Delete no longer needed call to `context()` in `testthat` test files.