### PR TITLE
Fix CRAN check issues

### DIFF
--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -158,7 +158,7 @@ make_doc_example <- function(example, op_name) {
     last_quote <- quotes[length(quotes)]
     first <- substr(x, 1, first_quote)
     middle <- substr(x, first_quote+1, nchar(x)-1)
-    middle <- paste0(substr(middle, 1, 90-nchar(first)-5), "...")
+    middle <- paste0(substr(middle, 1, 80-nchar(first)-5), "...")
     middle <- escape_unmatched_chars(middle, '"')
     middle <- escape_unmatched_pairs(middle, c("{" = "}"))
     last <- substr(x, last_quote, nchar(x))

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -152,7 +152,11 @@ make_doc_example <- function(example, op_name) {
   # to avoid further warnings from R CMD check about unmatched quotes.
   lines <- strsplit(call, "\n")[[1]]
   truncated <- lapply(lines, function(x) {
-    if (nchar(x) <= 95) return(x)
+    if (nchar(x) <= 95) {
+      x <- escape_unmatched_chars(x, '"')
+      x <- escape_unmatched_pairs(x, c("{" = "}"))
+      return(x)
+    }
     quotes <- stringr::str_locate_all(x, '"')[[1]][, 1]
     first_quote <- quotes[1]
     last_quote <- quotes[length(quotes)]

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -414,7 +414,7 @@ test_that("make_doc_examples", {
     "#' svc$operation(",
     "#'   Foo = \"bar\",",
     "#'   Baz = list(",
-    "#'     Qux = \"\\{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[\\{\\\"Sid\\\":\\\"Stmt1\\\",\\\"Effect\\\":\\\"Allow\\\",\\\"Acti...\",",
+    "#'     Qux = \"\\{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[\\{\\\"Sid\\\":\\\"Stmt1\\\",\\\"Effect\\\":\\\"Al...\",",
     "#'     Quux = 123",
     "#'   )",
     "#' )",

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -482,6 +482,30 @@ test_that("make_doc_examples", {
     sep = "\n"
   )
   expect_equal(actual, expected)
+
+  operation <- list(
+    name = "Operation",
+    examples = list(
+      list(
+        input = list(
+          "Foo" = "bar{"
+        ),
+        description = "Example with unmatched curly brace"
+      )
+    )
+  )
+  actual <- make_doc_examples(operation, api)
+  expected <- paste(
+    "#' @examples",
+    "#' \\dontrun{",
+    "#' # Example with unmatched curly brace",
+    "#' svc$operation(",
+    "#'   Foo = \"bar\\{\"",
+    "#' )",
+    "#' }",
+    sep = "\n"
+  )
+  expect_equal(actual, expected)
 })
 
 test_that("convert", {


### PR DESCRIPTION
* Shorten overly long lines in examples.
* Escape unmatched quotes and curly braces in short examples.

With these, we should be able to regenerate and submit to CRAN.