### PR TITLE
Regenerate Paws

### DIFF
--- a/cran/paws.analytics/DESCRIPTION
+++ b/cran/paws.analytics/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.analytics
 Title: Amazon Web Services Analytics Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.application.integration/DESCRIPTION
+++ b/cran/paws.application.integration/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.application.integration
 Title: Amazon Web Services Application Integration Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.business.applications/DESCRIPTION
+++ b/cran/paws.business.applications/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.business.applications
 Title: Amazon Web Services Business Applications Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.compute/DESCRIPTION
+++ b/cran/paws.compute/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.compute
 Title: Amazon Web Services Compute Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.compute/R/ec2instanceconnect_operations.R
+++ b/cran/paws.compute/R/ec2instanceconnect_operations.R
@@ -48,7 +48,7 @@ NULL
 #'   AvailabilityZone = "us-west-2a",
 #'   InstanceId = "i-abcd1234",
 #'   InstanceOSUser = "ec2-user",
-#'   SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6dRjfZXQ4HX5..."
+#'   SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6d..."
 #' )
 #' }
 #'

--- a/cran/paws.compute/R/ec2instanceconnect_service.R
+++ b/cran/paws.compute/R/ec2instanceconnect_service.R
@@ -41,7 +41,7 @@ NULL
 #'   AvailabilityZone = "us-west-2a",
 #'   InstanceId = "i-abcd1234",
 #'   InstanceOSUser = "ec2-user",
-#'   SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6dRjfZXQ4HX5..."
+#'   SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6d..."
 #' )
 #' }
 #'

--- a/cran/paws.compute/R/eks_operations.R
+++ b/cran/paws.compute/R/eks_operations.R
@@ -343,7 +343,7 @@ eks_create_addon <- function(clusterName, addonName, addonVersion = NULL, servic
 #'       "subnet-e7e761ac"
 #'     )
 #'   ),
-#'   roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonE..."
+#'   roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRole..."
 #' )
 #' }
 #'

--- a/cran/paws.compute/R/eks_service.R
+++ b/cran/paws.compute/R/eks_service.R
@@ -58,7 +58,7 @@ NULL
 #'       "subnet-e7e761ac"
 #'     )
 #'   ),
-#'   roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonE..."
+#'   roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRole..."
 #' )
 #' }
 #'

--- a/cran/paws.compute/R/elasticbeanstalk_operations.R
+++ b/cran/paws.compute/R/elasticbeanstalk_operations.R
@@ -4373,7 +4373,7 @@ elasticbeanstalk_update_tags_for_resource <- function(ResourceArn, TagsToAdd = N
 #'     list(
 #'       Namespace = "aws:elasticbeanstalk:healthreporting:system",
 #'       OptionName = "ConfigDocument",
-#'       Value = "\{"CloudWatchMetrics": \{"Environment": \{"ApplicationLatencyP99.9": null..."
+#'       Value = "\{\"CloudWatchMetrics\": \{\"Environment\": \{\"ApplicationLatencyP9..."
 #'     )
 #'   )
 #' )

--- a/cran/paws.compute/man/ec2instanceconnect.Rd
+++ b/cran/paws.compute/man/ec2instanceconnect.Rd
@@ -49,7 +49,7 @@ svc$send_ssh_public_key(
   AvailabilityZone = "us-west-2a",
   InstanceId = "i-abcd1234",
   InstanceOSUser = "ec2-user",
-  SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6dRjfZXQ4HX5..."
+  SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6d..."
 )
 }
 

--- a/cran/paws.compute/man/ec2instanceconnect_send_ssh_public_key.Rd
+++ b/cran/paws.compute/man/ec2instanceconnect_send_ssh_public_key.Rd
@@ -48,7 +48,7 @@ svc$send_ssh_public_key(
   AvailabilityZone = "us-west-2a",
   InstanceId = "i-abcd1234",
   InstanceOSUser = "ec2-user",
-  SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6dRjfZXQ4HX5..."
+  SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6d..."
 )
 }
 

--- a/cran/paws.compute/man/eks.Rd
+++ b/cran/paws.compute/man/eks.Rd
@@ -92,7 +92,7 @@ svc$create_cluster(
       "subnet-e7e761ac"
     )
   ),
-  roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonE..."
+  roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRole..."
 )
 }
 

--- a/cran/paws.compute/man/eks_create_cluster.Rd
+++ b/cran/paws.compute/man/eks_create_cluster.Rd
@@ -222,7 +222,7 @@ svc$create_cluster(
       "subnet-e7e761ac"
     )
   ),
-  roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonE..."
+  roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRole..."
 )
 }
 

--- a/cran/paws.compute/man/elasticbeanstalk_validate_configuration_settings.Rd
+++ b/cran/paws.compute/man/elasticbeanstalk_validate_configuration_settings.Rd
@@ -71,7 +71,7 @@ svc$validate_configuration_settings(
     list(
       Namespace = "aws:elasticbeanstalk:healthreporting:system",
       OptionName = "ConfigDocument",
-      Value = "\{"CloudWatchMetrics": \{"Environment": \{"ApplicationLatencyP99.9": null..."
+      Value = "\{\"CloudWatchMetrics\": \{\"Environment\": \{\"ApplicationLatencyP9..."
     )
   )
 )

--- a/cran/paws.cost.management/DESCRIPTION
+++ b/cran/paws.cost.management/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.cost.management
 Title: Amazon Web Services Cost Management Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.customer.engagement/DESCRIPTION
+++ b/cran/paws.customer.engagement/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.customer.engagement
 Title: Amazon Web Services Customer Engagement Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.customer.engagement/R/ses_operations.R
+++ b/cran/paws.customer.engagement/R/ses_operations.R
@@ -2954,7 +2954,7 @@ ses_put_configuration_set_delivery_options <- function(ConfigurationSetName, Del
 #' # identity:
 #' svc$put_identity_policy(
 #'   Identity = "example.com",
-#'   Policy = "\{"Version":"2008-10-17","Statement":[\{"Sid":"stmt1469123904194","Effect":...",
+#'   Policy = "\{"Version":"2008-10-17","Statement":[\{"Sid":"stmt1469123904194"...",
 #'   PolicyName = "MyPolicy"
 #' )
 #' }
@@ -3625,7 +3625,7 @@ ses_send_custom_verification_email <- function(EmailAddress, TemplateName, Confi
 #'     Body = list(
 #'       Html = list(
 #'         Charset = "UTF-8",
-#'         Data = "This message body contains HTML formatting. It can, for example, cont..."
+#'         Data = "This message body contains HTML formatting. It can, for exa..."
 #'       ),
 #'       Text = list(
 #'         Charset = "UTF-8",
@@ -3918,7 +3918,7 @@ ses_send_email <- function(Source, Destination, Message, ReplyToAddresses = NULL
 #'   Destinations = list(),
 #'   FromArn = "",
 #'   RawMessage = list(
-#'     Data = "From: sender@example.com\\nTo: recipient@example.com\\nSubject: Test emai..."
+#'     Data = "From: sender@example.com\\nTo: recipient@example.com\\nSubject:..."
 #'   ),
 #'   ReturnPathArn = "",
 #'   Source = "",

--- a/cran/paws.customer.engagement/man/ses_put_identity_policy.Rd
+++ b/cran/paws.customer.engagement/man/ses_put_identity_policy.Rd
@@ -56,7 +56,7 @@ You can execute this operation no more than once per second.
 # identity:
 svc$put_identity_policy(
   Identity = "example.com",
-  Policy = "\{"Version":"2008-10-17","Statement":[\{"Sid":"stmt1469123904194","Effect":...",
+  Policy = "\{"Version":"2008-10-17","Statement":[\{"Sid":"stmt1469123904194"...",
   PolicyName = "MyPolicy"
 )
 }

--- a/cran/paws.customer.engagement/man/ses_send_email.Rd
+++ b/cran/paws.customer.engagement/man/ses_send_email.Rd
@@ -188,7 +188,7 @@ svc$send_email(
     Body = list(
       Html = list(
         Charset = "UTF-8",
-        Data = "This message body contains HTML formatting. It can, for example, cont..."
+        Data = "This message body contains HTML formatting. It can, for exa..."
       ),
       Text = list(
         Charset = "UTF-8",

--- a/cran/paws.customer.engagement/man/ses_send_raw_email.Rd
+++ b/cran/paws.customer.engagement/man/ses_send_raw_email.Rd
@@ -231,7 +231,7 @@ svc$send_raw_email(
   Destinations = list(),
   FromArn = "",
   RawMessage = list(
-    Data = "From: sender@example.com\\\\nTo: recipient@example.com\\\\nSubject: Test emai..."
+    Data = "From: sender@example.com\\\\nTo: recipient@example.com\\\\nSubject:..."
   ),
   ReturnPathArn = "",
   Source = "",

--- a/cran/paws.database/DESCRIPTION
+++ b/cran/paws.database/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.database
 Title: Amazon Web Services Database Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.database/R/dynamodbstreams_operations.R
+++ b/cran/paws.database/R/dynamodbstreams_operations.R
@@ -78,7 +78,7 @@ NULL
 #' \dontrun{
 #' # The following example describes a stream with a given stream ARN.
 #' svc$describe_stream(
-#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T..."
+#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2..."
 #' )
 #' }
 #'
@@ -240,7 +240,7 @@ dynamodbstreams_describe_stream <- function(StreamArn, Limit = NULL, ExclusiveSt
 #' \dontrun{
 #' # The following example retrieves all the stream records from a shard.
 #' svc$get_records(
-#'   ShardIterator = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05..."
+#'   ShardIterator = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stre..."
 #' )
 #' }
 #'
@@ -328,7 +328,7 @@ dynamodbstreams_get_records <- function(ShardIterator, Limit = NULL) {
 #' svc$get_shard_iterator(
 #'   ShardId = "00000001414576573621-f55eea83",
 #'   ShardIteratorType = "TRIM_HORIZON",
-#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T..."
+#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2..."
 #' )
 #' }
 #'

--- a/cran/paws.database/R/dynamodbstreams_service.R
+++ b/cran/paws.database/R/dynamodbstreams_service.R
@@ -40,7 +40,7 @@ NULL
 #' svc <- dynamodbstreams()
 #' # The following example describes a stream with a given stream ARN.
 #' svc$describe_stream(
-#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T..."
+#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2..."
 #' )
 #' }
 #'

--- a/cran/paws.database/man/dynamodbstreams.Rd
+++ b/cran/paws.database/man/dynamodbstreams.Rd
@@ -50,7 +50,7 @@ in the Amazon DynamoDB Developer Guide.
 svc <- dynamodbstreams()
 # The following example describes a stream with a given stream ARN.
 svc$describe_stream(
-  StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T..."
+  StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2..."
 )
 }
 

--- a/cran/paws.database/man/dynamodbstreams_describe_stream.Rd
+++ b/cran/paws.database/man/dynamodbstreams_describe_stream.Rd
@@ -77,7 +77,7 @@ longer receive more data.
 \dontrun{
 # The following example describes a stream with a given stream ARN.
 svc$describe_stream(
-  StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T..."
+  StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2..."
 )
 }
 

--- a/cran/paws.database/man/dynamodbstreams_get_records.Rd
+++ b/cran/paws.database/man/dynamodbstreams_get_records.Rd
@@ -139,7 +139,7 @@ MB of data or 1000 stream records, whichever comes first.
 \dontrun{
 # The following example retrieves all the stream records from a shard.
 svc$get_records(
-  ShardIterator = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05..."
+  ShardIterator = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stre..."
 )
 }
 

--- a/cran/paws.database/man/dynamodbstreams_get_shard_iterator.Rd
+++ b/cran/paws.database/man/dynamodbstreams_get_shard_iterator.Rd
@@ -65,7 +65,7 @@ requester.
 svc$get_shard_iterator(
   ShardId = "00000001414576573621-f55eea83",
   ShardIteratorType = "TRIM_HORIZON",
-  StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T..."
+  StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2..."
 )
 }
 

--- a/cran/paws.developer.tools/DESCRIPTION
+++ b/cran/paws.developer.tools/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.developer.tools
 Title: Amazon Web Services Developer Tools Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.end.user.computing/DESCRIPTION
+++ b/cran/paws.end.user.computing/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.end.user.computing
 Title: Amazon Web Services End User Computing Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.game.development/DESCRIPTION
+++ b/cran/paws.game.development/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.game.development
 Title: Amazon Web Services Game Development Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.internet.of.things/DESCRIPTION
+++ b/cran/paws.internet.of.things/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.internet.of.things
 Title: Amazon Web Services Internet of Things Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.machine.learning/DESCRIPTION
+++ b/cran/paws.machine.learning/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.machine.learning
 Title: Amazon Web Services Machine Learning Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.management/DESCRIPTION
+++ b/cran/paws.management/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.management
 Title: Amazon Web Services Management & Governance Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.management/R/autoscaling_operations.R
+++ b/cran/paws.management/R/autoscaling_operations.R
@@ -129,7 +129,7 @@ autoscaling_attach_instances <- function(InstanceIds = NULL, AutoScalingGroupNam
 #' svc$attach_load_balancer_target_groups(
 #'   AutoScalingGroupName = "my-auto-scaling-group",
 #'   TargetGroupARNs = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-tar..."
 #'   )
 #' )
 #' }
@@ -830,7 +830,7 @@ autoscaling_complete_lifecycle_action <- function(LifecycleHookName, AutoScaling
 #'   MaxSize = 3L,
 #'   MinSize = 1L,
 #'   TargetGroupARNs = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-tar..."
 #'   ),
 #'   VPCZoneIdentifier = "subnet-057fa0918fEXAMPLE, subnet-610acd08EXAMPLE"
 #' )
@@ -3330,7 +3330,7 @@ autoscaling_detach_instances <- function(InstanceIds = NULL, AutoScalingGroupNam
 #' svc$detach_load_balancer_target_groups(
 #'   AutoScalingGroupName = "my-auto-scaling-group",
 #'   TargetGroupARNs = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-tar..."
 #'   )
 #' )
 #' }
@@ -4272,7 +4272,7 @@ autoscaling_put_notification_configuration <- function(AutoScalingGroupName, Top
 #'   TargetTrackingConfiguration = list(
 #'     PredefinedMetricSpecification = list(
 #'       PredefinedMetricType = "ALBRequestCountPerTarget",
-#'       ResourceLabel = "app/EC2Co-EcsEl-1TKLTMITMM0EO/f37c06a68c1748aa/targetgroup/EC2..."
+#'       ResourceLabel = "app/EC2Co-EcsEl-1TKLTMITMM0EO/f37c06a68c1748aa/targe..."
 #'     ),
 #'     TargetValue = 1000
 #'   )

--- a/cran/paws.management/R/cloudformation_operations.R
+++ b/cran/paws.management/R/cloudformation_operations.R
@@ -1990,8 +1990,9 @@ cloudformation_describe_stack_resource <- function(StackName, LogicalResourceId)
 #' resource that has been checked for drift. Resources that have not yet
 #' been checked for drift are not included. Resources that do not currently
 #' support drift detection are not checked, and so not included. For a list
-#' of resources that support drift detection, see Resources that Support
-#' Drift Detection.
+#' of resources that support drift detection, see [Resources that Support
+#' Drift
+#' Detection](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html).
 #' 
 #' Use
 #' [`detect_stack_resource_drift`][cloudformation_detect_stack_resource_drift]
@@ -2117,8 +2118,9 @@ cloudformation_describe_stack_resource_drifts <- function(StackName, StackResour
 #' You must specify either `StackName` or `PhysicalResourceId`, but not
 #' both. In addition, you can specify `LogicalResourceId` to filter the
 #' returned result. For more information about resources, the
-#' `LogicalResourceId` and `PhysicalResourceId`, go to the AWS
-#' CloudFormation User Guide.
+#' `LogicalResourceId` and `PhysicalResourceId`, go to the [AWS
+#' CloudFormation User
+#' Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/).
 #' 
 #' A `ValidationError` is returned if you specify both `StackName` and
 #' `PhysicalResourceId` in the same request.
@@ -2708,7 +2710,8 @@ cloudformation_describe_type_registration <- function(RegistrationToken) {
 #' to detect drift on individual resources.
 #' 
 #' For a list of stack resources that currently support drift detection,
-#' see Resources that Support Drift Detection.
+#' see [Resources that Support Drift
+#' Detection](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html).
 #' 
 #' [`detect_stack_drift`][cloudformation_detect_stack_drift] can take up to
 #' several minutes, depending on the number of resources contained within
@@ -2791,7 +2794,8 @@ cloudformation_detect_stack_drift <- function(StackName, LogicalResourceIds = NU
 #' 
 #' Resources that do not currently support drift detection cannot be
 #' checked. For a list of resources that support drift detection, see
-#' Resources that Support Drift Detection.
+#' [Resources that Support Drift
+#' Detection](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html).
 #'
 #' @usage
 #' cloudformation_detect_stack_resource_drift(StackName, LogicalResourceId)
@@ -2870,8 +2874,8 @@ cloudformation_detect_stack_resource_drift <- function(StackName, LogicalResourc
 #' Detect drift on a stack set. When CloudFormation performs drift
 #' detection on a stack set, it performs drift detection on the stack
 #' associated with each stack instance in the stack set. For more
-#' information, see How CloudFormation Performs Drift Detection on a Stack
-#' Set.
+#' information, see [How CloudFormation Performs Drift Detection on a Stack
+#' Set](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-drift.html).
 #' 
 #' [`detect_stack_set_drift`][cloudformation_detect_stack_set_drift]
 #' returns the `OperationId` of the stack set drift detection operation.

--- a/cran/paws.management/R/organizations_operations.R
+++ b/cran/paws.management/R/organizations_operations.R
@@ -4962,7 +4962,7 @@ organizations_update_organizational_unit <- function(OrganizationalUnitId, Name 
 #' # the preceding example with a new JSON policy text string that allows S3
 #' # actions instead of EC2 actions:/n/n
 #' svc$update_policy(
-#'   Content = "\{ \"Version\": \"2012-10-17\", \"Statement\": \{\"Effect\": \"Allow\", \"Action\": \"s...",
+#'   Content = "\{ \"Version\": \"2012-10-17\", \"Statement\": \{\"Effect\": \"Allow\", \"A...",
 #'   PolicyId = "p-examplepolicyid111"
 #' )
 #' }

--- a/cran/paws.management/man/autoscaling_attach_load_balancer_target_groups.Rd
+++ b/cran/paws.management/man/autoscaling_attach_load_balancer_target_groups.Rd
@@ -57,7 +57,7 @@ in the \emph{Amazon EC2 Auto Scaling User Guide}.
 svc$attach_load_balancer_target_groups(
   AutoScalingGroupName = "my-auto-scaling-group",
   TargetGroupARNs = list(
-    "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d..."
+    "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-tar..."
   )
 )
 }

--- a/cran/paws.management/man/autoscaling_create_auto_scaling_group.Rd
+++ b/cran/paws.management/man/autoscaling_create_auto_scaling_group.Rd
@@ -317,7 +317,7 @@ svc$create_auto_scaling_group(
   MaxSize = 3L,
   MinSize = 1L,
   TargetGroupARNs = list(
-    "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d..."
+    "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-tar..."
   ),
   VPCZoneIdentifier = "subnet-057fa0918fEXAMPLE, subnet-610acd08EXAMPLE"
 )

--- a/cran/paws.management/man/autoscaling_detach_load_balancer_target_groups.Rd
+++ b/cran/paws.management/man/autoscaling_detach_load_balancer_target_groups.Rd
@@ -37,7 +37,7 @@ group.
 svc$detach_load_balancer_target_groups(
   AutoScalingGroupName = "my-auto-scaling-group",
   TargetGroupARNs = list(
-    "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d..."
+    "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-tar..."
   )
 )
 }

--- a/cran/paws.management/man/autoscaling_put_scaling_policy.Rd
+++ b/cran/paws.management/man/autoscaling_put_scaling_policy.Rd
@@ -184,7 +184,7 @@ svc$put_scaling_policy(
   TargetTrackingConfiguration = list(
     PredefinedMetricSpecification = list(
       PredefinedMetricType = "ALBRequestCountPerTarget",
-      ResourceLabel = "app/EC2Co-EcsEl-1TKLTMITMM0EO/f37c06a68c1748aa/targetgroup/EC2..."
+      ResourceLabel = "app/EC2Co-EcsEl-1TKLTMITMM0EO/f37c06a68c1748aa/targe..."
     ),
     TargetValue = 1000
   )

--- a/cran/paws.management/man/cloudformation_describe_stack_resource_drifts.Rd
+++ b/cran/paws.management/man/cloudformation_describe_stack_resource_drifts.Rd
@@ -79,8 +79,7 @@ For a given stack, there will be one \code{StackResourceDrift} for each stack
 resource that has been checked for drift. Resources that have not yet
 been checked for drift are not included. Resources that do not currently
 support drift detection are not checked, and so not included. For a list
-of resources that support drift detection, see Resources that Support
-Drift Detection.
+of resources that support drift detection, see \href{https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html}{Resources that Support Drift Detection}.
 
 Use
 \code{\link[=cloudformation_detect_stack_resource_drift]{detect_stack_resource_drift}}

--- a/cran/paws.management/man/cloudformation_describe_stack_resources.Rd
+++ b/cran/paws.management/man/cloudformation_describe_stack_resources.Rd
@@ -89,8 +89,7 @@ deleted.
 You must specify either \code{StackName} or \code{PhysicalResourceId}, but not
 both. In addition, you can specify \code{LogicalResourceId} to filter the
 returned result. For more information about resources, the
-\code{LogicalResourceId} and \code{PhysicalResourceId}, go to the AWS
-CloudFormation User Guide.
+\code{LogicalResourceId} and \code{PhysicalResourceId}, go to the \href{https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/}{AWS CloudFormation User Guide}.
 
 A \code{ValidationError} is returned if you specify both \code{StackName} and
 \code{PhysicalResourceId} in the same request.

--- a/cran/paws.management/man/cloudformation_detect_stack_drift.Rd
+++ b/cran/paws.management/man/cloudformation_detect_stack_drift.Rd
@@ -36,7 +36,7 @@ drift on all supported resources for a given stack, or
 to detect drift on individual resources.
 
 For a list of stack resources that currently support drift detection,
-see Resources that Support Drift Detection.
+see \href{https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html}{Resources that Support Drift Detection}.
 
 \code{\link[=cloudformation_detect_stack_drift]{detect_stack_drift}} can take up to
 several minutes, depending on the number of resources contained within

--- a/cran/paws.management/man/cloudformation_detect_stack_resource_drift.Rd
+++ b/cran/paws.management/man/cloudformation_detect_stack_resource_drift.Rd
@@ -66,7 +66,7 @@ drift on all resources in a given stack that support drift detection.
 
 Resources that do not currently support drift detection cannot be
 checked. For a list of resources that support drift detection, see
-Resources that Support Drift Detection.
+\href{https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html}{Resources that Support Drift Detection}.
 }
 \section{Request syntax}{
 \preformatted{svc$detect_stack_resource_drift(

--- a/cran/paws.management/man/cloudformation_detect_stack_set_drift.Rd
+++ b/cran/paws.management/man/cloudformation_detect_stack_set_drift.Rd
@@ -25,8 +25,7 @@ A list with the following syntax:\preformatted{list(
 Detect drift on a stack set. When CloudFormation performs drift
 detection on a stack set, it performs drift detection on the stack
 associated with each stack instance in the stack set. For more
-information, see How CloudFormation Performs Drift Detection on a Stack
-Set.
+information, see \href{https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-drift.html}{How CloudFormation Performs Drift Detection on a Stack Set}.
 
 \code{\link[=cloudformation_detect_stack_set_drift]{detect_stack_set_drift}}
 returns the \code{OperationId} of the stack set drift detection operation.

--- a/cran/paws.management/man/organizations_update_policy.Rd
+++ b/cran/paws.management/man/organizations_update_policy.Rd
@@ -75,7 +75,7 @@ svc$update_policy(
 # the preceding example with a new JSON policy text string that allows S3
 # actions instead of EC2 actions:/n/n
 svc$update_policy(
-  Content = "\{ \"Version\": \"2012-10-17\", \"Statement\": \{\"Effect\": \"Allow\", \"Action\": \"s...",
+  Content = "\{ \"Version\": \"2012-10-17\", \"Statement\": \{\"Effect\": \"Allow\", \"A...",
   PolicyId = "p-examplepolicyid111"
 )
 }

--- a/cran/paws.media.services/DESCRIPTION
+++ b/cran/paws.media.services/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.media.services
 Title: Amazon Web Services Media Services Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.media.services/R/kinesisvideoarchivedmedia_operations.R
+++ b/cran/paws.media.services/R/kinesisvideoarchivedmedia_operations.R
@@ -30,9 +30,9 @@ NULL
 #' 
 #' -   The video track of each fragment must contain codec private data in
 #'     the Advanced Video Coding (AVC) for H.264 format and HEVC for H.265
-#'     format. For more information, see MPEG-4 specification ISO/IEC
-#'     14496-15. For information about adapting stream data to a given
-#'     format, see [NAL Adaptation
+#'     format. For more information, see [MPEG-4 specification ISO/IEC
+#'     14496-15](https://www.iso.org/standard/55980.html). For information
+#'     about adapting stream data to a given format, see [NAL Adaptation
 #'     Flags](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html).
 #' 
 #' -   The audio track (if present) of each fragment must contain codec

--- a/cran/paws.media.services/man/kinesisvideoarchivedmedia_get_clip.Rd
+++ b/cran/paws.media.services/man/kinesisvideoarchivedmedia_get_clip.Rd
@@ -49,9 +49,8 @@ AAC) or A_MS/ACM (for G.711).
 \item Data retention must be greater than 0.
 \item The video track of each fragment must contain codec private data in
 the Advanced Video Coding (AVC) for H.264 format and HEVC for H.265
-format. For more information, see MPEG-4 specification ISO/IEC
-14496-15. For information about adapting stream data to a given
-format, see \href{https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html}{NAL Adaptation Flags}.
+format. For more information, see \href{https://www.iso.org/standard/55980.html}{MPEG-4 specification ISO/IEC 14496-15}. For information
+about adapting stream data to a given format, see \href{https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html}{NAL Adaptation Flags}.
 \item The audio track (if present) of each fragment must contain codec
 private data in the AAC format (\href{https://www.iso.org/standard/43345.html}{AAC specification ISO/IEC 13818-7}) or the \href{http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html}{MS Wave format}.
 }

--- a/cran/paws.migration/DESCRIPTION
+++ b/cran/paws.migration/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.migration
 Title: Amazon Web Services Migration & Transfer Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.migration/R/snowball_operations.R
+++ b/cran/paws.migration/R/snowball_operations.R
@@ -1930,7 +1930,7 @@ snowball_update_cluster <- function(ClusterId, RoleARN = NULL, Description = NUL
 #' # job being created, this action is no longer available.
 #' svc$update_job(
 #'   AddressId = "ADID1234ab12-3eec-4eb3-9be6-9374c10eb51b",
-#'   Description = "Upgraded to Edge, shipped to Finance Dept, and requested faster ship...",
+#'   Description = "Upgraded to Edge, shipped to Finance Dept, and requested f...",
 #'   JobId = "JID123e4567-e89b-12d3-a456-426655440000",
 #'   ShippingOption = "NEXT_DAY",
 #'   SnowballCapacityPreference = "T100"

--- a/cran/paws.migration/man/snowball_update_job.Rd
+++ b/cran/paws.migration/man/snowball_update_job.Rd
@@ -97,7 +97,7 @@ action is no longer available.
 # job being created, this action is no longer available.
 svc$update_job(
   AddressId = "ADID1234ab12-3eec-4eb3-9be6-9374c10eb51b",
-  Description = "Upgraded to Edge, shipped to Finance Dept, and requested faster ship...",
+  Description = "Upgraded to Edge, shipped to Finance Dept, and requested f...",
   JobId = "JID123e4567-e89b-12d3-a456-426655440000",
   ShippingOption = "NEXT_DAY",
   SnowballCapacityPreference = "T100"

--- a/cran/paws.mobile/DESCRIPTION
+++ b/cran/paws.mobile/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.mobile
 Title: Amazon Web Services Mobile Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.mobile/R/devicefarm_operations.R
+++ b/cran/paws.mobile/R/devicefarm_operations.R
@@ -2237,7 +2237,7 @@ devicefarm_get_offering_status <- function(nextToken = NULL) {
 #' \dontrun{
 #' # The following example gets information about a specific project.
 #' svc$get_project(
-#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:project:5e01a8c7-c861-4c0a-b1d5-12..."
+#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:project:5e01a8c7-c861-4c..."
 #' )
 #' }
 #'
@@ -2518,7 +2518,7 @@ devicefarm_get_remote_access_session <- function(arn) {
 #' \dontrun{
 #' # The following example gets information about a specific test run.
 #' svc$get_run(
-#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b1d5-5ec6e6..."
+#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b..."
 #' )
 #' }
 #'
@@ -3003,7 +3003,7 @@ devicefarm_get_vpce_configuration <- function(arn) {
 #' # remote access session.
 #' svc$install_to_remote_access_session(
 #'   appArn = "arn:aws:devicefarm:us-west-2:123456789101:app:EXAMPLE-GUID-123-456",
-#'   remoteAccessSessionArn = "arn:aws:devicefarm:us-west-2:123456789101:session:EXAMPLE..."
+#'   remoteAccessSessionArn = "arn:aws:devicefarm:us-west-2:123456789101:sessi..."
 #' )
 #' }
 #'
@@ -4002,7 +4002,7 @@ devicefarm_list_offerings <- function(nextToken = NULL) {
 #' # The following example returns information about the specified project in
 #' # Device Farm.
 #' svc$list_projects(
-#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:project:7ad300ed-8183-41a7-bf94-12...",
+#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:project:7ad300ed-8183-41...",
 #'   nextToken = "RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE"
 #' )
 #' }
@@ -4301,7 +4301,7 @@ devicefarm_list_remote_access_sessions <- function(arn, nextToken = NULL) {
 #' \dontrun{
 #' # The following example returns information about a specific test run.
 #' svc$list_runs(
-#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b1d5-5ec6e6...",
+#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b...",
 #'   nextToken = "RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE"
 #' )
 #' }
@@ -6575,7 +6575,7 @@ devicefarm_update_network_profile <- function(arn, name = NULL, description = NU
 #' # The following example updates the specified project with a new name.
 #' svc$update_project(
 #'   name = "NewName",
-#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:project:8f75187d-101e-4625-accc-12..."
+#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:project:8f75187d-101e-46..."
 #' )
 #' }
 #'

--- a/cran/paws.mobile/man/devicefarm_get_project.Rd
+++ b/cran/paws.mobile/man/devicefarm_get_project.Rd
@@ -36,7 +36,7 @@ Gets information about a project.
 \dontrun{
 # The following example gets information about a specific project.
 svc$get_project(
-  arn = "arn:aws:devicefarm:us-west-2:123456789101:project:5e01a8c7-c861-4c0a-b1d5-12..."
+  arn = "arn:aws:devicefarm:us-west-2:123456789101:project:5e01a8c7-c861-4c..."
 )
 }
 

--- a/cran/paws.mobile/man/devicefarm_get_run.Rd
+++ b/cran/paws.mobile/man/devicefarm_get_run.Rd
@@ -122,7 +122,7 @@ Gets information about a run.
 \dontrun{
 # The following example gets information about a specific test run.
 svc$get_run(
-  arn = "arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b1d5-5ec6e6..."
+  arn = "arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b..."
 )
 }
 

--- a/cran/paws.mobile/man/devicefarm_install_to_remote_access_session.Rd
+++ b/cran/paws.mobile/man/devicefarm_install_to_remote_access_session.Rd
@@ -51,7 +51,7 @@ applications, the file must be in .ipa format.
 # remote access session.
 svc$install_to_remote_access_session(
   appArn = "arn:aws:devicefarm:us-west-2:123456789101:app:EXAMPLE-GUID-123-456",
-  remoteAccessSessionArn = "arn:aws:devicefarm:us-west-2:123456789101:session:EXAMPLE..."
+  remoteAccessSessionArn = "arn:aws:devicefarm:us-west-2:123456789101:sessi..."
 )
 }
 

--- a/cran/paws.mobile/man/devicefarm_list_projects.Rd
+++ b/cran/paws.mobile/man/devicefarm_list_projects.Rd
@@ -47,7 +47,7 @@ Gets information about projects.
 # The following example returns information about the specified project in
 # Device Farm.
 svc$list_projects(
-  arn = "arn:aws:devicefarm:us-west-2:123456789101:project:7ad300ed-8183-41a7-bf94-12...",
+  arn = "arn:aws:devicefarm:us-west-2:123456789101:project:7ad300ed-8183-41...",
   nextToken = "RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE"
 )
 }

--- a/cran/paws.mobile/man/devicefarm_list_runs.Rd
+++ b/cran/paws.mobile/man/devicefarm_list_runs.Rd
@@ -131,7 +131,7 @@ Gets information about runs, given an AWS Device Farm project ARN.
 \dontrun{
 # The following example returns information about a specific test run.
 svc$list_runs(
-  arn = "arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b1d5-5ec6e6...",
+  arn = "arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b...",
   nextToken = "RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE"
 )
 }

--- a/cran/paws.mobile/man/devicefarm_update_project.Rd
+++ b/cran/paws.mobile/man/devicefarm_update_project.Rd
@@ -47,7 +47,7 @@ name.
 # The following example updates the specified project with a new name.
 svc$update_project(
   name = "NewName",
-  arn = "arn:aws:devicefarm:us-west-2:123456789101:project:8f75187d-101e-4625-accc-12..."
+  arn = "arn:aws:devicefarm:us-west-2:123456789101:project:8f75187d-101e-46..."
 )
 }
 

--- a/cran/paws.networking/DESCRIPTION
+++ b/cran/paws.networking/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.networking
 Title: Amazon Web Services Networking & Content Delivery Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.networking/R/elb_operations.R
+++ b/cran/paws.networking/R/elb_operations.R
@@ -853,7 +853,7 @@ elb_create_load_balancer_listeners <- function(LoadBalancerName, Listeners) {
 #'   PolicyAttributes = list(
 #'     list(
 #'       AttributeName = "PublicKey",
-#'       AttributeValue = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwAYUjnfyEyXr1pxjh..."
+#'       AttributeValue = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwAYUjnf..."
 #'     )
 #'   ),
 #'   PolicyName = "my-PublicKey-policy",

--- a/cran/paws.networking/R/elbv2_operations.R
+++ b/cran/paws.networking/R/elbv2_operations.R
@@ -112,7 +112,7 @@ elbv2_add_listener_certificates <- function(ListenerArn, Certificates) {
 #' # This example adds the specified tags to the specified load balancer.
 #' svc$add_tags(
 #'   ResourceArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
 #'   ),
 #'   Tags = list(
 #'     list(
@@ -390,11 +390,11 @@ elbv2_add_tags <- function(ResourceArns, Tags) {
 #' svc$create_listener(
 #'   DefaultActions = list(
 #'     list(
-#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgro...",
+#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012...",
 #'       Type = "forward"
 #'     )
 #'   ),
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer...",
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo...",
 #'   Port = 80L,
 #'   Protocol = "HTTP"
 #' )
@@ -414,11 +414,11 @@ elbv2_add_tags <- function(ResourceArns, Tags) {
 #'   ),
 #'   DefaultActions = list(
 #'     list(
-#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgro...",
+#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012...",
 #'       Type = "forward"
 #'     )
 #'   ),
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer...",
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo...",
 #'   Port = 443L,
 #'   Protocol = "HTTPS",
 #'   SslPolicy = "ELBSecurityPolicy-2015-05"
@@ -928,7 +928,7 @@ elbv2_create_load_balancer <- function(Name, Subnets = NULL, SubnetMappings = NU
 #' svc$create_rule(
 #'   Actions = list(
 #'     list(
-#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgro...",
+#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012...",
 #'       Type = "forward"
 #'     )
 #'   ),
@@ -940,7 +940,7 @@ elbv2_create_load_balancer <- function(Name, Subnets = NULL, SubnetMappings = NU
 #'       )
 #'     )
 #'   ),
-#'   ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-...",
+#'   ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listen...",
 #'   Priority = 10L
 #' )
 #' }
@@ -1199,7 +1199,7 @@ elbv2_create_target_group <- function(Name, Protocol = NULL, ProtocolVersion = N
 #' \dontrun{
 #' # This example deletes the specified listener.
 #' svc$delete_listener(
-#'   ListenerArn = "arn:aws:elasticloadbalancing:ua-west-2:123456789012:listener/app/my-..."
+#'   ListenerArn = "arn:aws:elasticloadbalancing:ua-west-2:123456789012:listen..."
 #' )
 #' }
 #'
@@ -1259,7 +1259,7 @@ elbv2_delete_listener <- function(ListenerArn) {
 #' \dontrun{
 #' # This example deletes the specified load balancer.
 #' svc$delete_load_balancer(
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 #' )
 #' }
 #'
@@ -1309,7 +1309,7 @@ elbv2_delete_load_balancer <- function(LoadBalancerArn) {
 #' \dontrun{
 #' # This example deletes the specified rule.
 #' svc$delete_rule(
-#'   RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/my..."
+#'   RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-r..."
 #' )
 #' }
 #'
@@ -1363,7 +1363,7 @@ elbv2_delete_rule <- function(RuleArn) {
 #' \dontrun{
 #' # This example deletes the specified target group.
 #' svc$delete_target_group(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 #' )
 #' }
 #'
@@ -1424,7 +1424,7 @@ elbv2_delete_target_group <- function(TargetGroupArn) {
 #' # This example deregisters the specified instance from the specified
 #' # target group.
 #' svc$deregister_targets(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m...",
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar...",
 #'   Targets = list(
 #'     list(
 #'       Id = "i-0f76fade"
@@ -1711,7 +1711,7 @@ elbv2_describe_listener_certificates <- function(ListenerArn, Marker = NULL, Pag
 #' # This example describes the specified listener.
 #' svc$describe_listeners(
 #'   ListenerArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-load-balance..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-lo..."
 #'   )
 #' )
 #' }
@@ -1786,7 +1786,7 @@ elbv2_describe_listeners <- function(LoadBalancerArn = NULL, ListenerArns = NULL
 #' \dontrun{
 #' # This example describes the attributes of the specified load balancer.
 #' svc$describe_load_balancer_attributes(
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 #' )
 #' }
 #'
@@ -1890,7 +1890,7 @@ elbv2_describe_load_balancer_attributes <- function(LoadBalancerArn) {
 #' # This example describes the specified load balancer.
 #' svc$describe_load_balancers(
 #'   LoadBalancerArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
 #'   )
 #' )
 #' }
@@ -2064,7 +2064,7 @@ elbv2_describe_load_balancers <- function(LoadBalancerArns = NULL, Names = NULL,
 #' # This example describes the specified rule.
 #' svc$describe_rules(
 #'   RuleArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/my-load-ba..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/..."
 #'   )
 #' )
 #' }
@@ -2219,7 +2219,7 @@ elbv2_describe_ssl_policies <- function(Names = NULL, Marker = NULL, PageSize = 
 #' # This example describes the tags assigned to the specified load balancer.
 #' svc$describe_tags(
 #'   ResourceArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
 #'   )
 #' )
 #' }
@@ -2292,7 +2292,7 @@ elbv2_describe_tags <- function(ResourceArns) {
 #' \dontrun{
 #' # This example describes the attributes of the specified target group.
 #' svc$describe_target_group_attributes(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 #' )
 #' }
 #'
@@ -2390,7 +2390,7 @@ elbv2_describe_target_group_attributes <- function(TargetGroupArn) {
 #' # This example describes the specified target group.
 #' svc$describe_target_groups(
 #'   TargetGroupArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-tar..."
 #'   )
 #' )
 #' }
@@ -2468,13 +2468,13 @@ elbv2_describe_target_groups <- function(LoadBalancerArn = NULL, TargetGroupArns
 #' # target group. One target is healthy but the other is not specified in an
 #' # action, so it can't receive traffic from the load balancer.
 #' svc$describe_target_health(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 #' )
 #' 
 #' # This example describes the health of the specified target. This target
 #' # is healthy.
 #' svc$describe_target_health(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m...",
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar...",
 #'   Targets = list(
 #'     list(
 #'       Id = "i-0f76fade",
@@ -2731,11 +2731,11 @@ elbv2_describe_target_health <- function(TargetGroupArn, Targets = NULL) {
 #' svc$modify_listener(
 #'   DefaultActions = list(
 #'     list(
-#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgro...",
+#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012...",
 #'       Type = "forward"
 #'     )
 #'   ),
-#'   ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-..."
+#'   ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listen..."
 #' )
 #' 
 #' # This example changes the server certificate for the specified HTTPS
@@ -2746,7 +2746,7 @@ elbv2_describe_target_health <- function(TargetGroupArn, Targets = NULL) {
 #'       CertificateArn = "arn:aws:iam::123456789012:server-certificate/my-new-server-cert"
 #'     )
 #'   ),
-#'   ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-..."
+#'   ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listen..."
 #' )
 #' }
 #'
@@ -2824,7 +2824,7 @@ elbv2_modify_listener <- function(ListenerArn, Port = NULL, Protocol = NULL, Ssl
 #'       Value = "true"
 #'     )
 #'   ),
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 #' )
 #' 
 #' # This example changes the idle timeout value for the specified load
@@ -2836,7 +2836,7 @@ elbv2_modify_listener <- function(ListenerArn, Port = NULL, Protocol = NULL, Ssl
 #'       Value = "30"
 #'     )
 #'   ),
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 #' )
 #' 
 #' # This example enables access logs for the specified load balancer. Note
@@ -2858,7 +2858,7 @@ elbv2_modify_listener <- function(ListenerArn, Port = NULL, Protocol = NULL, Ssl
 #'       Value = "myapp"
 #'     )
 #'   ),
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 #' )
 #' }
 #'
@@ -3136,7 +3136,7 @@ elbv2_modify_load_balancer_attributes <- function(LoadBalancerArn, Attributes) {
 #'       )
 #'     )
 #'   ),
-#'   RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/my..."
+#'   RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-r..."
 #' )
 #' }
 #'
@@ -3268,7 +3268,7 @@ elbv2_modify_rule <- function(RuleArn, Conditions = NULL, Actions = NULL) {
 #' svc$modify_target_group(
 #'   HealthCheckPort = "443",
 #'   HealthCheckProtocol = "HTTPS",
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 #' )
 #' }
 #'
@@ -3340,7 +3340,7 @@ elbv2_modify_target_group <- function(TargetGroupArn, HealthCheckProtocol = NULL
 #'       Value = "600"
 #'     )
 #'   ),
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 #' )
 #' }
 #'
@@ -3411,7 +3411,7 @@ elbv2_modify_target_group_attributes <- function(TargetGroupArn, Attributes) {
 #' # This example registers the specified instances with the specified target
 #' # group.
 #' svc$register_targets(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m...",
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar...",
 #'   Targets = list(
 #'     list(
 #'       Id = "i-80c8dd94"
@@ -3426,7 +3426,7 @@ elbv2_modify_target_group_attributes <- function(TargetGroupArn, Attributes) {
 #' # group using multiple ports. This enables you to register ECS containers
 #' # on the same instance as targets in the target group.
 #' svc$register_targets(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m...",
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar...",
 #'   Targets = list(
 #'     list(
 #'       Id = "i-80c8dd94",
@@ -3546,7 +3546,7 @@ elbv2_remove_listener_certificates <- function(ListenerArn, Certificates) {
 #' # balancer.
 #' svc$remove_tags(
 #'   ResourceArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
 #'   ),
 #'   TagKeys = list(
 #'     "project",
@@ -3776,7 +3776,7 @@ elbv2_set_ip_address_type <- function(LoadBalancerArn, IpAddressType) {
 #'   RulePriorities = list(
 #'     list(
 #'       Priority = 5L,
-#'       RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/ap..."
+#'       RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listen..."
 #'     )
 #'   )
 #' )
@@ -3844,7 +3844,7 @@ elbv2_set_rule_priorities <- function(RulePriorities) {
 #' # This example associates the specified security group with the specified
 #' # load balancer.
 #' svc$set_security_groups(
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer...",
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo...",
 #'   SecurityGroups = list(
 #'     "sg-5943793c"
 #'   )
@@ -3974,7 +3974,7 @@ elbv2_set_security_groups <- function(LoadBalancerArn, SecurityGroups) {
 #' # This example enables the Availability Zones for the specified subnets
 #' # for the specified load balancer.
 #' svc$set_subnets(
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer...",
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo...",
 #'   Subnets = list(
 #'     "subnet-8360a9e7",
 #'     "subnet-b7d581c0"

--- a/cran/paws.networking/R/elbv2_service.R
+++ b/cran/paws.networking/R/elbv2_service.R
@@ -63,7 +63,7 @@ NULL
 #' # This example adds the specified tags to the specified load balancer.
 #' svc$add_tags(
 #'   ResourceArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
 #'   ),
 #'   Tags = list(
 #'     list(

--- a/cran/paws.networking/R/servicediscovery_operations.R
+++ b/cran/paws.networking/R/servicediscovery_operations.R
@@ -1815,7 +1815,7 @@ servicediscovery_register_instance <- function(ServiceId, InstanceId, CreatorReq
 #' \dontrun{
 #' # This example adds "Department" and "Project" tags to a resource.
 #' svc$tag_resource(
-#'   ResourceARN = "arn:aws:servicediscovery:us-east-1:123456789012:namespace/ns-ylexjil...",
+#'   ResourceARN = "arn:aws:servicediscovery:us-east-1:123456789012:namespace/...",
 #'   Tags = list(
 #'     list(
 #'       Key = "Department",
@@ -1879,7 +1879,7 @@ servicediscovery_tag_resource <- function(ResourceARN, Tags) {
 #' # This example removes the "Department" and "Project" tags from a
 #' # resource.
 #' svc$untag_resource(
-#'   ResourceARN = "arn:aws:servicediscovery:us-east-1:123456789012:namespace/ns-ylexjil...",
+#'   ResourceARN = "arn:aws:servicediscovery:us-east-1:123456789012:namespace/...",
 #'   TagKeys = list(
 #'     "Project",
 #'     "Department"

--- a/cran/paws.networking/man/elb_create_load_balancer_policy.Rd
+++ b/cran/paws.networking/man/elb_create_load_balancer_policy.Rd
@@ -67,7 +67,7 @@ svc$create_load_balancer_policy(
   PolicyAttributes = list(
     list(
       AttributeName = "PublicKey",
-      AttributeValue = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwAYUjnfyEyXr1pxjh..."
+      AttributeValue = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwAYUjnf..."
     )
   ),
   PolicyName = "my-PublicKey-policy",

--- a/cran/paws.networking/man/elbv2.Rd
+++ b/cran/paws.networking/man/elbv2.Rd
@@ -102,7 +102,7 @@ svc <- elbv2()
 # This example adds the specified tags to the specified load balancer.
 svc$add_tags(
   ResourceArns = list(
-    "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+    "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
   ),
   Tags = list(
     list(

--- a/cran/paws.networking/man/elbv2_add_tags.Rd
+++ b/cran/paws.networking/man/elbv2_add_tags.Rd
@@ -43,7 +43,7 @@ value.
 # This example adds the specified tags to the specified load balancer.
 svc$add_tags(
   ResourceArns = list(
-    "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+    "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
   ),
   Tags = list(
     list(

--- a/cran/paws.networking/man/elbv2_create_listener.Rd
+++ b/cran/paws.networking/man/elbv2_create_listener.Rd
@@ -240,11 +240,11 @@ settings, each call succeeds.
 svc$create_listener(
   DefaultActions = list(
     list(
-      TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgro...",
+      TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012...",
       Type = "forward"
     )
   ),
-  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer...",
+  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo...",
   Port = 80L,
   Protocol = "HTTP"
 )
@@ -264,11 +264,11 @@ svc$create_listener(
   ),
   DefaultActions = list(
     list(
-      TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgro...",
+      TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012...",
       Type = "forward"
     )
   ),
-  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer...",
+  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo...",
   Port = 443L,
   Protocol = "HTTPS",
   SslPolicy = "ELBSecurityPolicy-2015-05"

--- a/cran/paws.networking/man/elbv2_create_rule.Rd
+++ b/cran/paws.networking/man/elbv2_create_rule.Rd
@@ -268,7 +268,7 @@ in the \emph{Application Load Balancers Guide}.
 svc$create_rule(
   Actions = list(
     list(
-      TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgro...",
+      TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012...",
       Type = "forward"
     )
   ),
@@ -280,7 +280,7 @@ svc$create_rule(
       )
     )
   ),
-  ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-...",
+  ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listen...",
   Priority = 10L
 )
 }

--- a/cran/paws.networking/man/elbv2_delete_listener.Rd
+++ b/cran/paws.networking/man/elbv2_delete_listener.Rd
@@ -29,7 +29,7 @@ balancer to which it is attached.
 \dontrun{
 # This example deletes the specified listener.
 svc$delete_listener(
-  ListenerArn = "arn:aws:elasticloadbalancing:ua-west-2:123456789012:listener/app/my-..."
+  ListenerArn = "arn:aws:elasticloadbalancing:ua-west-2:123456789012:listen..."
 )
 }
 

--- a/cran/paws.networking/man/elbv2_delete_load_balancer.Rd
+++ b/cran/paws.networking/man/elbv2_delete_load_balancer.Rd
@@ -38,7 +38,7 @@ stop or terminate them.
 \dontrun{
 # This example deletes the specified load balancer.
 svc$delete_load_balancer(
-  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 )
 }
 

--- a/cran/paws.networking/man/elbv2_delete_rule.Rd
+++ b/cran/paws.networking/man/elbv2_delete_rule.Rd
@@ -28,7 +28,7 @@ You can't delete the default rule.
 \dontrun{
 # This example deletes the specified rule.
 svc$delete_rule(
-  RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/my..."
+  RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-r..."
 )
 }
 

--- a/cran/paws.networking/man/elbv2_delete_target_group.Rd
+++ b/cran/paws.networking/man/elbv2_delete_target_group.Rd
@@ -32,7 +32,7 @@ them.
 \dontrun{
 # This example deletes the specified target group.
 svc$delete_target_group(
-  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 )
 }
 

--- a/cran/paws.networking/man/elbv2_deregister_targets.Rd
+++ b/cran/paws.networking/man/elbv2_deregister_targets.Rd
@@ -40,7 +40,7 @@ load balancer.
 # This example deregisters the specified instance from the specified
 # target group.
 svc$deregister_targets(
-  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m...",
+  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar...",
   Targets = list(
     list(
       Id = "i-0f76fade"

--- a/cran/paws.networking/man/elbv2_describe_listeners.Rd
+++ b/cran/paws.networking/man/elbv2_describe_listeners.Rd
@@ -126,7 +126,7 @@ listeners.
 # This example describes the specified listener.
 svc$describe_listeners(
   ListenerArns = list(
-    "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-load-balance..."
+    "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-lo..."
   )
 )
 }

--- a/cran/paws.networking/man/elbv2_describe_load_balancer_attributes.Rd
+++ b/cran/paws.networking/man/elbv2_describe_load_balancer_attributes.Rd
@@ -46,7 +46,7 @@ in the \emph{Gateway Load Balancers Guide}
 \dontrun{
 # This example describes the attributes of the specified load balancer.
 svc$describe_load_balancer_attributes(
-  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 )
 }
 

--- a/cran/paws.networking/man/elbv2_describe_load_balancers.Rd
+++ b/cran/paws.networking/man/elbv2_describe_load_balancers.Rd
@@ -83,7 +83,7 @@ Describes the specified load balancers or all of your load balancers.
 # This example describes the specified load balancer.
 svc$describe_load_balancers(
   LoadBalancerArns = list(
-    "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+    "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
   )
 )
 }

--- a/cran/paws.networking/man/elbv2_describe_rules.Rd
+++ b/cran/paws.networking/man/elbv2_describe_rules.Rd
@@ -152,7 +152,7 @@ You must specify either a listener or one or more rules.
 # This example describes the specified rule.
 svc$describe_rules(
   RuleArns = list(
-    "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/my-load-ba..."
+    "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/..."
   )
 )
 }

--- a/cran/paws.networking/man/elbv2_describe_tags.Rd
+++ b/cran/paws.networking/man/elbv2_describe_tags.Rd
@@ -46,7 +46,7 @@ listeners, or rules.
 # This example describes the tags assigned to the specified load balancer.
 svc$describe_tags(
   ResourceArns = list(
-    "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+    "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
   )
 )
 }

--- a/cran/paws.networking/man/elbv2_describe_target_group_attributes.Rd
+++ b/cran/paws.networking/man/elbv2_describe_target_group_attributes.Rd
@@ -44,7 +44,7 @@ in the \emph{Gateway Load Balancers Guide}
 \dontrun{
 # This example describes the attributes of the specified target group.
 svc$describe_target_group_attributes(
-  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 )
 }
 

--- a/cran/paws.networking/man/elbv2_describe_target_groups.Rd
+++ b/cran/paws.networking/man/elbv2_describe_target_groups.Rd
@@ -78,7 +78,7 @@ more target groups.
 # This example describes the specified target group.
 svc$describe_target_groups(
   TargetGroupArns = list(
-    "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d..."
+    "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-tar..."
   )
 )
 }

--- a/cran/paws.networking/man/elbv2_describe_target_health.Rd
+++ b/cran/paws.networking/man/elbv2_describe_target_health.Rd
@@ -54,13 +54,13 @@ Describes the health of the specified targets or all of your targets.
 # target group. One target is healthy but the other is not specified in an
 # action, so it can't receive traffic from the load balancer.
 svc$describe_target_health(
-  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 )
 
 # This example describes the health of the specified target. This target
 # is healthy.
 svc$describe_target_health(
-  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m...",
+  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar...",
   Targets = list(
     list(
       Id = "i-0f76fade",

--- a/cran/paws.networking/man/elbv2_modify_listener.Rd
+++ b/cran/paws.networking/man/elbv2_modify_listener.Rd
@@ -227,11 +227,11 @@ action, specify a list with the current actions plus the new action.
 svc$modify_listener(
   DefaultActions = list(
     list(
-      TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgro...",
+      TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012...",
       Type = "forward"
     )
   ),
-  ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-..."
+  ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listen..."
 )
 
 # This example changes the server certificate for the specified HTTPS
@@ -242,7 +242,7 @@ svc$modify_listener(
       CertificateArn = "arn:aws:iam::123456789012:server-certificate/my-new-server-cert"
     )
   ),
-  ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-..."
+  ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listen..."
 )
 }
 

--- a/cran/paws.networking/man/elbv2_modify_load_balancer_attributes.Rd
+++ b/cran/paws.networking/man/elbv2_modify_load_balancer_attributes.Rd
@@ -55,7 +55,7 @@ svc$modify_load_balancer_attributes(
       Value = "true"
     )
   ),
-  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 )
 
 # This example changes the idle timeout value for the specified load
@@ -67,7 +67,7 @@ svc$modify_load_balancer_attributes(
       Value = "30"
     )
   ),
-  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 )
 
 # This example enables access logs for the specified load balancer. Note
@@ -89,7 +89,7 @@ svc$modify_load_balancer_attributes(
       Value = "myapp"
     )
   ),
-  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 )
 }
 

--- a/cran/paws.networking/man/elbv2_modify_rule.Rd
+++ b/cran/paws.networking/man/elbv2_modify_rule.Rd
@@ -256,7 +256,7 @@ svc$modify_rule(
       )
     )
   ),
-  RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/my..."
+  RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-r..."
 )
 }
 

--- a/cran/paws.networking/man/elbv2_modify_target_group.Rd
+++ b/cran/paws.networking/man/elbv2_modify_target_group.Rd
@@ -117,7 +117,7 @@ targets in the specified target group.
 svc$modify_target_group(
   HealthCheckPort = "443",
   HealthCheckProtocol = "HTTPS",
-  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 )
 }
 

--- a/cran/paws.networking/man/elbv2_modify_target_group_attributes.Rd
+++ b/cran/paws.networking/man/elbv2_modify_target_group_attributes.Rd
@@ -49,7 +49,7 @@ svc$modify_target_group_attributes(
       Value = "600"
     )
   ),
-  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 )
 }
 

--- a/cran/paws.networking/man/elbv2_register_targets.Rd
+++ b/cran/paws.networking/man/elbv2_register_targets.Rd
@@ -50,7 +50,7 @@ instances of these types by IP address.
 # This example registers the specified instances with the specified target
 # group.
 svc$register_targets(
-  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m...",
+  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar...",
   Targets = list(
     list(
       Id = "i-80c8dd94"
@@ -65,7 +65,7 @@ svc$register_targets(
 # group using multiple ports. This enables you to register ECS containers
 # on the same instance as targets in the target group.
 svc$register_targets(
-  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m...",
+  TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar...",
   Targets = list(
     list(
       Id = "i-80c8dd94",

--- a/cran/paws.networking/man/elbv2_remove_tags.Rd
+++ b/cran/paws.networking/man/elbv2_remove_tags.Rd
@@ -39,7 +39,7 @@ groups, listeners, or rules.
 # balancer.
 svc$remove_tags(
   ResourceArns = list(
-    "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+    "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
   ),
   TagKeys = list(
     "project",

--- a/cran/paws.networking/man/elbv2_set_rule_priorities.Rd
+++ b/cran/paws.networking/man/elbv2_set_rule_priorities.Rd
@@ -149,7 +149,7 @@ svc$set_rule_priorities(
   RulePriorities = list(
     list(
       Priority = 5L,
-      RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/ap..."
+      RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listen..."
     )
   )
 )

--- a/cran/paws.networking/man/elbv2_set_security_groups.Rd
+++ b/cran/paws.networking/man/elbv2_set_security_groups.Rd
@@ -43,7 +43,7 @@ Gateway Load Balancer.
 # This example associates the specified security group with the specified
 # load balancer.
 svc$set_security_groups(
-  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer...",
+  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo...",
   SecurityGroups = list(
     "sg-5943793c"
   )

--- a/cran/paws.networking/man/elbv2_set_subnets.Rd
+++ b/cran/paws.networking/man/elbv2_set_subnets.Rd
@@ -106,7 +106,7 @@ configurations, plus any additional subnets.
 # This example enables the Availability Zones for the specified subnets
 # for the specified load balancer.
 svc$set_subnets(
-  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer...",
+  LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo...",
   Subnets = list(
     "subnet-8360a9e7",
     "subnet-b7d581c0"

--- a/cran/paws.networking/man/servicediscovery_tag_resource.Rd
+++ b/cran/paws.networking/man/servicediscovery_tag_resource.Rd
@@ -37,7 +37,7 @@ Adds one or more tags to the specified resource.
 \dontrun{
 # This example adds "Department" and "Project" tags to a resource.
 svc$tag_resource(
-  ResourceARN = "arn:aws:servicediscovery:us-east-1:123456789012:namespace/ns-ylexjil...",
+  ResourceARN = "arn:aws:servicediscovery:us-east-1:123456789012:namespace/...",
   Tags = list(
     list(
       Key = "Department",

--- a/cran/paws.networking/man/servicediscovery_untag_resource.Rd
+++ b/cran/paws.networking/man/servicediscovery_untag_resource.Rd
@@ -33,7 +33,7 @@ Removes one or more tags from the specified resource.
 # This example removes the "Department" and "Project" tags from a
 # resource.
 svc$untag_resource(
-  ResourceARN = "arn:aws:servicediscovery:us-east-1:123456789012:namespace/ns-ylexjil...",
+  ResourceARN = "arn:aws:servicediscovery:us-east-1:123456789012:namespace/...",
   TagKeys = list(
     "Project",
     "Department"

--- a/cran/paws.robotics/DESCRIPTION
+++ b/cran/paws.robotics/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.robotics
 Title: Amazon Web Services Robotics Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.security.identity/DESCRIPTION
+++ b/cran/paws.security.identity/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.security.identity
 Title: Amazon Web Services Security, Identity, & Compliance Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.security.identity/R/iam_operations.R
+++ b/cran/paws.security.identity/R/iam_operations.R
@@ -473,7 +473,7 @@ iam_attach_user_policy <- function(UserName, PolicyArn) {
 #' \dontrun{
 #' # The following command changes the password for the current IAM user.
 #' svc$change_password(
-#'   NewPassword = "]35d/{pB9Fo9wJ",
+#'   NewPassword = "]35d/\{pB9Fo9wJ",
 #'   OldPassword = "3s0K_;xh4~8XXI"
 #' )
 #' }
@@ -909,7 +909,7 @@ iam_create_instance_profile <- function(InstanceProfileName, Path = NULL) {
 #' # The following command changes IAM user Bob's password and sets the flag
 #' # that required Bob to change the password the next time he signs in.
 #' svc$create_login_profile(
-#'   Password = "h]6EszR}vJ*m",
+#'   Password = "h]6EszR\}vJ*m",
 #'   PasswordResetRequired = TRUE,
 #'   UserName = "Bob"
 #' )
@@ -9083,7 +9083,7 @@ iam_list_virtual_mfa_devices <- function(AssignmentStatus = NULL, Marker = NULL,
 #' # named Admins.
 #' svc$put_group_policy(
 #'   GroupName = "Admins",
-#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"Action\":\"*...",
+#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"...",
 #'   PolicyName = "AllPerms"
 #' )
 #' }
@@ -9254,7 +9254,7 @@ iam_put_role_permissions_boundary <- function(RoleName, PermissionsBoundary) {
 #' # The following command adds a permissions policy to the role named
 #' # Test-Role.
 #' svc$put_role_policy(
-#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"Action\":\"s...",
+#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"...",
 #'   PolicyName = "S3AccessPolicy",
 #'   RoleName = "S3Access"
 #' )
@@ -9414,7 +9414,7 @@ iam_put_user_permissions_boundary <- function(UserName, PermissionsBoundary) {
 #' \dontrun{
 #' # The following command attaches a policy to the IAM user named Bob.
 #' svc$put_user_policy(
-#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"Action\":\"*...",
+#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"...",
 #'   PolicyName = "AllAccessPolicy",
 #'   UserName = "Bob"
 #' )
@@ -11199,7 +11199,7 @@ iam_update_account_password_policy <- function(MinimumPasswordLength = NULL, Req
 #' # The following command updates the role trust policy for the role named
 #' # Test-Role:
 #' svc$update_assume_role_policy(
-#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Effect\":\"Allow\",\"Principal...",
+#'   PolicyDocument = "\{"Version":"2012-10-17","Statement":[\{"Effect":"Allow",...",
 #'   RoleName = "S3AccessForEC2Instances"
 #' )
 #' }
@@ -12275,9 +12275,9 @@ iam_upload_ssh_public_key <- function(UserName, SSHPublicKeyBody) {
 #' # The following upload-server-certificate command uploads a server
 #' # certificate to your AWS account:
 #' svc$upload_server_certificate(
-#'   CertificateBody = "-----BEGIN CERTIFICATE-----<a very long certificate text string>...",
+#'   CertificateBody = "-----BEGIN CERTIFICATE-----<a very long certificate te...",
 #'   Path = "/company/servercerts/",
-#'   PrivateKey = "-----BEGIN DSA PRIVATE KEY-----<a very long private key string>-----E...",
+#'   PrivateKey = "-----BEGIN DSA PRIVATE KEY-----<a very long private key str...",
 #'   ServerCertificateName = "ProdServerCert"
 #' )
 #' }

--- a/cran/paws.security.identity/R/inspector_operations.R
+++ b/cran/paws.security.identity/R/inspector_operations.R
@@ -57,7 +57,7 @@ NULL
 #'     )
 #'   ),
 #'   findingArns = list(
-#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-8l1VIE0D/r..."
+#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
 #'   )
 #' )
 #' }
@@ -409,7 +409,7 @@ inspector_create_resource_group <- function(resourceGroupTags) {
 #' # Deletes the assessment run that is specified by the ARN of the
 #' # assessment run.
 #' svc$delete_assessment_run(
-#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/temp..."
+#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvg..."
 #' )
 #' }
 #'
@@ -511,7 +511,7 @@ inspector_delete_assessment_target <- function(assessmentTargetArn) {
 #' # Deletes the assessment template that is specified by the ARN of the
 #' # assessment template.
 #' svc$delete_assessment_template(
-#'   assessmentTemplateArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX..."
+#'   assessmentTemplateArn = "arn:aws:inspector:us-west-2:123456789012:target/..."
 #' )
 #' }
 #'
@@ -629,7 +629,7 @@ inspector_delete_assessment_template <- function(assessmentTemplateArn) {
 #' # assessment runs.
 #' svc$describe_assessment_runs(
 #'   assessmentRunArns = list(
-#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/r..."
+#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
 #'   )
 #' )
 #' }
@@ -1069,7 +1069,7 @@ inspector_describe_exclusions <- function(exclusionArns, locale = NULL) {
 #' # Describes the findings that are specified by the ARNs of the findings.
 #' svc$describe_findings(
 #'   findingArns = list(
-#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/r..."
+#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
 #'   )
 #' )
 #' }
@@ -1431,7 +1431,7 @@ inspector_get_exclusions_preview <- function(assessmentTemplateArn, previewToken
 #' # Information about the data that is collected for the specified
 #' # assessment run.
 #' svc$get_telemetry_metadata(
-#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/temp..."
+#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kF..."
 #' )
 #' }
 #'
@@ -1529,7 +1529,7 @@ inspector_get_telemetry_metadata <- function(assessmentRunArn) {
 #' # Lists the agents of the assessment runs that are specified by the ARNs
 #' # of the assessment runs.
 #' svc$list_assessment_run_agents(
-#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/temp...",
+#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kF...",
 #'   maxResults = 123L
 #' )
 #' }
@@ -1898,7 +1898,7 @@ inspector_list_assessment_templates <- function(assessmentTargetArns = NULL, fil
 #' # specified by the ARN of the assessment template.
 #' svc$list_event_subscriptions(
 #'   maxResults = 123L,
-#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/..."
+#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX..."
 #' )
 #' }
 #'
@@ -2073,7 +2073,7 @@ inspector_list_exclusions <- function(assessmentRunArn, nextToken = NULL, maxRes
 #' # specified by the ARNs of the assessment runs.
 #' svc$list_findings(
 #'   assessmentRunArns = list(
-#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/r..."
+#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
 #'   ),
 #'   maxResults = 123L
 #' )
@@ -2197,7 +2197,7 @@ inspector_list_rules_packages <- function(nextToken = NULL, maxResults = NULL) {
 #' \dontrun{
 #' # Lists all tags associated with an assessment template.
 #' svc$list_tags_for_resource(
-#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/..."
+#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq..."
 #' )
 #' }
 #'
@@ -2404,7 +2404,7 @@ inspector_register_cross_account_access_role <- function(roleArn) {
 #'     "key=Example,value=example"
 #'   ),
 #'   findingArns = list(
-#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-8l1VIE0D/r..."
+#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
 #'   )
 #' )
 #' }
@@ -2464,7 +2464,7 @@ inspector_remove_attributes_from_findings <- function(findingArns, attributeKeys
 #' # Sets tags (key and value pairs) to the assessment template that is
 #' # specified by the ARN of the assessment template.
 #' svc$set_tags_for_resource(
-#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/...",
+#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX...",
 #'   tags = list(
 #'     list(
 #'       key = "Example",
@@ -2534,7 +2534,7 @@ inspector_set_tags_for_resource <- function(resourceArn, tags = NULL) {
 #' # limit of running up to 500 concurrent agents per AWS account.
 #' svc$start_assessment_run(
 #'   assessmentRunName = "examplerun",
-#'   assessmentTemplateArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX..."
+#'   assessmentTemplateArn = "arn:aws:inspector:us-west-2:123456789012:target/..."
 #' )
 #' }
 #'
@@ -2591,7 +2591,7 @@ inspector_start_assessment_run <- function(assessmentTemplateArn, assessmentRunN
 #' # Stops the assessment run that is specified by the ARN of the assessment
 #' # run.
 #' svc$stop_assessment_run(
-#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/temp..."
+#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvg..."
 #' )
 #' }
 #'
@@ -2648,7 +2648,7 @@ inspector_stop_assessment_run <- function(assessmentRunArn, stopAction = NULL) {
 #' # notifications about a specified event to a specified SNS topic.
 #' svc$subscribe_to_event(
 #'   event = "ASSESSMENT_RUN_COMPLETED",
-#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/...",
+#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX...",
 #'   topicArn = "arn:aws:sns:us-west-2:123456789012:exampletopic"
 #' )
 #' }
@@ -2706,7 +2706,7 @@ inspector_subscribe_to_event <- function(resourceArn, event, topicArn) {
 #' # notifications about a specified event to a specified SNS topic.
 #' svc$unsubscribe_from_event(
 #'   event = "ASSESSMENT_RUN_COMPLETED",
-#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/...",
+#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX...",
 #'   topicArn = "arn:aws:sns:us-west-2:123456789012:exampletopic"
 #' )
 #' }

--- a/cran/paws.security.identity/R/inspector_service.R
+++ b/cran/paws.security.identity/R/inspector_service.R
@@ -45,7 +45,7 @@ NULL
 #'     )
 #'   ),
 #'   findingArns = list(
-#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-8l1VIE0D/r..."
+#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
 #'   )
 #' )
 #' }

--- a/cran/paws.security.identity/R/kms_operations.R
+++ b/cran/paws.security.identity/R/kms_operations.R
@@ -4671,7 +4671,7 @@ kms_list_retirable_grants <- function(Limit = NULL, Marker = NULL, RetiringPrinc
 #' # The following example attaches a key policy to the specified CMK.
 #' svc$put_key_policy(
 #'   KeyId = "1234abcd-12ab-34cd-56ef-1234567890ab",
-#'   Policy = "\{\n    "Version": "2012-10-17",\n    "Id": "custom-policy-2016-12-07",\n ...",
+#'   Policy = "\{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"custom-policy-2016-...",
 #'   PolicyName = "default"
 #' )
 #' }

--- a/cran/paws.security.identity/R/secretsmanager_operations.R
+++ b/cran/paws.security.identity/R/secretsmanager_operations.R
@@ -1497,7 +1497,7 @@ secretsmanager_list_secrets <- function(MaxResults = NULL, NextToken = NULL, Fil
 #' # The following example shows how to add a resource-based policy to a
 #' # secret.
 #' svc$put_resource_policy(
-#'   ResourcePolicy = "\{\n\"Version\":\"2012-10-17\",\n\"Statement\":[\{\n\"Effect\":\"Allow\",\n\"P...",
+#'   ResourcePolicy = "\{\n\"Version\":\"2012-10-17\",\n\"Statement\":[\{\n\"Effect\":\"A...",
 #'   SecretId = "MyTestDatabaseSecret"
 #' )
 #' }
@@ -2002,7 +2002,7 @@ secretsmanager_restore_secret <- function(SecretId) {
 #' # upon completion of this command. The rotation function runs
 #' # asynchronously in the background.
 #' svc$rotate_secret(
-#'   RotationLambdaARN = "arn:aws:lambda:us-west-2:123456789012:function:MyTestDatabaseR...",
+#'   RotationLambdaARN = "arn:aws:lambda:us-west-2:123456789012:function:MyTes...",
 #'   RotationRules = list(
 #'     AutomaticallyAfterDays = 30L
 #'   ),
@@ -2760,7 +2760,7 @@ secretsmanager_update_secret_version_stage <- function(SecretId, VersionStage, R
 #' # The following example shows how to validate a resource-based policy to a
 #' # secret.
 #' svc$validate_resource_policy(
-#'   ResourcePolicy = "\{\n\"Version\":\"2012-10-17\",\n\"Statement\":[\{\n\"Effect\":\"Allow\",\n\"P...",
+#'   ResourcePolicy = "\{\n\"Version\":\"2012-10-17\",\n\"Statement\":[\{\n\"Effect\":\"A...",
 #'   SecretId = "MyTestDatabaseSecret"
 #' )
 #' }

--- a/cran/paws.security.identity/R/sts_operations.R
+++ b/cran/paws.security.identity/R/sts_operations.R
@@ -381,7 +381,7 @@ NULL
 #' # 
 #' svc$assume_role(
 #'   ExternalId = "123ABC",
-#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
 #'   RoleArn = "arn:aws:iam::123456789012:role/demo",
 #'   RoleSessionName = "testAssumeRoleSession",
 #'   Tags = list(
@@ -709,7 +709,7 @@ sts_assume_role <- function(RoleArn, RoleSessionName, PolicyArns = NULL, Policy 
 #'   DurationSeconds = 3600L,
 #'   PrincipalArn = "arn:aws:iam::123456789012:saml-provider/SAML-test",
 #'   RoleArn = "arn:aws:iam::123456789012:role/TestSaml",
-#'   SAMLAssertion = "VERYLONGENCODEDASSERTIONEXAMPLExzYW1sOkF1ZGllbmNlPmJsYW5rPC9zYW1sO..."
+#'   SAMLAssertion = "VERYLONGENCODEDASSERTIONEXAMPLExzYW1sOkF1ZGllbmNlPmJsYW5..."
 #' )
 #' }
 #'
@@ -1059,11 +1059,11 @@ sts_assume_role_with_saml <- function(RoleArn, PrincipalArn, SAMLAssertion, Poli
 #' # 
 #' svc$assume_role_with_web_identity(
 #'   DurationSeconds = 3600L,
-#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
 #'   ProviderId = "www.amazon.com",
 #'   RoleArn = "arn:aws:iam::123456789012:role/FederatedWebIdentityRole",
 #'   RoleSessionName = "app1",
-#'   WebIdentityToken = "Atza%7CIQEBLjAsAhRFiXuWpUXuRvQ9PZL3GMFcYevydwIUFAHZwXZXXXXXXXXJ..."
+#'   WebIdentityToken = "Atza%7CIQEBLjAsAhRFiXuWpUXuRvQ9PZL3GMFcYevydwIUFAHZwX..."
 #' )
 #' }
 #'
@@ -1608,7 +1608,7 @@ sts_get_caller_identity <- function() {
 #' svc$get_federation_token(
 #'   DurationSeconds = 3600L,
 #'   Name = "testFedUserSession",
-#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
 #'   Tags = list(
 #'     list(
 #'       Key = "Project",

--- a/cran/paws.security.identity/R/sts_service.R
+++ b/cran/paws.security.identity/R/sts_service.R
@@ -40,7 +40,7 @@ NULL
 #' # 
 #' svc$assume_role(
 #'   ExternalId = "123ABC",
-#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
 #'   RoleArn = "arn:aws:iam::123456789012:role/demo",
 #'   RoleSessionName = "testAssumeRoleSession",
 #'   Tags = list(

--- a/cran/paws.security.identity/man/iam_change_password.Rd
+++ b/cran/paws.security.identity/man/iam_change_password.Rd
@@ -46,7 +46,7 @@ in the \emph{IAM User Guide}.
 \dontrun{
 # The following command changes the password for the current IAM user.
 svc$change_password(
-  NewPassword = "]35d/{pB9Fo9wJ",
+  NewPassword = "]35d/\{pB9Fo9wJ",
   OldPassword = "3s0K_;xh4~8XXI"
 )
 }

--- a/cran/paws.security.identity/man/iam_create_login_profile.Rd
+++ b/cran/paws.security.identity/man/iam_create_login_profile.Rd
@@ -62,7 +62,7 @@ in the \emph{IAM User Guide}.
 # The following command changes IAM user Bob's password and sets the flag
 # that required Bob to change the password the next time he signs in.
 svc$create_login_profile(
-  Password = "h]6EszR}vJ*m",
+  Password = "h]6EszR\}vJ*m",
   PasswordResetRequired = TRUE,
   UserName = "Bob"
 )

--- a/cran/paws.security.identity/man/iam_put_group_policy.Rd
+++ b/cran/paws.security.identity/man/iam_put_group_policy.Rd
@@ -77,7 +77,7 @@ in the \emph{IAM User Guide}.
 # named Admins.
 svc$put_group_policy(
   GroupName = "Admins",
-  PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"Action\":\"*...",
+  PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"...",
   PolicyName = "AllPerms"
 )
 }

--- a/cran/paws.security.identity/man/iam_put_role_policy.Rd
+++ b/cran/paws.security.identity/man/iam_put_role_policy.Rd
@@ -83,7 +83,7 @@ in the \emph{IAM User Guide}.
 # The following command adds a permissions policy to the role named
 # Test-Role.
 svc$put_role_policy(
-  PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"Action\":\"s...",
+  PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"...",
   PolicyName = "S3AccessPolicy",
   RoleName = "S3Access"
 )

--- a/cran/paws.security.identity/man/iam_put_user_policy.Rd
+++ b/cran/paws.security.identity/man/iam_put_user_policy.Rd
@@ -75,7 +75,7 @@ in the \emph{IAM User Guide}.
 \dontrun{
 # The following command attaches a policy to the IAM user named Bob.
 svc$put_user_policy(
-  PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"Action\":\"*...",
+  PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"...",
   PolicyName = "AllAccessPolicy",
   UserName = "Bob"
 )

--- a/cran/paws.security.identity/man/iam_update_assume_role_policy.Rd
+++ b/cran/paws.security.identity/man/iam_update_assume_role_policy.Rd
@@ -53,7 +53,7 @@ information about roles, go to \href{https://docs.aws.amazon.com/IAM/latest/User
 # The following command updates the role trust policy for the role named
 # Test-Role:
 svc$update_assume_role_policy(
-  PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Effect\":\"Allow\",\"Principal...",
+  PolicyDocument = "\{"Version":"2012-10-17","Statement":[\{"Effect":"Allow",...",
   RoleName = "S3AccessForEC2Instances"
 )
 }

--- a/cran/paws.security.identity/man/iam_upload_server_certificate.Rd
+++ b/cran/paws.security.identity/man/iam_upload_server_certificate.Rd
@@ -137,9 +137,9 @@ in the \emph{IAM User Guide}.
 # The following upload-server-certificate command uploads a server
 # certificate to your AWS account:
 svc$upload_server_certificate(
-  CertificateBody = "-----BEGIN CERTIFICATE-----<a very long certificate text string>...",
+  CertificateBody = "-----BEGIN CERTIFICATE-----<a very long certificate te...",
   Path = "/company/servercerts/",
-  PrivateKey = "-----BEGIN DSA PRIVATE KEY-----<a very long private key string>-----E...",
+  PrivateKey = "-----BEGIN DSA PRIVATE KEY-----<a very long private key str...",
   ServerCertificateName = "ProdServerCert"
 )
 }

--- a/cran/paws.security.identity/man/inspector.Rd
+++ b/cran/paws.security.identity/man/inspector.Rd
@@ -88,7 +88,7 @@ svc$add_attributes_to_findings(
     )
   ),
   findingArns = list(
-    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-8l1VIE0D/r..."
+    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
   )
 )
 }

--- a/cran/paws.security.identity/man/inspector_add_attributes_to_findings.Rd
+++ b/cran/paws.security.identity/man/inspector_add_attributes_to_findings.Rd
@@ -55,7 +55,7 @@ svc$add_attributes_to_findings(
     )
   ),
   findingArns = list(
-    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-8l1VIE0D/r..."
+    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
   )
 )
 }

--- a/cran/paws.security.identity/man/inspector_delete_assessment_run.Rd
+++ b/cran/paws.security.identity/man/inspector_delete_assessment_run.Rd
@@ -29,7 +29,7 @@ assessment run.
 # Deletes the assessment run that is specified by the ARN of the
 # assessment run.
 svc$delete_assessment_run(
-  assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/temp..."
+  assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvg..."
 )
 }
 

--- a/cran/paws.security.identity/man/inspector_delete_assessment_template.Rd
+++ b/cran/paws.security.identity/man/inspector_delete_assessment_template.Rd
@@ -29,7 +29,7 @@ assessment template.
 # Deletes the assessment template that is specified by the ARN of the
 # assessment template.
 svc$delete_assessment_template(
-  assessmentTemplateArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX..."
+  assessmentTemplateArn = "arn:aws:inspector:us-west-2:123456789012:target/..."
 )
 }
 

--- a/cran/paws.security.identity/man/inspector_describe_assessment_runs.Rd
+++ b/cran/paws.security.identity/man/inspector_describe_assessment_runs.Rd
@@ -94,7 +94,7 @@ assessment runs.
 # assessment runs.
 svc$describe_assessment_runs(
   assessmentRunArns = list(
-    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/r..."
+    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
   )
 )
 }

--- a/cran/paws.security.identity/man/inspector_describe_findings.Rd
+++ b/cran/paws.security.identity/man/inspector_describe_findings.Rd
@@ -122,7 +122,7 @@ Describes the findings that are specified by the ARNs of the findings.
 # Describes the findings that are specified by the ARNs of the findings.
 svc$describe_findings(
   findingArns = list(
-    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/r..."
+    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
   )
 )
 }

--- a/cran/paws.security.identity/man/inspector_get_telemetry_metadata.Rd
+++ b/cran/paws.security.identity/man/inspector_get_telemetry_metadata.Rd
@@ -39,7 +39,7 @@ assessment run.
 # Information about the data that is collected for the specified
 # assessment run.
 svc$get_telemetry_metadata(
-  assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/temp..."
+  assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kF..."
 )
 }
 

--- a/cran/paws.security.identity/man/inspector_list_assessment_run_agents.Rd
+++ b/cran/paws.security.identity/man/inspector_list_assessment_run_agents.Rd
@@ -77,7 +77,7 @@ of the assessment runs.
 # Lists the agents of the assessment runs that are specified by the ARNs
 # of the assessment runs.
 svc$list_assessment_run_agents(
-  assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/temp...",
+  assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kF...",
   maxResults = 123L
 )
 }

--- a/cran/paws.security.identity/man/inspector_list_event_subscriptions.Rd
+++ b/cran/paws.security.identity/man/inspector_list_event_subscriptions.Rd
@@ -61,7 +61,7 @@ see \code{\link[=inspector_subscribe_to_event]{subscribe_to_event}} and
 # specified by the ARN of the assessment template.
 svc$list_event_subscriptions(
   maxResults = 123L,
-  resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/..."
+  resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX..."
 )
 }
 

--- a/cran/paws.security.identity/man/inspector_list_findings.Rd
+++ b/cran/paws.security.identity/man/inspector_list_findings.Rd
@@ -95,7 +95,7 @@ specified by the ARNs of the assessment runs.
 # specified by the ARNs of the assessment runs.
 svc$list_findings(
   assessmentRunArns = list(
-    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/r..."
+    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
   ),
   maxResults = 123L
 )

--- a/cran/paws.security.identity/man/inspector_list_tags_for_resource.Rd
+++ b/cran/paws.security.identity/man/inspector_list_tags_for_resource.Rd
@@ -35,7 +35,7 @@ Lists all tags associated with an assessment template.
 \dontrun{
 # Lists all tags associated with an assessment template.
 svc$list_tags_for_resource(
-  resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/..."
+  resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq..."
 )
 }
 

--- a/cran/paws.security.identity/man/inspector_remove_attributes_from_findings.Rd
+++ b/cran/paws.security.identity/man/inspector_remove_attributes_from_findings.Rd
@@ -53,7 +53,7 @@ svc$remove_attributes_from_findings(
     "key=Example,value=example"
   ),
   findingArns = list(
-    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-8l1VIE0D/r..."
+    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
   )
 )
 }

--- a/cran/paws.security.identity/man/inspector_set_tags_for_resource.Rd
+++ b/cran/paws.security.identity/man/inspector_set_tags_for_resource.Rd
@@ -38,7 +38,7 @@ specified by the ARN of the assessment template.
 # Sets tags (key and value pairs) to the assessment template that is
 # specified by the ARN of the assessment template.
 svc$set_tags_for_resource(
-  resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/...",
+  resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX...",
   tags = list(
     list(
       key = "Example",

--- a/cran/paws.security.identity/man/inspector_start_assessment_run.Rd
+++ b/cran/paws.security.identity/man/inspector_start_assessment_run.Rd
@@ -41,7 +41,7 @@ limit of running up to 500 concurrent agents per AWS account.
 # limit of running up to 500 concurrent agents per AWS account.
 svc$start_assessment_run(
   assessmentRunName = "examplerun",
-  assessmentTemplateArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX..."
+  assessmentTemplateArn = "arn:aws:inspector:us-west-2:123456789012:target/..."
 )
 }
 

--- a/cran/paws.security.identity/man/inspector_stop_assessment_run.Rd
+++ b/cran/paws.security.identity/man/inspector_stop_assessment_run.Rd
@@ -36,7 +36,7 @@ run.
 # Stops the assessment run that is specified by the ARN of the assessment
 # run.
 svc$stop_assessment_run(
-  assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/temp..."
+  assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvg..."
 )
 }
 

--- a/cran/paws.security.identity/man/inspector_subscribe_to_event.Rd
+++ b/cran/paws.security.identity/man/inspector_subscribe_to_event.Rd
@@ -37,7 +37,7 @@ notifications about a specified event to a specified SNS topic.
 # notifications about a specified event to a specified SNS topic.
 svc$subscribe_to_event(
   event = "ASSESSMENT_RUN_COMPLETED",
-  resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/...",
+  resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX...",
   topicArn = "arn:aws:sns:us-west-2:123456789012:exampletopic"
 )
 }

--- a/cran/paws.security.identity/man/inspector_unsubscribe_from_event.Rd
+++ b/cran/paws.security.identity/man/inspector_unsubscribe_from_event.Rd
@@ -37,7 +37,7 @@ notifications about a specified event to a specified SNS topic.
 # notifications about a specified event to a specified SNS topic.
 svc$unsubscribe_from_event(
   event = "ASSESSMENT_RUN_COMPLETED",
-  resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/...",
+  resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX...",
   topicArn = "arn:aws:sns:us-west-2:123456789012:exampletopic"
 )
 }

--- a/cran/paws.security.identity/man/kms_put_key_policy.Rd
+++ b/cran/paws.security.identity/man/kms_put_key_policy.Rd
@@ -101,7 +101,7 @@ a different AWS account.
 # The following example attaches a key policy to the specified CMK.
 svc$put_key_policy(
   KeyId = "1234abcd-12ab-34cd-56ef-1234567890ab",
-  Policy = "\{\n    "Version": "2012-10-17",\n    "Id": "custom-policy-2016-12-07",\n ...",
+  Policy = "\{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"custom-policy-2016-...",
   PolicyName = "default"
 )
 }

--- a/cran/paws.security.identity/man/secretsmanager_put_resource_policy.Rd
+++ b/cran/paws.security.identity/man/secretsmanager_put_resource_policy.Rd
@@ -92,7 +92,7 @@ To run this command, you must have the following permissions:
 # The following example shows how to add a resource-based policy to a
 # secret.
 svc$put_resource_policy(
-  ResourcePolicy = "\{\n\"Version\":\"2012-10-17\",\n\"Statement\":[\{\n\"Effect\":\"Allow\",\n\"P...",
+  ResourcePolicy = "\{\n\"Version\":\"2012-10-17\",\n\"Statement\":[\{\n\"Effect\":\"A...",
   SecretId = "MyTestDatabaseSecret"
 )
 }

--- a/cran/paws.security.identity/man/secretsmanager_rotate_secret.Rd
+++ b/cran/paws.security.identity/man/secretsmanager_rotate_secret.Rd
@@ -149,7 +149,7 @@ of a secret, use
 # upon completion of this command. The rotation function runs
 # asynchronously in the background.
 svc$rotate_secret(
-  RotationLambdaARN = "arn:aws:lambda:us-west-2:123456789012:function:MyTestDatabaseR...",
+  RotationLambdaARN = "arn:aws:lambda:us-west-2:123456789012:function:MyTes...",
   RotationRules = list(
     AutomaticallyAfterDays = 30L
   ),

--- a/cran/paws.security.identity/man/secretsmanager_validate_resource_policy.Rd
+++ b/cran/paws.security.identity/man/secretsmanager_validate_resource_policy.Rd
@@ -65,7 +65,7 @@ resource-based policy is optional.
 # The following example shows how to validate a resource-based policy to a
 # secret.
 svc$validate_resource_policy(
-  ResourcePolicy = "\{\n\"Version\":\"2012-10-17\",\n\"Statement\":[\{\n\"Effect\":\"Allow\",\n\"P...",
+  ResourcePolicy = "\{\n\"Version\":\"2012-10-17\",\n\"Statement\":[\{\n\"Effect\":\"A...",
   SecretId = "MyTestDatabaseSecret"
 )
 }

--- a/cran/paws.security.identity/man/sts.Rd
+++ b/cran/paws.security.identity/man/sts.Rd
@@ -54,7 +54,7 @@ svc <- sts()
 # 
 svc$assume_role(
   ExternalId = "123ABC",
-  Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+  Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
   RoleArn = "arn:aws:iam::123456789012:role/demo",
   RoleSessionName = "testAssumeRoleSession",
   Tags = list(

--- a/cran/paws.security.identity/man/sts_assume_role.Rd
+++ b/cran/paws.security.identity/man/sts_assume_role.Rd
@@ -360,7 +360,7 @@ the time-based one-time password (TOTP) that the MFA device produces.
 # 
 svc$assume_role(
   ExternalId = "123ABC",
-  Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+  Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
   RoleArn = "arn:aws:iam::123456789012:role/demo",
   RoleSessionName = "testAssumeRoleSession",
   Tags = list(

--- a/cran/paws.security.identity/man/sts_assume_role_with_saml.Rd
+++ b/cran/paws.security.identity/man/sts_assume_role_with_saml.Rd
@@ -263,7 +263,7 @@ svc$assume_role_with_saml(
   DurationSeconds = 3600L,
   PrincipalArn = "arn:aws:iam::123456789012:saml-provider/SAML-test",
   RoleArn = "arn:aws:iam::123456789012:role/TestSaml",
-  SAMLAssertion = "VERYLONGENCODEDASSERTIONEXAMPLExzYW1sOkF1ZGllbmNlPmJsYW5rPC9zYW1sO..."
+  SAMLAssertion = "VERYLONGENCODEDASSERTIONEXAMPLExzYW1sOkF1ZGllbmNlPmJsYW5..."
 )
 }
 

--- a/cran/paws.security.identity/man/sts_assume_role_with_web_identity.Rd
+++ b/cran/paws.security.identity/man/sts_assume_role_with_web_identity.Rd
@@ -302,11 +302,11 @@ Amazon S3.
 # 
 svc$assume_role_with_web_identity(
   DurationSeconds = 3600L,
-  Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+  Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
   ProviderId = "www.amazon.com",
   RoleArn = "arn:aws:iam::123456789012:role/FederatedWebIdentityRole",
   RoleSessionName = "app1",
-  WebIdentityToken = "Atza\%7CIQEBLjAsAhRFiXuWpUXuRvQ9PZL3GMFcYevydwIUFAHZwXZXXXXXXXXJ..."
+  WebIdentityToken = "Atza\%7CIQEBLjAsAhRFiXuWpUXuRvQ9PZL3GMFcYevydwIUFAHZwX..."
 )
 }
 

--- a/cran/paws.security.identity/man/sts_get_federation_token.Rd
+++ b/cran/paws.security.identity/man/sts_get_federation_token.Rd
@@ -270,7 +270,7 @@ the user tag.
 svc$get_federation_token(
   DurationSeconds = 3600L,
   Name = "testFedUserSession",
-  Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+  Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
   Tags = list(
     list(
       Key = "Project",

--- a/cran/paws.storage/DESCRIPTION
+++ b/cran/paws.storage/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws.storage
 Title: Amazon Web Services Storage Services
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "David",
              family = "Kretch",

--- a/cran/paws.storage/R/glacier_operations.R
+++ b/cran/paws.storage/R/glacier_operations.R
@@ -61,7 +61,7 @@ NULL
 #' # my-vault:
 #' svc$abort_multipart_upload(
 #'   accountId = "-",
-#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
 #'   vaultName = "my-vault"
 #' )
 #' }
@@ -338,7 +338,7 @@ glacier_add_tags_to_vault <- function(accountId, vaultName, Tags = NULL) {
 #'   accountId = "-",
 #'   archiveSize = "3145728",
 #'   checksum = "9628195fcdbcbbe76cdde456d4646fa7de5f219fb39823836d81f0cc0e18aa67",
-#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
 #'   vaultName = "my-vault"
 #' )
 #' }
@@ -592,7 +592,7 @@ glacier_create_vault <- function(accountId, vaultName) {
 #' # The example deletes the archive specified by the archive ID.
 #' svc$delete_archive(
 #'   accountId = "-",
-#'   archiveId = "NkbByEejwEggmBz2fTHgJrg0XBoDfjP4q6iu87-TjhqG6eGoOY9Z8i1_AUyUsuhPAdTqLH...",
+#'   archiveId = "NkbByEejwEggmBz2fTHgJrg0XBoDfjP4q6iu87-TjhqG6eGoOY9Z8i1_AUyU...",
 #'   vaultName = "examplevault"
 #' )
 #' }
@@ -984,7 +984,7 @@ glacier_delete_vault_notifications <- function(accountId, vaultName) {
 #' # specified by the job ID.
 #' svc$describe_job(
 #'   accountId = "-",
-#'   jobId = "zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ejh18CnTS5XW...",
+#'   jobId = "zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ej...",
 #'   vaultName = "my-vault"
 #' )
 #' }
@@ -1298,7 +1298,7 @@ glacier_get_data_retrieval_policy <- function(accountId) {
 #' # retrieval job that is identified by the job ID.
 #' svc$get_job_output(
 #'   accountId = "-",
-#'   jobId = "zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ejh18CnTS5XW...",
+#'   jobId = "zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ej...",
 #'   range = "",
 #'   vaultName = "my-vaul"
 #' )
@@ -1915,7 +1915,7 @@ glacier_initiate_multipart_upload <- function(accountId, vaultName, archiveDescr
 #' svc$initiate_vault_lock(
 #'   accountId = "-",
 #'   policy = list(
-#'     Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Define-vault-lock\",\"Effect..."
+#'     Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Define-vault-loc..."
 #'   ),
 #'   vaultName = "my-vault"
 #' )
@@ -2341,7 +2341,7 @@ glacier_list_multipart_uploads <- function(accountId, vaultName, marker = NULL, 
 #' # The example lists all the parts of a multipart upload.
 #' svc$list_parts(
 #'   accountId = "-",
-#'   uploadId = "OW2fM5iVylEpFEMM9_HpKowRapC3vn5sSL39_396UW9zLFUWVrnRHaPjUJddQ5OxSHVXjYt...",
+#'   uploadId = "OW2fM5iVylEpFEMM9_HpKowRapC3vn5sSL39_396UW9zLFUWVrnRHaPjUJddQ...",
 #'   vaultName = "examplevault"
 #' )
 #' }
@@ -2846,7 +2846,7 @@ glacier_set_data_retrieval_policy <- function(accountId, Policy = NULL) {
 #' svc$set_vault_access_policy(
 #'   accountId = "-",
 #'   policy = list(
-#'     Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Define-owner-access-rights..."
+#'     Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Define-owner-acc..."
 #'   ),
 #'   vaultName = "examplevault"
 #' )
@@ -3198,7 +3198,7 @@ glacier_upload_archive <- function(vaultName, accountId, archiveDescription = NU
 #'   body = "part1",
 #'   checksum = "c06f7cd4baacb087002a99a5f48bf953",
 #'   range = "bytes 0-1048575/*",
-#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
 #'   vaultName = "examplevault"
 #' )
 #' }

--- a/cran/paws.storage/R/glacier_service.R
+++ b/cran/paws.storage/R/glacier_service.R
@@ -70,7 +70,7 @@ NULL
 #' # my-vault:
 #' svc$abort_multipart_upload(
 #'   accountId = "-",
-#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
 #'   vaultName = "my-vault"
 #' )
 #' }

--- a/cran/paws.storage/R/s3_operations.R
+++ b/cran/paws.storage/R/s3_operations.R
@@ -91,7 +91,7 @@ NULL
 #' svc$abort_multipart_upload(
 #'   Bucket = "examplebucket",
 #'   Key = "bigobject",
-#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 #' )
 #' }
 #'
@@ -267,7 +267,7 @@ s3_abort_multipart_upload <- function(Bucket, Key, UploadId, RequestPayer = NULL
 #'       )
 #'     )
 #'   ),
-#'   UploadId = "7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOmrEQHDsP..."
+#'   UploadId = "7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91..."
 #' )
 #' }
 #'
@@ -7363,7 +7363,7 @@ s3_list_objects_v2 <- function(Bucket, Delimiter = NULL, EncodingType = NULL, Ma
 #' svc$list_parts(
 #'   Bucket = "examplebucket",
 #'   Key = "bigobject",
-#'   UploadId = "example7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+#'   UploadId = "example7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 #' )
 #' }
 #'
@@ -9358,7 +9358,7 @@ s3_put_bucket_ownership_controls <- function(Bucket, ContentMD5 = NULL, Expected
 #' # The following example sets a permission policy on a bucket.
 #' svc$put_bucket_policy(
 #'   Bucket = "examplebucket",
-#'   Policy = "\{"Version": "2012-10-17", "Statement": [\{ "Sid": "id-1","Effect": "Allow"..."
+#'   Policy = "\{\"Version\": \"2012-10-17\", \"Statement\": [\{ \"Sid\": \"id-1\",\"Effect..."
 #' )
 #' }
 #'
@@ -12129,7 +12129,7 @@ s3_select_object_content <- function(Bucket, Key, SSECustomerAlgorithm = NULL, S
 #'   Bucket = "examplebucket",
 #'   Key = "examplelargeobject",
 #'   PartNumber = "1",
-#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 #' )
 #' }
 #'
@@ -12443,7 +12443,7 @@ s3_upload_part <- function(Body = NULL, Bucket, ContentLength = NULL, ContentMD5
 #'   CopySource = "/bucketname/sourceobjectkey",
 #'   Key = "examplelargeobject",
 #'   PartNumber = "1",
-#'   UploadId = "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3cq3LZSUsfjI..."
+#'   UploadId = "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3c..."
 #' )
 #' 
 #' # The following example uploads a part of a multipart upload by copying a
@@ -12454,7 +12454,7 @@ s3_upload_part <- function(Body = NULL, Bucket, ContentLength = NULL, ContentMD5
 #'   CopySourceRange = "bytes=1-100000",
 #'   Key = "examplelargeobject",
 #'   PartNumber = "2",
-#'   UploadId = "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3cq3LZSUsfjI..."
+#'   UploadId = "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3c..."
 #' )
 #' }
 #'

--- a/cran/paws.storage/R/s3_service.R
+++ b/cran/paws.storage/R/s3_service.R
@@ -35,7 +35,7 @@ NULL
 #' svc$abort_multipart_upload(
 #'   Bucket = "examplebucket",
 #'   Key = "bigobject",
-#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 #' )
 #' }
 #'

--- a/cran/paws.storage/R/storagegateway_operations.R
+++ b/cran/paws.storage/R/storagegateway_operations.R
@@ -1288,7 +1288,7 @@ storagegateway_create_smb_file_share <- function(ClientToken, GatewayARN, KMSEnc
 #' # Initiates an ad-hoc snapshot of a gateway volume.
 #' svc$create_snapshot(
 #'   SnapshotDescription = "My root volume snapshot as of 10/03/2017",
-#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -1388,7 +1388,7 @@ storagegateway_create_snapshot <- function(VolumeARN, SnapshotDescription, Tags 
 #' # Initiates a snapshot of a gateway from a volume recovery point.
 #' svc$create_snapshot_from_volume_recovery_point(
 #'   SnapshotDescription = "My root volume snapshot as of 2017-06-30T10:10:10.000Z",
-#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -1998,7 +1998,7 @@ storagegateway_delete_bandwidth_rate_limit <- function(GatewayARN, BandwidthType
 #' # for a specified iSCSI target and initiator pair.
 #' svc$delete_chap_credentials(
 #'   InitiatorName = "iqn.1991-05.com.microsoft:computername.domain.example.com",
-#'   TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/tar..."
+#'   TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -2191,7 +2191,7 @@ storagegateway_delete_gateway <- function(GatewayARN) {
 #' \dontrun{
 #' # This action enables you to delete a snapshot schedule for a volume.
 #' svc$delete_snapshot_schedule(
-#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -2440,7 +2440,7 @@ storagegateway_delete_tape_pool <- function(PoolARN) {
 #' # Deletes the specified gateway volume that you previously created using
 #' # the CreateCachediSCSIVolume or CreateStorediSCSIVolume API.
 #' svc$delete_volume(
-#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -2858,7 +2858,7 @@ storagegateway_describe_cachedi_scsi_volumes <- function(VolumeARNs) {
 #' # credentials information for a specified iSCSI target, one for each
 #' # target-initiator pair.
 #' svc$describe_chap_credentials(
-#'   TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/tar..."
+#'   TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -3310,7 +3310,7 @@ storagegateway_describe_smb_settings <- function(GatewayARN) {
 #' # Describes the snapshot schedule for the specified gateway volume
 #' # including intervals at which snapshots are automatically initiated.
 #' svc$describe_snapshot_schedule(
-#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -5871,7 +5871,7 @@ storagegateway_update_bandwidth_rate_limit_schedule <- function(GatewayARN, Band
 #'   InitiatorName = "iqn.1991-05.com.microsoft:computername.domain.example.com",
 #'   SecretToAuthenticateInitiator = "111111111111",
 #'   SecretToAuthenticateTarget = "222222222222",
-#'   TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/tar..."
+#'   TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -6611,7 +6611,7 @@ storagegateway_update_smb_security_strategy <- function(GatewayARN, SMBSecurityS
 #'   Description = "Hourly snapshot",
 #'   RecurrenceInHours = 1L,
 #'   StartAt = 0L,
-#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -6674,7 +6674,7 @@ storagegateway_update_snapshot_schedule <- function(VolumeARN, StartAt, Recurren
 #' # is activated.
 #' svc$update_vtl_device_type(
 #'   DeviceType = "Medium Changer",
-#'   VTLDeviceARN = "arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw-12A3456B/..."
+#'   VTLDeviceARN = "arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw..."
 #' )
 #' }
 #'

--- a/cran/paws.storage/R/storagegateway_service.R
+++ b/cran/paws.storage/R/storagegateway_service.R
@@ -68,7 +68,7 @@ NULL
 #' 
 #' For more information, see [Announcement: Heads-up – Longer AWS Storage
 #' Gateway volume and snapshot IDs coming in
-#' 2016](https://forums.aws.amazon.com:443/ann.jspa?annID=3557).
+#' 2016](https://forums.aws.amazon.com/ann.jspa?annID=3557).
 #'
 #' @param
 #' config

--- a/cran/paws.storage/man/glacier.Rd
+++ b/cran/paws.storage/man/glacier.Rd
@@ -107,7 +107,7 @@ svc <- glacier()
 # my-vault:
 svc$abort_multipart_upload(
   accountId = "-",
-  uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+  uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
   vaultName = "my-vault"
 )
 }

--- a/cran/paws.storage/man/glacier_abort_multipart_upload.Rd
+++ b/cran/paws.storage/man/glacier_abort_multipart_upload.Rd
@@ -57,7 +57,7 @@ in the \emph{Amazon Glacier Developer Guide}.
 # my-vault:
 svc$abort_multipart_upload(
   accountId = "-",
-  uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+  uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
   vaultName = "my-vault"
 )
 }

--- a/cran/paws.storage/man/glacier_complete_multipart_upload.Rd
+++ b/cran/paws.storage/man/glacier_complete_multipart_upload.Rd
@@ -101,7 +101,7 @@ svc$complete_multipart_upload(
   accountId = "-",
   archiveSize = "3145728",
   checksum = "9628195fcdbcbbe76cdde456d4646fa7de5f219fb39823836d81f0cc0e18aa67",
-  uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+  uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
   vaultName = "my-vault"
 )
 }

--- a/cran/paws.storage/man/glacier_delete_archive.Rd
+++ b/cran/paws.storage/man/glacier_delete_archive.Rd
@@ -60,7 +60,7 @@ in the \emph{Amazon Glacier Developer Guide}.
 # The example deletes the archive specified by the archive ID.
 svc$delete_archive(
   accountId = "-",
-  archiveId = "NkbByEejwEggmBz2fTHgJrg0XBoDfjP4q6iu87-TjhqG6eGoOY9Z8i1_AUyUsuhPAdTqLH...",
+  archiveId = "NkbByEejwEggmBz2fTHgJrg0XBoDfjP4q6iu87-TjhqG6eGoOY9Z8i1_AUyU...",
   vaultName = "examplevault"
 )
 }

--- a/cran/paws.storage/man/glacier_describe_job.Rd
+++ b/cran/paws.storage/man/glacier_describe_job.Rd
@@ -143,7 +143,7 @@ in the \emph{Amazon Glacier Developer Guide}.
 # specified by the job ID.
 svc$describe_job(
   accountId = "-",
-  jobId = "zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ejh18CnTS5XW...",
+  jobId = "zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ej...",
   vaultName = "my-vault"
 )
 }

--- a/cran/paws.storage/man/glacier_get_job_output.Rd
+++ b/cran/paws.storage/man/glacier_get_job_output.Rd
@@ -122,7 +122,7 @@ and \href{https://docs.aws.amazon.com/amazonglacier/latest/dev/api-job-output-ge
 # retrieval job that is identified by the job ID.
 svc$get_job_output(
   accountId = "-",
-  jobId = "zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ejh18CnTS5XW...",
+  jobId = "zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ej...",
   range = "",
   vaultName = "my-vaul"
 )

--- a/cran/paws.storage/man/glacier_initiate_vault_lock.Rd
+++ b/cran/paws.storage/man/glacier_initiate_vault_lock.Rd
@@ -80,7 +80,7 @@ new vault lock policy.
 svc$initiate_vault_lock(
   accountId = "-",
   policy = list(
-    Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Define-vault-lock\",\"Effect..."
+    Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Define-vault-loc..."
   ),
   vaultName = "my-vault"
 )

--- a/cran/paws.storage/man/glacier_list_parts.Rd
+++ b/cran/paws.storage/man/glacier_list_parts.Rd
@@ -87,7 +87,7 @@ in the \emph{Amazon Glacier Developer Guide}.
 # The example lists all the parts of a multipart upload.
 svc$list_parts(
   accountId = "-",
-  uploadId = "OW2fM5iVylEpFEMM9_HpKowRapC3vn5sSL39_396UW9zLFUWVrnRHaPjUJddQ5OxSHVXjYt...",
+  uploadId = "OW2fM5iVylEpFEMM9_HpKowRapC3vn5sSL39_396UW9zLFUWVrnRHaPjUJddQ...",
   vaultName = "examplevault"
 )
 }

--- a/cran/paws.storage/man/glacier_set_vault_access_policy.Rd
+++ b/cran/paws.storage/man/glacier_set_vault_access_policy.Rd
@@ -48,7 +48,7 @@ KB in size. For more information about vault access policies, see
 svc$set_vault_access_policy(
   accountId = "-",
   policy = list(
-    Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Define-owner-access-rights..."
+    Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Define-owner-acc..."
   ),
   vaultName = "examplevault"
 )

--- a/cran/paws.storage/man/glacier_upload_multipart_part.Rd
+++ b/cran/paws.storage/man/glacier_upload_multipart_part.Rd
@@ -100,7 +100,7 @@ svc$upload_multipart_part(
   body = "part1",
   checksum = "c06f7cd4baacb087002a99a5f48bf953",
   range = "bytes 0-1048575/*",
-  uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+  uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
   vaultName = "examplevault"
 )
 }

--- a/cran/paws.storage/man/s3.Rd
+++ b/cran/paws.storage/man/s3.Rd
@@ -138,7 +138,7 @@ svc <- s3()
 svc$abort_multipart_upload(
   Bucket = "examplebucket",
   Key = "bigobject",
-  UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+  UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 )
 }
 

--- a/cran/paws.storage/man/s3_abort_multipart_upload.Rd
+++ b/cran/paws.storage/man/s3_abort_multipart_upload.Rd
@@ -86,7 +86,7 @@ The following operations are related to
 svc$abort_multipart_upload(
   Bucket = "examplebucket",
   Key = "bigobject",
-  UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+  UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 )
 }
 

--- a/cran/paws.storage/man/s3_complete_multipart_upload.Rd
+++ b/cran/paws.storage/man/s3_complete_multipart_upload.Rd
@@ -148,7 +148,7 @@ svc$complete_multipart_upload(
       )
     )
   ),
-  UploadId = "7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOmrEQHDsP..."
+  UploadId = "7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91..."
 )
 }
 

--- a/cran/paws.storage/man/s3_list_parts.Rd
+++ b/cran/paws.storage/man/s3_list_parts.Rd
@@ -126,7 +126,7 @@ The following operations are related to \code{\link[=s3_list_parts]{list_parts}}
 svc$list_parts(
   Bucket = "examplebucket",
   Key = "bigobject",
-  UploadId = "example7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+  UploadId = "example7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 )
 }
 

--- a/cran/paws.storage/man/s3_put_bucket_policy.Rd
+++ b/cran/paws.storage/man/s3_put_bucket_policy.Rd
@@ -70,7 +70,7 @@ The following operations are related to
 # The following example sets a permission policy on a bucket.
 svc$put_bucket_policy(
   Bucket = "examplebucket",
-  Policy = "\{"Version": "2012-10-17", "Statement": [\{ "Sid": "id-1","Effect": "Allow"..."
+  Policy = "\{\"Version\": \"2012-10-17\", \"Statement\": [\{ \"Sid\": \"id-1\",\"Effect..."
 )
 }
 

--- a/cran/paws.storage/man/s3_upload_part.Rd
+++ b/cran/paws.storage/man/s3_upload_part.Rd
@@ -198,7 +198,7 @@ svc$upload_part(
   Bucket = "examplebucket",
   Key = "examplelargeobject",
   PartNumber = "1",
-  UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+  UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 )
 }
 

--- a/cran/paws.storage/man/s3_upload_part_copy.Rd
+++ b/cran/paws.storage/man/s3_upload_part_copy.Rd
@@ -296,7 +296,7 @@ svc$upload_part_copy(
   CopySource = "/bucketname/sourceobjectkey",
   Key = "examplelargeobject",
   PartNumber = "1",
-  UploadId = "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3cq3LZSUsfjI..."
+  UploadId = "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3c..."
 )
 
 # The following example uploads a part of a multipart upload by copying a
@@ -307,7 +307,7 @@ svc$upload_part_copy(
   CopySourceRange = "bytes=1-100000",
   Key = "examplelargeobject",
   PartNumber = "2",
-  UploadId = "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3cq3LZSUsfjI..."
+  UploadId = "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3c..."
 )
 }
 

--- a/cran/paws.storage/man/storagegateway.Rd
+++ b/cran/paws.storage/man/storagegateway.Rd
@@ -62,7 +62,7 @@ ID format looks like the following:
 A snapshot ID with the longer ID format looks like the following:
 \verb{snap-78e226633445566ee}.
 
-For more information, see \href{https://forums.aws.amazon.com:443/ann.jspa?annID=3557}{Announcement: Heads-up – Longer AWS Storage Gateway volume and snapshot IDs coming in 2016}.
+For more information, see \href{https://forums.aws.amazon.com/ann.jspa?annID=3557}{Announcement: Heads-up – Longer AWS Storage Gateway volume and snapshot IDs coming in 2016}.
 }
 \section{Service syntax}{
 \preformatted{svc <- storagegateway(

--- a/cran/paws.storage/man/storagegateway_create_snapshot.Rd
+++ b/cran/paws.storage/man/storagegateway_create_snapshot.Rd
@@ -83,7 +83,7 @@ page.
 # Initiates an ad-hoc snapshot of a gateway volume.
 svc$create_snapshot(
   SnapshotDescription = "My root volume snapshot as of 10/03/2017",
-  VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+  VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 )
 }
 

--- a/cran/paws.storage/man/storagegateway_create_snapshot_from_volume_recovery_point.Rd
+++ b/cran/paws.storage/man/storagegateway_create_snapshot_from_volume_recovery_point.Rd
@@ -78,7 +78,7 @@ in the \emph{Amazon Elastic Compute Cloud API Reference}.
 # Initiates a snapshot of a gateway from a volume recovery point.
 svc$create_snapshot_from_volume_recovery_point(
   SnapshotDescription = "My root volume snapshot as of 2017-06-30T10:10:10.000Z",
-  VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+  VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 )
 }
 

--- a/cran/paws.storage/man/storagegateway_delete_chap_credentials.Rd
+++ b/cran/paws.storage/man/storagegateway_delete_chap_credentials.Rd
@@ -40,7 +40,7 @@ supported in volume and tape gateway types.
 # for a specified iSCSI target and initiator pair.
 svc$delete_chap_credentials(
   InitiatorName = "iqn.1991-05.com.microsoft:computername.domain.example.com",
-  TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/tar..."
+  TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 )
 }
 

--- a/cran/paws.storage/man/storagegateway_delete_snapshot_schedule.Rd
+++ b/cran/paws.storage/man/storagegateway_delete_snapshot_schedule.Rd
@@ -43,7 +43,7 @@ in the \emph{Amazon Elastic Compute Cloud API Reference}.
 \dontrun{
 # This action enables you to delete a snapshot schedule for a volume.
 svc$delete_snapshot_schedule(
-  VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+  VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 )
 }
 

--- a/cran/paws.storage/man/storagegateway_delete_volume.Rd
+++ b/cran/paws.storage/man/storagegateway_delete_volume.Rd
@@ -52,7 +52,7 @@ storage volume you want to delete.
 # Deletes the specified gateway volume that you previously created using
 # the CreateCachediSCSIVolume or CreateStorediSCSIVolume API.
 svc$delete_volume(
-  VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+  VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 )
 }
 

--- a/cran/paws.storage/man/storagegateway_describe_chap_credentials.Rd
+++ b/cran/paws.storage/man/storagegateway_describe_chap_credentials.Rd
@@ -45,7 +45,7 @@ tape gateway types.
 # credentials information for a specified iSCSI target, one for each
 # target-initiator pair.
 svc$describe_chap_credentials(
-  TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/tar..."
+  TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 )
 }
 

--- a/cran/paws.storage/man/storagegateway_describe_snapshot_schedule.Rd
+++ b/cran/paws.storage/man/storagegateway_describe_snapshot_schedule.Rd
@@ -45,7 +45,7 @@ in the cached volume and stored volume types.
 # Describes the snapshot schedule for the specified gateway volume
 # including intervals at which snapshots are automatically initiated.
 svc$describe_snapshot_schedule(
-  VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+  VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 )
 }
 

--- a/cran/paws.storage/man/storagegateway_update_chap_credentials.Rd
+++ b/cran/paws.storage/man/storagegateway_update_chap_credentials.Rd
@@ -62,7 +62,7 @@ svc$update_chap_credentials(
   InitiatorName = "iqn.1991-05.com.microsoft:computername.domain.example.com",
   SecretToAuthenticateInitiator = "111111111111",
   SecretToAuthenticateTarget = "222222222222",
-  TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/tar..."
+  TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 )
 }
 

--- a/cran/paws.storage/man/storagegateway_update_snapshot_schedule.Rd
+++ b/cran/paws.storage/man/storagegateway_update_snapshot_schedule.Rd
@@ -72,7 +72,7 @@ svc$update_snapshot_schedule(
   Description = "Hourly snapshot",
   RecurrenceInHours = 1L,
   StartAt = 0L,
-  VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+  VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 )
 }
 

--- a/cran/paws.storage/man/storagegateway_update_vtl_device_type.Rd
+++ b/cran/paws.storage/man/storagegateway_update_vtl_device_type.Rd
@@ -40,7 +40,7 @@ the tape gateway type.
 # is activated.
 svc$update_vtl_device_type(
   DeviceType = "Medium Changer",
-  VTLDeviceARN = "arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw-12A3456B/..."
+  VTLDeviceARN = "arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw..."
 )
 }
 

--- a/cran/paws/R/paws.R
+++ b/cran/paws/R/paws.R
@@ -623,7 +623,7 @@ ec2 <- function(config = list()) {
 #'   AvailabilityZone = "us-west-2a",
 #'   InstanceId = "i-abcd1234",
 #'   InstanceOSUser = "ec2-user",
-#'   SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6dRjfZXQ4HX5..."
+#'   SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6d..."
 #' )
 #' }
 #'
@@ -905,7 +905,7 @@ ecs <- function(config = list()) {
 #'       "subnet-e7e761ac"
 #'     )
 #'   ),
-#'   roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonE..."
+#'   roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRole..."
 #' )
 #' }
 #'
@@ -1851,7 +1851,7 @@ fsx <- function(config = list()) {
 #' # my-vault:
 #' svc$abort_multipart_upload(
 #'   accountId = "-",
-#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
 #'   vaultName = "my-vault"
 #' )
 #' }
@@ -1932,7 +1932,7 @@ glacier <- function(config = list()) {
 #' svc$abort_multipart_upload(
 #'   Bucket = "examplebucket",
 #'   Key = "bigobject",
-#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 #' )
 #' }
 #'
@@ -2191,7 +2191,7 @@ s3control <- function(config = list()) {
 #' 
 #' For more information, see [Announcement: Heads-up – Longer AWS Storage
 #' Gateway volume and snapshot IDs coming in
-#' 2016](https://forums.aws.amazon.com:443/ann.jspa?annID=3557).
+#' 2016](https://forums.aws.amazon.com/ann.jspa?annID=3557).
 #'
 #' @param
 #' config
@@ -2666,7 +2666,7 @@ dynamodb <- function(config = list()) {
 #' svc <- dynamodbstreams()
 #' # The following example describes a stream with a given stream ARN.
 #' svc$describe_stream(
-#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T..."
+#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2..."
 #' )
 #' }
 #'
@@ -4308,7 +4308,7 @@ elb <- function(config = list()) {
 #' # This example adds the specified tags to the specified load balancer.
 #' svc$add_tags(
 #'   ResourceArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
 #'   ),
 #'   Tags = list(
 #'     list(
@@ -11684,7 +11684,7 @@ iam <- function(config = list()) {
 #'     )
 #'   ),
 #'   findingArns = list(
-#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-8l1VIE0D/r..."
+#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
 #'   )
 #' )
 #' }
@@ -12446,7 +12446,7 @@ shield <- function(config = list()) {
 #' # 
 #' svc$assume_role(
 #'   ExternalId = "123ABC",
-#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
 #'   RoleArn = "arn:aws:iam::123456789012:role/demo",
 #'   RoleSessionName = "testAssumeRoleSession",
 #'   Tags = list(

--- a/cran/paws/man/dynamodbstreams.Rd
+++ b/cran/paws/man/dynamodbstreams.Rd
@@ -50,7 +50,7 @@ in the Amazon DynamoDB Developer Guide.
 svc <- dynamodbstreams()
 # The following example describes a stream with a given stream ARN.
 svc$describe_stream(
-  StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T..."
+  StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2..."
 )
 }
 

--- a/cran/paws/man/ec2instanceconnect.Rd
+++ b/cran/paws/man/ec2instanceconnect.Rd
@@ -49,7 +49,7 @@ svc$send_ssh_public_key(
   AvailabilityZone = "us-west-2a",
   InstanceId = "i-abcd1234",
   InstanceOSUser = "ec2-user",
-  SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6dRjfZXQ4HX5..."
+  SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6d..."
 )
 }
 

--- a/cran/paws/man/eks.Rd
+++ b/cran/paws/man/eks.Rd
@@ -92,7 +92,7 @@ svc$create_cluster(
       "subnet-e7e761ac"
     )
   ),
-  roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonE..."
+  roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRole..."
 )
 }
 

--- a/cran/paws/man/elbv2.Rd
+++ b/cran/paws/man/elbv2.Rd
@@ -102,7 +102,7 @@ svc <- elbv2()
 # This example adds the specified tags to the specified load balancer.
 svc$add_tags(
   ResourceArns = list(
-    "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+    "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
   ),
   Tags = list(
     list(

--- a/cran/paws/man/glacier.Rd
+++ b/cran/paws/man/glacier.Rd
@@ -107,7 +107,7 @@ svc <- glacier()
 # my-vault:
 svc$abort_multipart_upload(
   accountId = "-",
-  uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+  uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
   vaultName = "my-vault"
 )
 }

--- a/cran/paws/man/inspector.Rd
+++ b/cran/paws/man/inspector.Rd
@@ -88,7 +88,7 @@ svc$add_attributes_to_findings(
     )
   ),
   findingArns = list(
-    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-8l1VIE0D/r..."
+    "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
   )
 )
 }

--- a/cran/paws/man/s3.Rd
+++ b/cran/paws/man/s3.Rd
@@ -138,7 +138,7 @@ svc <- s3()
 svc$abort_multipart_upload(
   Bucket = "examplebucket",
   Key = "bigobject",
-  UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+  UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 )
 }
 

--- a/cran/paws/man/storagegateway.Rd
+++ b/cran/paws/man/storagegateway.Rd
@@ -62,7 +62,7 @@ ID format looks like the following:
 A snapshot ID with the longer ID format looks like the following:
 \verb{snap-78e226633445566ee}.
 
-For more information, see \href{https://forums.aws.amazon.com:443/ann.jspa?annID=3557}{Announcement: Heads-up – Longer AWS Storage Gateway volume and snapshot IDs coming in 2016}.
+For more information, see \href{https://forums.aws.amazon.com/ann.jspa?annID=3557}{Announcement: Heads-up – Longer AWS Storage Gateway volume and snapshot IDs coming in 2016}.
 }
 \section{Service syntax}{
 \preformatted{svc <- storagegateway(

--- a/cran/paws/man/sts.Rd
+++ b/cran/paws/man/sts.Rd
@@ -54,7 +54,7 @@ svc <- sts()
 # 
 svc$assume_role(
   ExternalId = "123ABC",
-  Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+  Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
   RoleArn = "arn:aws:iam::123456789012:role/demo",
   RoleSessionName = "testAssumeRoleSession",
   Tags = list(

--- a/paws/DESCRIPTION
+++ b/paws/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: paws
 Title: Amazon Web Services Software Development Kit
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: c(
     person(given = "David", family = "Kretch", role = c("aut", "cre"), email = "david.kretch@gmail.com"),
     person(given = "Adam", family = "Banker", role = "aut", email = "adam.banker39@gmail.com"),

--- a/paws/R/autoscaling_operations.R
+++ b/paws/R/autoscaling_operations.R
@@ -129,7 +129,7 @@ autoscaling_attach_instances <- function(InstanceIds = NULL, AutoScalingGroupNam
 #' svc$attach_load_balancer_target_groups(
 #'   AutoScalingGroupName = "my-auto-scaling-group",
 #'   TargetGroupARNs = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-tar..."
 #'   )
 #' )
 #' }
@@ -830,7 +830,7 @@ autoscaling_complete_lifecycle_action <- function(LifecycleHookName, AutoScaling
 #'   MaxSize = 3L,
 #'   MinSize = 1L,
 #'   TargetGroupARNs = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-tar..."
 #'   ),
 #'   VPCZoneIdentifier = "subnet-057fa0918fEXAMPLE, subnet-610acd08EXAMPLE"
 #' )
@@ -3330,7 +3330,7 @@ autoscaling_detach_instances <- function(InstanceIds = NULL, AutoScalingGroupNam
 #' svc$detach_load_balancer_target_groups(
 #'   AutoScalingGroupName = "my-auto-scaling-group",
 #'   TargetGroupARNs = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-tar..."
 #'   )
 #' )
 #' }
@@ -4272,7 +4272,7 @@ autoscaling_put_notification_configuration <- function(AutoScalingGroupName, Top
 #'   TargetTrackingConfiguration = list(
 #'     PredefinedMetricSpecification = list(
 #'       PredefinedMetricType = "ALBRequestCountPerTarget",
-#'       ResourceLabel = "app/EC2Co-EcsEl-1TKLTMITMM0EO/f37c06a68c1748aa/targetgroup/EC2..."
+#'       ResourceLabel = "app/EC2Co-EcsEl-1TKLTMITMM0EO/f37c06a68c1748aa/targe..."
 #'     ),
 #'     TargetValue = 1000
 #'   )

--- a/paws/R/cloudformation_operations.R
+++ b/paws/R/cloudformation_operations.R
@@ -1990,8 +1990,9 @@ cloudformation_describe_stack_resource <- function(StackName, LogicalResourceId)
 #' resource that has been checked for drift. Resources that have not yet
 #' been checked for drift are not included. Resources that do not currently
 #' support drift detection are not checked, and so not included. For a list
-#' of resources that support drift detection, see Resources that Support
-#' Drift Detection.
+#' of resources that support drift detection, see [Resources that Support
+#' Drift
+#' Detection](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html).
 #' 
 #' Use
 #' [`detect_stack_resource_drift`][cloudformation_detect_stack_resource_drift]
@@ -2117,8 +2118,9 @@ cloudformation_describe_stack_resource_drifts <- function(StackName, StackResour
 #' You must specify either `StackName` or `PhysicalResourceId`, but not
 #' both. In addition, you can specify `LogicalResourceId` to filter the
 #' returned result. For more information about resources, the
-#' `LogicalResourceId` and `PhysicalResourceId`, go to the AWS
-#' CloudFormation User Guide.
+#' `LogicalResourceId` and `PhysicalResourceId`, go to the [AWS
+#' CloudFormation User
+#' Guide](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/).
 #' 
 #' A `ValidationError` is returned if you specify both `StackName` and
 #' `PhysicalResourceId` in the same request.
@@ -2708,7 +2710,8 @@ cloudformation_describe_type_registration <- function(RegistrationToken) {
 #' to detect drift on individual resources.
 #' 
 #' For a list of stack resources that currently support drift detection,
-#' see Resources that Support Drift Detection.
+#' see [Resources that Support Drift
+#' Detection](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html).
 #' 
 #' [`detect_stack_drift`][cloudformation_detect_stack_drift] can take up to
 #' several minutes, depending on the number of resources contained within
@@ -2791,7 +2794,8 @@ cloudformation_detect_stack_drift <- function(StackName, LogicalResourceIds = NU
 #' 
 #' Resources that do not currently support drift detection cannot be
 #' checked. For a list of resources that support drift detection, see
-#' Resources that Support Drift Detection.
+#' [Resources that Support Drift
+#' Detection](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-supported-resources.html).
 #'
 #' @usage
 #' cloudformation_detect_stack_resource_drift(StackName, LogicalResourceId)
@@ -2870,8 +2874,8 @@ cloudformation_detect_stack_resource_drift <- function(StackName, LogicalResourc
 #' Detect drift on a stack set. When CloudFormation performs drift
 #' detection on a stack set, it performs drift detection on the stack
 #' associated with each stack instance in the stack set. For more
-#' information, see How CloudFormation Performs Drift Detection on a Stack
-#' Set.
+#' information, see [How CloudFormation Performs Drift Detection on a Stack
+#' Set](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacksets-drift.html).
 #' 
 #' [`detect_stack_set_drift`][cloudformation_detect_stack_set_drift]
 #' returns the `OperationId` of the stack set drift detection operation.

--- a/paws/R/devicefarm_operations.R
+++ b/paws/R/devicefarm_operations.R
@@ -2237,7 +2237,7 @@ devicefarm_get_offering_status <- function(nextToken = NULL) {
 #' \dontrun{
 #' # The following example gets information about a specific project.
 #' svc$get_project(
-#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:project:5e01a8c7-c861-4c0a-b1d5-12..."
+#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:project:5e01a8c7-c861-4c..."
 #' )
 #' }
 #'
@@ -2518,7 +2518,7 @@ devicefarm_get_remote_access_session <- function(arn) {
 #' \dontrun{
 #' # The following example gets information about a specific test run.
 #' svc$get_run(
-#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b1d5-5ec6e6..."
+#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b..."
 #' )
 #' }
 #'
@@ -3003,7 +3003,7 @@ devicefarm_get_vpce_configuration <- function(arn) {
 #' # remote access session.
 #' svc$install_to_remote_access_session(
 #'   appArn = "arn:aws:devicefarm:us-west-2:123456789101:app:EXAMPLE-GUID-123-456",
-#'   remoteAccessSessionArn = "arn:aws:devicefarm:us-west-2:123456789101:session:EXAMPLE..."
+#'   remoteAccessSessionArn = "arn:aws:devicefarm:us-west-2:123456789101:sessi..."
 #' )
 #' }
 #'
@@ -4002,7 +4002,7 @@ devicefarm_list_offerings <- function(nextToken = NULL) {
 #' # The following example returns information about the specified project in
 #' # Device Farm.
 #' svc$list_projects(
-#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:project:7ad300ed-8183-41a7-bf94-12...",
+#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:project:7ad300ed-8183-41...",
 #'   nextToken = "RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE"
 #' )
 #' }
@@ -4301,7 +4301,7 @@ devicefarm_list_remote_access_sessions <- function(arn, nextToken = NULL) {
 #' \dontrun{
 #' # The following example returns information about a specific test run.
 #' svc$list_runs(
-#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b1d5-5ec6e6...",
+#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:run:5e01a8c7-c861-4c0a-b...",
 #'   nextToken = "RW5DdDJkMWYwZjM2MzM2VHVpOHJIUXlDUXlhc2QzRGViYnc9SEXAMPLE"
 #' )
 #' }
@@ -6575,7 +6575,7 @@ devicefarm_update_network_profile <- function(arn, name = NULL, description = NU
 #' # The following example updates the specified project with a new name.
 #' svc$update_project(
 #'   name = "NewName",
-#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:project:8f75187d-101e-4625-accc-12..."
+#'   arn = "arn:aws:devicefarm:us-west-2:123456789101:project:8f75187d-101e-46..."
 #' )
 #' }
 #'

--- a/paws/R/dynamodbstreams_operations.R
+++ b/paws/R/dynamodbstreams_operations.R
@@ -78,7 +78,7 @@ NULL
 #' \dontrun{
 #' # The following example describes a stream with a given stream ARN.
 #' svc$describe_stream(
-#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T..."
+#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2..."
 #' )
 #' }
 #'
@@ -240,7 +240,7 @@ dynamodbstreams_describe_stream <- function(StreamArn, Limit = NULL, ExclusiveSt
 #' \dontrun{
 #' # The following example retrieves all the stream records from a shard.
 #' svc$get_records(
-#'   ShardIterator = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05..."
+#'   ShardIterator = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stre..."
 #' )
 #' }
 #'
@@ -328,7 +328,7 @@ dynamodbstreams_get_records <- function(ShardIterator, Limit = NULL) {
 #' svc$get_shard_iterator(
 #'   ShardId = "00000001414576573621-f55eea83",
 #'   ShardIteratorType = "TRIM_HORIZON",
-#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T..."
+#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2..."
 #' )
 #' }
 #'

--- a/paws/R/dynamodbstreams_service.R
+++ b/paws/R/dynamodbstreams_service.R
@@ -40,7 +40,7 @@ NULL
 #' svc <- dynamodbstreams()
 #' # The following example describes a stream with a given stream ARN.
 #' svc$describe_stream(
-#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2015-05-20T..."
+#'   StreamArn = "arn:aws:dynamodb:us-west-2:111122223333:table/Forum/stream/2..."
 #' )
 #' }
 #'

--- a/paws/R/ec2instanceconnect_operations.R
+++ b/paws/R/ec2instanceconnect_operations.R
@@ -48,7 +48,7 @@ NULL
 #'   AvailabilityZone = "us-west-2a",
 #'   InstanceId = "i-abcd1234",
 #'   InstanceOSUser = "ec2-user",
-#'   SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6dRjfZXQ4HX5..."
+#'   SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6d..."
 #' )
 #' }
 #'

--- a/paws/R/ec2instanceconnect_service.R
+++ b/paws/R/ec2instanceconnect_service.R
@@ -41,7 +41,7 @@ NULL
 #'   AvailabilityZone = "us-west-2a",
 #'   InstanceId = "i-abcd1234",
 #'   InstanceOSUser = "ec2-user",
-#'   SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6dRjfZXQ4HX5..."
+#'   SSHPublicKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3FlHqj2eqCdrGHuA6d..."
 #' )
 #' }
 #'

--- a/paws/R/eks_operations.R
+++ b/paws/R/eks_operations.R
@@ -343,7 +343,7 @@ eks_create_addon <- function(clusterName, addonName, addonVersion = NULL, servic
 #'       "subnet-e7e761ac"
 #'     )
 #'   ),
-#'   roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonE..."
+#'   roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRole..."
 #' )
 #' }
 #'

--- a/paws/R/eks_service.R
+++ b/paws/R/eks_service.R
@@ -58,7 +58,7 @@ NULL
 #'       "subnet-e7e761ac"
 #'     )
 #'   ),
-#'   roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRoleForAmazonE..."
+#'   roleArn = "arn:aws:iam::012345678910:role/eks-service-role-AWSServiceRole..."
 #' )
 #' }
 #'

--- a/paws/R/elasticbeanstalk_operations.R
+++ b/paws/R/elasticbeanstalk_operations.R
@@ -4373,7 +4373,7 @@ elasticbeanstalk_update_tags_for_resource <- function(ResourceArn, TagsToAdd = N
 #'     list(
 #'       Namespace = "aws:elasticbeanstalk:healthreporting:system",
 #'       OptionName = "ConfigDocument",
-#'       Value = "\{"CloudWatchMetrics": \{"Environment": \{"ApplicationLatencyP99.9": null..."
+#'       Value = "\{\"CloudWatchMetrics\": \{\"Environment\": \{\"ApplicationLatencyP9..."
 #'     )
 #'   )
 #' )

--- a/paws/R/elb_operations.R
+++ b/paws/R/elb_operations.R
@@ -853,7 +853,7 @@ elb_create_load_balancer_listeners <- function(LoadBalancerName, Listeners) {
 #'   PolicyAttributes = list(
 #'     list(
 #'       AttributeName = "PublicKey",
-#'       AttributeValue = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwAYUjnfyEyXr1pxjh..."
+#'       AttributeValue = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwAYUjnf..."
 #'     )
 #'   ),
 #'   PolicyName = "my-PublicKey-policy",

--- a/paws/R/elbv2_operations.R
+++ b/paws/R/elbv2_operations.R
@@ -112,7 +112,7 @@ elbv2_add_listener_certificates <- function(ListenerArn, Certificates) {
 #' # This example adds the specified tags to the specified load balancer.
 #' svc$add_tags(
 #'   ResourceArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
 #'   ),
 #'   Tags = list(
 #'     list(
@@ -390,11 +390,11 @@ elbv2_add_tags <- function(ResourceArns, Tags) {
 #' svc$create_listener(
 #'   DefaultActions = list(
 #'     list(
-#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgro...",
+#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012...",
 #'       Type = "forward"
 #'     )
 #'   ),
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer...",
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo...",
 #'   Port = 80L,
 #'   Protocol = "HTTP"
 #' )
@@ -414,11 +414,11 @@ elbv2_add_tags <- function(ResourceArns, Tags) {
 #'   ),
 #'   DefaultActions = list(
 #'     list(
-#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgro...",
+#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012...",
 #'       Type = "forward"
 #'     )
 #'   ),
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer...",
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo...",
 #'   Port = 443L,
 #'   Protocol = "HTTPS",
 #'   SslPolicy = "ELBSecurityPolicy-2015-05"
@@ -928,7 +928,7 @@ elbv2_create_load_balancer <- function(Name, Subnets = NULL, SubnetMappings = NU
 #' svc$create_rule(
 #'   Actions = list(
 #'     list(
-#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgro...",
+#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012...",
 #'       Type = "forward"
 #'     )
 #'   ),
@@ -940,7 +940,7 @@ elbv2_create_load_balancer <- function(Name, Subnets = NULL, SubnetMappings = NU
 #'       )
 #'     )
 #'   ),
-#'   ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-...",
+#'   ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listen...",
 #'   Priority = 10L
 #' )
 #' }
@@ -1199,7 +1199,7 @@ elbv2_create_target_group <- function(Name, Protocol = NULL, ProtocolVersion = N
 #' \dontrun{
 #' # This example deletes the specified listener.
 #' svc$delete_listener(
-#'   ListenerArn = "arn:aws:elasticloadbalancing:ua-west-2:123456789012:listener/app/my-..."
+#'   ListenerArn = "arn:aws:elasticloadbalancing:ua-west-2:123456789012:listen..."
 #' )
 #' }
 #'
@@ -1259,7 +1259,7 @@ elbv2_delete_listener <- function(ListenerArn) {
 #' \dontrun{
 #' # This example deletes the specified load balancer.
 #' svc$delete_load_balancer(
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 #' )
 #' }
 #'
@@ -1309,7 +1309,7 @@ elbv2_delete_load_balancer <- function(LoadBalancerArn) {
 #' \dontrun{
 #' # This example deletes the specified rule.
 #' svc$delete_rule(
-#'   RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/my..."
+#'   RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-r..."
 #' )
 #' }
 #'
@@ -1363,7 +1363,7 @@ elbv2_delete_rule <- function(RuleArn) {
 #' \dontrun{
 #' # This example deletes the specified target group.
 #' svc$delete_target_group(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 #' )
 #' }
 #'
@@ -1424,7 +1424,7 @@ elbv2_delete_target_group <- function(TargetGroupArn) {
 #' # This example deregisters the specified instance from the specified
 #' # target group.
 #' svc$deregister_targets(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m...",
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar...",
 #'   Targets = list(
 #'     list(
 #'       Id = "i-0f76fade"
@@ -1711,7 +1711,7 @@ elbv2_describe_listener_certificates <- function(ListenerArn, Marker = NULL, Pag
 #' # This example describes the specified listener.
 #' svc$describe_listeners(
 #'   ListenerArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-load-balance..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-lo..."
 #'   )
 #' )
 #' }
@@ -1786,7 +1786,7 @@ elbv2_describe_listeners <- function(LoadBalancerArn = NULL, ListenerArns = NULL
 #' \dontrun{
 #' # This example describes the attributes of the specified load balancer.
 #' svc$describe_load_balancer_attributes(
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 #' )
 #' }
 #'
@@ -1890,7 +1890,7 @@ elbv2_describe_load_balancer_attributes <- function(LoadBalancerArn) {
 #' # This example describes the specified load balancer.
 #' svc$describe_load_balancers(
 #'   LoadBalancerArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
 #'   )
 #' )
 #' }
@@ -2064,7 +2064,7 @@ elbv2_describe_load_balancers <- function(LoadBalancerArns = NULL, Names = NULL,
 #' # This example describes the specified rule.
 #' svc$describe_rules(
 #'   RuleArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/my-load-ba..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/..."
 #'   )
 #' )
 #' }
@@ -2219,7 +2219,7 @@ elbv2_describe_ssl_policies <- function(Names = NULL, Marker = NULL, PageSize = 
 #' # This example describes the tags assigned to the specified load balancer.
 #' svc$describe_tags(
 #'   ResourceArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
 #'   )
 #' )
 #' }
@@ -2292,7 +2292,7 @@ elbv2_describe_tags <- function(ResourceArns) {
 #' \dontrun{
 #' # This example describes the attributes of the specified target group.
 #' svc$describe_target_group_attributes(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 #' )
 #' }
 #'
@@ -2390,7 +2390,7 @@ elbv2_describe_target_group_attributes <- function(TargetGroupArn) {
 #' # This example describes the specified target group.
 #' svc$describe_target_groups(
 #'   TargetGroupArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-targets/73e2d..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-tar..."
 #'   )
 #' )
 #' }
@@ -2468,13 +2468,13 @@ elbv2_describe_target_groups <- function(LoadBalancerArn = NULL, TargetGroupArns
 #' # target group. One target is healthy but the other is not specified in an
 #' # action, so it can't receive traffic from the load balancer.
 #' svc$describe_target_health(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 #' )
 #' 
 #' # This example describes the health of the specified target. This target
 #' # is healthy.
 #' svc$describe_target_health(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m...",
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar...",
 #'   Targets = list(
 #'     list(
 #'       Id = "i-0f76fade",
@@ -2731,11 +2731,11 @@ elbv2_describe_target_health <- function(TargetGroupArn, Targets = NULL) {
 #' svc$modify_listener(
 #'   DefaultActions = list(
 #'     list(
-#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgro...",
+#'       TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012...",
 #'       Type = "forward"
 #'     )
 #'   ),
-#'   ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-..."
+#'   ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listen..."
 #' )
 #' 
 #' # This example changes the server certificate for the specified HTTPS
@@ -2746,7 +2746,7 @@ elbv2_describe_target_health <- function(TargetGroupArn, Targets = NULL) {
 #'       CertificateArn = "arn:aws:iam::123456789012:server-certificate/my-new-server-cert"
 #'     )
 #'   ),
-#'   ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-..."
+#'   ListenerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listen..."
 #' )
 #' }
 #'
@@ -2824,7 +2824,7 @@ elbv2_modify_listener <- function(ListenerArn, Port = NULL, Protocol = NULL, Ssl
 #'       Value = "true"
 #'     )
 #'   ),
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 #' )
 #' 
 #' # This example changes the idle timeout value for the specified load
@@ -2836,7 +2836,7 @@ elbv2_modify_listener <- function(ListenerArn, Port = NULL, Protocol = NULL, Ssl
 #'       Value = "30"
 #'     )
 #'   ),
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 #' )
 #' 
 #' # This example enables access logs for the specified load balancer. Note
@@ -2858,7 +2858,7 @@ elbv2_modify_listener <- function(ListenerArn, Port = NULL, Protocol = NULL, Ssl
 #'       Value = "myapp"
 #'     )
 #'   ),
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer..."
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo..."
 #' )
 #' }
 #'
@@ -3136,7 +3136,7 @@ elbv2_modify_load_balancer_attributes <- function(LoadBalancerArn, Attributes) {
 #'       )
 #'     )
 #'   ),
-#'   RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/app/my..."
+#'   RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-r..."
 #' )
 #' }
 #'
@@ -3268,7 +3268,7 @@ elbv2_modify_rule <- function(RuleArn, Conditions = NULL, Actions = NULL) {
 #' svc$modify_target_group(
 #'   HealthCheckPort = "443",
 #'   HealthCheckProtocol = "HTTPS",
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 #' )
 #' }
 #'
@@ -3340,7 +3340,7 @@ elbv2_modify_target_group <- function(TargetGroupArn, HealthCheckProtocol = NULL
 #'       Value = "600"
 #'     )
 #'   ),
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m..."
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar..."
 #' )
 #' }
 #'
@@ -3411,7 +3411,7 @@ elbv2_modify_target_group_attributes <- function(TargetGroupArn, Attributes) {
 #' # This example registers the specified instances with the specified target
 #' # group.
 #' svc$register_targets(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m...",
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar...",
 #'   Targets = list(
 #'     list(
 #'       Id = "i-80c8dd94"
@@ -3426,7 +3426,7 @@ elbv2_modify_target_group_attributes <- function(TargetGroupArn, Attributes) {
 #' # group using multiple ports. This enables you to register ECS containers
 #' # on the same instance as targets in the target group.
 #' svc$register_targets(
-#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/m...",
+#'   TargetGroupArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:tar...",
 #'   Targets = list(
 #'     list(
 #'       Id = "i-80c8dd94",
@@ -3546,7 +3546,7 @@ elbv2_remove_listener_certificates <- function(ListenerArn, Certificates) {
 #' # balancer.
 #' svc$remove_tags(
 #'   ResourceArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
 #'   ),
 #'   TagKeys = list(
 #'     "project",
@@ -3776,7 +3776,7 @@ elbv2_set_ip_address_type <- function(LoadBalancerArn, IpAddressType) {
 #'   RulePriorities = list(
 #'     list(
 #'       Priority = 5L,
-#'       RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener-rule/ap..."
+#'       RuleArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:listen..."
 #'     )
 #'   )
 #' )
@@ -3844,7 +3844,7 @@ elbv2_set_rule_priorities <- function(RulePriorities) {
 #' # This example associates the specified security group with the specified
 #' # load balancer.
 #' svc$set_security_groups(
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer...",
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo...",
 #'   SecurityGroups = list(
 #'     "sg-5943793c"
 #'   )
@@ -3974,7 +3974,7 @@ elbv2_set_security_groups <- function(LoadBalancerArn, SecurityGroups) {
 #' # This example enables the Availability Zones for the specified subnets
 #' # for the specified load balancer.
 #' svc$set_subnets(
-#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer...",
+#'   LoadBalancerArn = "arn:aws:elasticloadbalancing:us-west-2:123456789012:lo...",
 #'   Subnets = list(
 #'     "subnet-8360a9e7",
 #'     "subnet-b7d581c0"

--- a/paws/R/elbv2_service.R
+++ b/paws/R/elbv2_service.R
@@ -63,7 +63,7 @@ NULL
 #' # This example adds the specified tags to the specified load balancer.
 #' svc$add_tags(
 #'   ResourceArns = list(
-#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/my-load-bal..."
+#'     "arn:aws:elasticloadbalancing:us-west-2:123456789012:loadbalancer/app/m..."
 #'   ),
 #'   Tags = list(
 #'     list(

--- a/paws/R/glacier_operations.R
+++ b/paws/R/glacier_operations.R
@@ -61,7 +61,7 @@ NULL
 #' # my-vault:
 #' svc$abort_multipart_upload(
 #'   accountId = "-",
-#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
 #'   vaultName = "my-vault"
 #' )
 #' }
@@ -338,7 +338,7 @@ glacier_add_tags_to_vault <- function(accountId, vaultName, Tags = NULL) {
 #'   accountId = "-",
 #'   archiveSize = "3145728",
 #'   checksum = "9628195fcdbcbbe76cdde456d4646fa7de5f219fb39823836d81f0cc0e18aa67",
-#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
 #'   vaultName = "my-vault"
 #' )
 #' }
@@ -592,7 +592,7 @@ glacier_create_vault <- function(accountId, vaultName) {
 #' # The example deletes the archive specified by the archive ID.
 #' svc$delete_archive(
 #'   accountId = "-",
-#'   archiveId = "NkbByEejwEggmBz2fTHgJrg0XBoDfjP4q6iu87-TjhqG6eGoOY9Z8i1_AUyUsuhPAdTqLH...",
+#'   archiveId = "NkbByEejwEggmBz2fTHgJrg0XBoDfjP4q6iu87-TjhqG6eGoOY9Z8i1_AUyU...",
 #'   vaultName = "examplevault"
 #' )
 #' }
@@ -984,7 +984,7 @@ glacier_delete_vault_notifications <- function(accountId, vaultName) {
 #' # specified by the job ID.
 #' svc$describe_job(
 #'   accountId = "-",
-#'   jobId = "zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ejh18CnTS5XW...",
+#'   jobId = "zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ej...",
 #'   vaultName = "my-vault"
 #' )
 #' }
@@ -1298,7 +1298,7 @@ glacier_get_data_retrieval_policy <- function(accountId) {
 #' # retrieval job that is identified by the job ID.
 #' svc$get_job_output(
 #'   accountId = "-",
-#'   jobId = "zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ejh18CnTS5XW...",
+#'   jobId = "zbxcm3Z_3z5UkoroF7SuZKrxgGoDc3RloGduS7Eg-RO47Yc6FxsdGBgf_Q2DK5Ej...",
 #'   range = "",
 #'   vaultName = "my-vaul"
 #' )
@@ -1915,7 +1915,7 @@ glacier_initiate_multipart_upload <- function(accountId, vaultName, archiveDescr
 #' svc$initiate_vault_lock(
 #'   accountId = "-",
 #'   policy = list(
-#'     Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Define-vault-lock\",\"Effect..."
+#'     Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Define-vault-loc..."
 #'   ),
 #'   vaultName = "my-vault"
 #' )
@@ -2341,7 +2341,7 @@ glacier_list_multipart_uploads <- function(accountId, vaultName, marker = NULL, 
 #' # The example lists all the parts of a multipart upload.
 #' svc$list_parts(
 #'   accountId = "-",
-#'   uploadId = "OW2fM5iVylEpFEMM9_HpKowRapC3vn5sSL39_396UW9zLFUWVrnRHaPjUJddQ5OxSHVXjYt...",
+#'   uploadId = "OW2fM5iVylEpFEMM9_HpKowRapC3vn5sSL39_396UW9zLFUWVrnRHaPjUJddQ...",
 #'   vaultName = "examplevault"
 #' )
 #' }
@@ -2846,7 +2846,7 @@ glacier_set_data_retrieval_policy <- function(accountId, Policy = NULL) {
 #' svc$set_vault_access_policy(
 #'   accountId = "-",
 #'   policy = list(
-#'     Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Define-owner-access-rights..."
+#'     Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Define-owner-acc..."
 #'   ),
 #'   vaultName = "examplevault"
 #' )
@@ -3198,7 +3198,7 @@ glacier_upload_archive <- function(vaultName, accountId, archiveDescription = NU
 #'   body = "part1",
 #'   checksum = "c06f7cd4baacb087002a99a5f48bf953",
 #'   range = "bytes 0-1048575/*",
-#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
 #'   vaultName = "examplevault"
 #' )
 #' }

--- a/paws/R/glacier_service.R
+++ b/paws/R/glacier_service.R
@@ -70,7 +70,7 @@ NULL
 #' # my-vault:
 #' svc$abort_multipart_upload(
 #'   accountId = "-",
-#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLqyFu7sY1_lR...",
+#'   uploadId = "19gaRezEXAMPLES6Ry5YYdqthHOC_kGRCT03L9yetr220UmPtBYKk-OssZtLq...",
 #'   vaultName = "my-vault"
 #' )
 #' }

--- a/paws/R/iam_operations.R
+++ b/paws/R/iam_operations.R
@@ -473,7 +473,7 @@ iam_attach_user_policy <- function(UserName, PolicyArn) {
 #' \dontrun{
 #' # The following command changes the password for the current IAM user.
 #' svc$change_password(
-#'   NewPassword = "]35d/{pB9Fo9wJ",
+#'   NewPassword = "]35d/\{pB9Fo9wJ",
 #'   OldPassword = "3s0K_;xh4~8XXI"
 #' )
 #' }
@@ -909,7 +909,7 @@ iam_create_instance_profile <- function(InstanceProfileName, Path = NULL) {
 #' # The following command changes IAM user Bob's password and sets the flag
 #' # that required Bob to change the password the next time he signs in.
 #' svc$create_login_profile(
-#'   Password = "h]6EszR}vJ*m",
+#'   Password = "h]6EszR\}vJ*m",
 #'   PasswordResetRequired = TRUE,
 #'   UserName = "Bob"
 #' )
@@ -9083,7 +9083,7 @@ iam_list_virtual_mfa_devices <- function(AssignmentStatus = NULL, Marker = NULL,
 #' # named Admins.
 #' svc$put_group_policy(
 #'   GroupName = "Admins",
-#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"Action\":\"*...",
+#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"...",
 #'   PolicyName = "AllPerms"
 #' )
 #' }
@@ -9254,7 +9254,7 @@ iam_put_role_permissions_boundary <- function(RoleName, PermissionsBoundary) {
 #' # The following command adds a permissions policy to the role named
 #' # Test-Role.
 #' svc$put_role_policy(
-#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"Action\":\"s...",
+#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"...",
 #'   PolicyName = "S3AccessPolicy",
 #'   RoleName = "S3Access"
 #' )
@@ -9414,7 +9414,7 @@ iam_put_user_permissions_boundary <- function(UserName, PermissionsBoundary) {
 #' \dontrun{
 #' # The following command attaches a policy to the IAM user named Bob.
 #' svc$put_user_policy(
-#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"Action\":\"*...",
+#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":\{\"Effect\":\"Allow\",\"...",
 #'   PolicyName = "AllAccessPolicy",
 #'   UserName = "Bob"
 #' )
@@ -11199,7 +11199,7 @@ iam_update_account_password_policy <- function(MinimumPasswordLength = NULL, Req
 #' # The following command updates the role trust policy for the role named
 #' # Test-Role:
 #' svc$update_assume_role_policy(
-#'   PolicyDocument = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Effect\":\"Allow\",\"Principal...",
+#'   PolicyDocument = "\{"Version":"2012-10-17","Statement":[\{"Effect":"Allow",...",
 #'   RoleName = "S3AccessForEC2Instances"
 #' )
 #' }
@@ -12275,9 +12275,9 @@ iam_upload_ssh_public_key <- function(UserName, SSHPublicKeyBody) {
 #' # The following upload-server-certificate command uploads a server
 #' # certificate to your AWS account:
 #' svc$upload_server_certificate(
-#'   CertificateBody = "-----BEGIN CERTIFICATE-----<a very long certificate text string>...",
+#'   CertificateBody = "-----BEGIN CERTIFICATE-----<a very long certificate te...",
 #'   Path = "/company/servercerts/",
-#'   PrivateKey = "-----BEGIN DSA PRIVATE KEY-----<a very long private key string>-----E...",
+#'   PrivateKey = "-----BEGIN DSA PRIVATE KEY-----<a very long private key str...",
 #'   ServerCertificateName = "ProdServerCert"
 #' )
 #' }

--- a/paws/R/inspector_operations.R
+++ b/paws/R/inspector_operations.R
@@ -57,7 +57,7 @@ NULL
 #'     )
 #'   ),
 #'   findingArns = list(
-#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-8l1VIE0D/r..."
+#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
 #'   )
 #' )
 #' }
@@ -409,7 +409,7 @@ inspector_create_resource_group <- function(resourceGroupTags) {
 #' # Deletes the assessment run that is specified by the ARN of the
 #' # assessment run.
 #' svc$delete_assessment_run(
-#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/temp..."
+#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvg..."
 #' )
 #' }
 #'
@@ -511,7 +511,7 @@ inspector_delete_assessment_target <- function(assessmentTargetArn) {
 #' # Deletes the assessment template that is specified by the ARN of the
 #' # assessment template.
 #' svc$delete_assessment_template(
-#'   assessmentTemplateArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX..."
+#'   assessmentTemplateArn = "arn:aws:inspector:us-west-2:123456789012:target/..."
 #' )
 #' }
 #'
@@ -629,7 +629,7 @@ inspector_delete_assessment_template <- function(assessmentTemplateArn) {
 #' # assessment runs.
 #' svc$describe_assessment_runs(
 #'   assessmentRunArns = list(
-#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/r..."
+#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
 #'   )
 #' )
 #' }
@@ -1069,7 +1069,7 @@ inspector_describe_exclusions <- function(exclusionArns, locale = NULL) {
 #' # Describes the findings that are specified by the ARNs of the findings.
 #' svc$describe_findings(
 #'   findingArns = list(
-#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/r..."
+#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
 #'   )
 #' )
 #' }
@@ -1431,7 +1431,7 @@ inspector_get_exclusions_preview <- function(assessmentTemplateArn, previewToken
 #' # Information about the data that is collected for the specified
 #' # assessment run.
 #' svc$get_telemetry_metadata(
-#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/temp..."
+#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kF..."
 #' )
 #' }
 #'
@@ -1529,7 +1529,7 @@ inspector_get_telemetry_metadata <- function(assessmentRunArn) {
 #' # Lists the agents of the assessment runs that are specified by the ARNs
 #' # of the assessment runs.
 #' svc$list_assessment_run_agents(
-#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/temp...",
+#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kF...",
 #'   maxResults = 123L
 #' )
 #' }
@@ -1898,7 +1898,7 @@ inspector_list_assessment_templates <- function(assessmentTargetArns = NULL, fil
 #' # specified by the ARN of the assessment template.
 #' svc$list_event_subscriptions(
 #'   maxResults = 123L,
-#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/..."
+#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX..."
 #' )
 #' }
 #'
@@ -2073,7 +2073,7 @@ inspector_list_exclusions <- function(assessmentRunArn, nextToken = NULL, maxRes
 #' # specified by the ARNs of the assessment runs.
 #' svc$list_findings(
 #'   assessmentRunArns = list(
-#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-4r1V2mAw/r..."
+#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
 #'   ),
 #'   maxResults = 123L
 #' )
@@ -2197,7 +2197,7 @@ inspector_list_rules_packages <- function(nextToken = NULL, maxResults = NULL) {
 #' \dontrun{
 #' # Lists all tags associated with an assessment template.
 #' svc$list_tags_for_resource(
-#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/..."
+#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq..."
 #' )
 #' }
 #'
@@ -2404,7 +2404,7 @@ inspector_register_cross_account_access_role <- function(roleArn) {
 #'     "key=Example,value=example"
 #'   ),
 #'   findingArns = list(
-#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-8l1VIE0D/r..."
+#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
 #'   )
 #' )
 #' }
@@ -2464,7 +2464,7 @@ inspector_remove_attributes_from_findings <- function(findingArns, attributeKeys
 #' # Sets tags (key and value pairs) to the assessment template that is
 #' # specified by the ARN of the assessment template.
 #' svc$set_tags_for_resource(
-#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/...",
+#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX...",
 #'   tags = list(
 #'     list(
 #'       key = "Example",
@@ -2534,7 +2534,7 @@ inspector_set_tags_for_resource <- function(resourceArn, tags = NULL) {
 #' # limit of running up to 500 concurrent agents per AWS account.
 #' svc$start_assessment_run(
 #'   assessmentRunName = "examplerun",
-#'   assessmentTemplateArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX..."
+#'   assessmentTemplateArn = "arn:aws:inspector:us-west-2:123456789012:target/..."
 #' )
 #' }
 #'
@@ -2591,7 +2591,7 @@ inspector_start_assessment_run <- function(assessmentTemplateArn, assessmentRunN
 #' # Stops the assessment run that is specified by the ARN of the assessment
 #' # run.
 #' svc$stop_assessment_run(
-#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/temp..."
+#'   assessmentRunArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvg..."
 #' )
 #' }
 #'
@@ -2648,7 +2648,7 @@ inspector_stop_assessment_run <- function(assessmentRunArn, stopAction = NULL) {
 #' # notifications about a specified event to a specified SNS topic.
 #' svc$subscribe_to_event(
 #'   event = "ASSESSMENT_RUN_COMPLETED",
-#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/...",
+#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX...",
 #'   topicArn = "arn:aws:sns:us-west-2:123456789012:exampletopic"
 #' )
 #' }
@@ -2706,7 +2706,7 @@ inspector_subscribe_to_event <- function(resourceArn, event, topicArn) {
 #' # notifications about a specified event to a specified SNS topic.
 #' svc$unsubscribe_from_event(
 #'   event = "ASSESSMENT_RUN_COMPLETED",
-#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX/template/...",
+#'   resourceArn = "arn:aws:inspector:us-west-2:123456789012:target/0-nvgVhaxX...",
 #'   topicArn = "arn:aws:sns:us-west-2:123456789012:exampletopic"
 #' )
 #' }

--- a/paws/R/inspector_service.R
+++ b/paws/R/inspector_service.R
@@ -45,7 +45,7 @@ NULL
 #'     )
 #'   ),
 #'   findingArns = list(
-#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-8l1VIE0D/r..."
+#'     "arn:aws:inspector:us-west-2:123456789012:target/0-0kFIPusq/template/0-..."
 #'   )
 #' )
 #' }

--- a/paws/R/kinesisvideoarchivedmedia_operations.R
+++ b/paws/R/kinesisvideoarchivedmedia_operations.R
@@ -30,9 +30,9 @@ NULL
 #' 
 #' -   The video track of each fragment must contain codec private data in
 #'     the Advanced Video Coding (AVC) for H.264 format and HEVC for H.265
-#'     format. For more information, see MPEG-4 specification ISO/IEC
-#'     14496-15. For information about adapting stream data to a given
-#'     format, see [NAL Adaptation
+#'     format. For more information, see [MPEG-4 specification ISO/IEC
+#'     14496-15](https://www.iso.org/standard/55980.html). For information
+#'     about adapting stream data to a given format, see [NAL Adaptation
 #'     Flags](https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/producer-reference-nal.html).
 #' 
 #' -   The audio track (if present) of each fragment must contain codec

--- a/paws/R/kms_operations.R
+++ b/paws/R/kms_operations.R
@@ -4671,7 +4671,7 @@ kms_list_retirable_grants <- function(Limit = NULL, Marker = NULL, RetiringPrinc
 #' # The following example attaches a key policy to the specified CMK.
 #' svc$put_key_policy(
 #'   KeyId = "1234abcd-12ab-34cd-56ef-1234567890ab",
-#'   Policy = "\{\n    "Version": "2012-10-17",\n    "Id": "custom-policy-2016-12-07",\n ...",
+#'   Policy = "\{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"custom-policy-2016-...",
 #'   PolicyName = "default"
 #' )
 #' }

--- a/paws/R/marketplacecatalog_operations.R
+++ b/paws/R/marketplacecatalog_operations.R
@@ -360,7 +360,8 @@ marketplacecatalog_list_entities <- function(Catalog, EntityType, FilterList = N
 #' try to start a ChangeSet containing a change against an entity that is
 #' already locked, you will receive a `ResourceInUseException`.
 #' 
-#' For example, you cannot start the ChangeSet described in the example
+#' For example, you cannot start the ChangeSet described in the
+#' [example](https://docs.aws.amazon.com/marketplace-catalog/latest/api-reference/API_StartChangeSet.html#API_StartChangeSet_Examples)
 #' below because it contains two changes to execute the same change type
 #' (`AddRevisions`) against the same entity (`entity-id@@1)`.
 #'

--- a/paws/R/organizations_operations.R
+++ b/paws/R/organizations_operations.R
@@ -4962,7 +4962,7 @@ organizations_update_organizational_unit <- function(OrganizationalUnitId, Name 
 #' # the preceding example with a new JSON policy text string that allows S3
 #' # actions instead of EC2 actions:/n/n
 #' svc$update_policy(
-#'   Content = "\{ \"Version\": \"2012-10-17\", \"Statement\": \{\"Effect\": \"Allow\", \"Action\": \"s...",
+#'   Content = "\{ \"Version\": \"2012-10-17\", \"Statement\": \{\"Effect\": \"Allow\", \"A...",
 #'   PolicyId = "p-examplepolicyid111"
 #' )
 #' }

--- a/paws/R/s3_operations.R
+++ b/paws/R/s3_operations.R
@@ -91,7 +91,7 @@ NULL
 #' svc$abort_multipart_upload(
 #'   Bucket = "examplebucket",
 #'   Key = "bigobject",
-#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 #' )
 #' }
 #'
@@ -267,7 +267,7 @@ s3_abort_multipart_upload <- function(Bucket, Key, UploadId, RequestPayer = NULL
 #'       )
 #'     )
 #'   ),
-#'   UploadId = "7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOmrEQHDsP..."
+#'   UploadId = "7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91..."
 #' )
 #' }
 #'
@@ -7363,7 +7363,7 @@ s3_list_objects_v2 <- function(Bucket, Delimiter = NULL, EncodingType = NULL, Ma
 #' svc$list_parts(
 #'   Bucket = "examplebucket",
 #'   Key = "bigobject",
-#'   UploadId = "example7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+#'   UploadId = "example7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 #' )
 #' }
 #'
@@ -9358,7 +9358,7 @@ s3_put_bucket_ownership_controls <- function(Bucket, ContentMD5 = NULL, Expected
 #' # The following example sets a permission policy on a bucket.
 #' svc$put_bucket_policy(
 #'   Bucket = "examplebucket",
-#'   Policy = "\{"Version": "2012-10-17", "Statement": [\{ "Sid": "id-1","Effect": "Allow"..."
+#'   Policy = "\{\"Version\": \"2012-10-17\", \"Statement\": [\{ \"Sid\": \"id-1\",\"Effect..."
 #' )
 #' }
 #'
@@ -12129,7 +12129,7 @@ s3_select_object_content <- function(Bucket, Key, SSECustomerAlgorithm = NULL, S
 #'   Bucket = "examplebucket",
 #'   Key = "examplelargeobject",
 #'   PartNumber = "1",
-#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 #' )
 #' }
 #'
@@ -12443,7 +12443,7 @@ s3_upload_part <- function(Body = NULL, Bucket, ContentLength = NULL, ContentMD5
 #'   CopySource = "/bucketname/sourceobjectkey",
 #'   Key = "examplelargeobject",
 #'   PartNumber = "1",
-#'   UploadId = "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3cq3LZSUsfjI..."
+#'   UploadId = "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3c..."
 #' )
 #' 
 #' # The following example uploads a part of a multipart upload by copying a
@@ -12454,7 +12454,7 @@ s3_upload_part <- function(Body = NULL, Bucket, ContentLength = NULL, ContentMD5
 #'   CopySourceRange = "bytes=1-100000",
 #'   Key = "examplelargeobject",
 #'   PartNumber = "2",
-#'   UploadId = "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3cq3LZSUsfjI..."
+#'   UploadId = "exampleuoh_10OhKhT7YukE9bjzTPRiuaCotmZM_pFngJFir9OZNrSr5cWa3c..."
 #' )
 #' }
 #'

--- a/paws/R/s3_service.R
+++ b/paws/R/s3_service.R
@@ -35,7 +35,7 @@ NULL
 #' svc$abort_multipart_upload(
 #'   Bucket = "examplebucket",
 #'   Key = "bigobject",
-#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LAT2dUN91cOm..."
+#'   UploadId = "xadcOB_7YPBOJuoFiQ9cz4P3Pe6FIZwO4f7wN93uHsNBEw97pl5eNwzExg0LA..."
 #' )
 #' }
 #'

--- a/paws/R/secretsmanager_operations.R
+++ b/paws/R/secretsmanager_operations.R
@@ -1497,7 +1497,7 @@ secretsmanager_list_secrets <- function(MaxResults = NULL, NextToken = NULL, Fil
 #' # The following example shows how to add a resource-based policy to a
 #' # secret.
 #' svc$put_resource_policy(
-#'   ResourcePolicy = "\{\n\"Version\":\"2012-10-17\",\n\"Statement\":[\{\n\"Effect\":\"Allow\",\n\"P...",
+#'   ResourcePolicy = "\{\n\"Version\":\"2012-10-17\",\n\"Statement\":[\{\n\"Effect\":\"A...",
 #'   SecretId = "MyTestDatabaseSecret"
 #' )
 #' }
@@ -2002,7 +2002,7 @@ secretsmanager_restore_secret <- function(SecretId) {
 #' # upon completion of this command. The rotation function runs
 #' # asynchronously in the background.
 #' svc$rotate_secret(
-#'   RotationLambdaARN = "arn:aws:lambda:us-west-2:123456789012:function:MyTestDatabaseR...",
+#'   RotationLambdaARN = "arn:aws:lambda:us-west-2:123456789012:function:MyTes...",
 #'   RotationRules = list(
 #'     AutomaticallyAfterDays = 30L
 #'   ),
@@ -2760,7 +2760,7 @@ secretsmanager_update_secret_version_stage <- function(SecretId, VersionStage, R
 #' # The following example shows how to validate a resource-based policy to a
 #' # secret.
 #' svc$validate_resource_policy(
-#'   ResourcePolicy = "\{\n\"Version\":\"2012-10-17\",\n\"Statement\":[\{\n\"Effect\":\"Allow\",\n\"P...",
+#'   ResourcePolicy = "\{\n\"Version\":\"2012-10-17\",\n\"Statement\":[\{\n\"Effect\":\"A...",
 #'   SecretId = "MyTestDatabaseSecret"
 #' )
 #' }

--- a/paws/R/servicediscovery_operations.R
+++ b/paws/R/servicediscovery_operations.R
@@ -1815,7 +1815,7 @@ servicediscovery_register_instance <- function(ServiceId, InstanceId, CreatorReq
 #' \dontrun{
 #' # This example adds "Department" and "Project" tags to a resource.
 #' svc$tag_resource(
-#'   ResourceARN = "arn:aws:servicediscovery:us-east-1:123456789012:namespace/ns-ylexjil...",
+#'   ResourceARN = "arn:aws:servicediscovery:us-east-1:123456789012:namespace/...",
 #'   Tags = list(
 #'     list(
 #'       Key = "Department",
@@ -1879,7 +1879,7 @@ servicediscovery_tag_resource <- function(ResourceARN, Tags) {
 #' # This example removes the "Department" and "Project" tags from a
 #' # resource.
 #' svc$untag_resource(
-#'   ResourceARN = "arn:aws:servicediscovery:us-east-1:123456789012:namespace/ns-ylexjil...",
+#'   ResourceARN = "arn:aws:servicediscovery:us-east-1:123456789012:namespace/...",
 #'   TagKeys = list(
 #'     "Project",
 #'     "Department"

--- a/paws/R/ses_operations.R
+++ b/paws/R/ses_operations.R
@@ -2954,7 +2954,7 @@ ses_put_configuration_set_delivery_options <- function(ConfigurationSetName, Del
 #' # identity:
 #' svc$put_identity_policy(
 #'   Identity = "example.com",
-#'   Policy = "\{"Version":"2008-10-17","Statement":[\{"Sid":"stmt1469123904194","Effect":...",
+#'   Policy = "\{"Version":"2008-10-17","Statement":[\{"Sid":"stmt1469123904194"...",
 #'   PolicyName = "MyPolicy"
 #' )
 #' }
@@ -3625,7 +3625,7 @@ ses_send_custom_verification_email <- function(EmailAddress, TemplateName, Confi
 #'     Body = list(
 #'       Html = list(
 #'         Charset = "UTF-8",
-#'         Data = "This message body contains HTML formatting. It can, for example, cont..."
+#'         Data = "This message body contains HTML formatting. It can, for exa..."
 #'       ),
 #'       Text = list(
 #'         Charset = "UTF-8",
@@ -3918,7 +3918,7 @@ ses_send_email <- function(Source, Destination, Message, ReplyToAddresses = NULL
 #'   Destinations = list(),
 #'   FromArn = "",
 #'   RawMessage = list(
-#'     Data = "From: sender@example.com\\nTo: recipient@example.com\\nSubject: Test emai..."
+#'     Data = "From: sender@example.com\\nTo: recipient@example.com\\nSubject:..."
 #'   ),
 #'   ReturnPathArn = "",
 #'   Source = "",

--- a/paws/R/snowball_operations.R
+++ b/paws/R/snowball_operations.R
@@ -1930,7 +1930,7 @@ snowball_update_cluster <- function(ClusterId, RoleARN = NULL, Description = NUL
 #' # job being created, this action is no longer available.
 #' svc$update_job(
 #'   AddressId = "ADID1234ab12-3eec-4eb3-9be6-9374c10eb51b",
-#'   Description = "Upgraded to Edge, shipped to Finance Dept, and requested faster ship...",
+#'   Description = "Upgraded to Edge, shipped to Finance Dept, and requested f...",
 #'   JobId = "JID123e4567-e89b-12d3-a456-426655440000",
 #'   ShippingOption = "NEXT_DAY",
 #'   SnowballCapacityPreference = "T100"

--- a/paws/R/storagegateway_operations.R
+++ b/paws/R/storagegateway_operations.R
@@ -1288,7 +1288,7 @@ storagegateway_create_smb_file_share <- function(ClientToken, GatewayARN, KMSEnc
 #' # Initiates an ad-hoc snapshot of a gateway volume.
 #' svc$create_snapshot(
 #'   SnapshotDescription = "My root volume snapshot as of 10/03/2017",
-#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -1388,7 +1388,7 @@ storagegateway_create_snapshot <- function(VolumeARN, SnapshotDescription, Tags 
 #' # Initiates a snapshot of a gateway from a volume recovery point.
 #' svc$create_snapshot_from_volume_recovery_point(
 #'   SnapshotDescription = "My root volume snapshot as of 2017-06-30T10:10:10.000Z",
-#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -1998,7 +1998,7 @@ storagegateway_delete_bandwidth_rate_limit <- function(GatewayARN, BandwidthType
 #' # for a specified iSCSI target and initiator pair.
 #' svc$delete_chap_credentials(
 #'   InitiatorName = "iqn.1991-05.com.microsoft:computername.domain.example.com",
-#'   TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/tar..."
+#'   TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -2191,7 +2191,7 @@ storagegateway_delete_gateway <- function(GatewayARN) {
 #' \dontrun{
 #' # This action enables you to delete a snapshot schedule for a volume.
 #' svc$delete_snapshot_schedule(
-#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -2440,7 +2440,7 @@ storagegateway_delete_tape_pool <- function(PoolARN) {
 #' # Deletes the specified gateway volume that you previously created using
 #' # the CreateCachediSCSIVolume or CreateStorediSCSIVolume API.
 #' svc$delete_volume(
-#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -2858,7 +2858,7 @@ storagegateway_describe_cachedi_scsi_volumes <- function(VolumeARNs) {
 #' # credentials information for a specified iSCSI target, one for each
 #' # target-initiator pair.
 #' svc$describe_chap_credentials(
-#'   TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/tar..."
+#'   TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -3310,7 +3310,7 @@ storagegateway_describe_smb_settings <- function(GatewayARN) {
 #' # Describes the snapshot schedule for the specified gateway volume
 #' # including intervals at which snapshots are automatically initiated.
 #' svc$describe_snapshot_schedule(
-#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -5871,7 +5871,7 @@ storagegateway_update_bandwidth_rate_limit_schedule <- function(GatewayARN, Band
 #'   InitiatorName = "iqn.1991-05.com.microsoft:computername.domain.example.com",
 #'   SecretToAuthenticateInitiator = "111111111111",
 #'   SecretToAuthenticateTarget = "222222222222",
-#'   TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/tar..."
+#'   TargetARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -6611,7 +6611,7 @@ storagegateway_update_smb_security_strategy <- function(GatewayARN, SMBSecurityS
 #'   Description = "Hourly snapshot",
 #'   RecurrenceInHours = 1L,
 #'   StartAt = 0L,
-#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12A3456B/vol..."
+#'   VolumeARN = "arn:aws:storagegateway:us-east-1:111122223333:gateway/sgw-12..."
 #' )
 #' }
 #'
@@ -6674,7 +6674,7 @@ storagegateway_update_snapshot_schedule <- function(VolumeARN, StartAt, Recurren
 #' # is activated.
 #' svc$update_vtl_device_type(
 #'   DeviceType = "Medium Changer",
-#'   VTLDeviceARN = "arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw-12A3456B/..."
+#'   VTLDeviceARN = "arn:aws:storagegateway:us-east-1:999999999999:gateway/sgw..."
 #' )
 #' }
 #'

--- a/paws/R/storagegateway_service.R
+++ b/paws/R/storagegateway_service.R
@@ -68,7 +68,7 @@ NULL
 #' 
 #' For more information, see [Announcement: Heads-up – Longer AWS Storage
 #' Gateway volume and snapshot IDs coming in
-#' 2016](https://forums.aws.amazon.com:443/ann.jspa?annID=3557).
+#' 2016](https://forums.aws.amazon.com/ann.jspa?annID=3557).
 #'
 #' @param
 #' config

--- a/paws/R/sts_operations.R
+++ b/paws/R/sts_operations.R
@@ -381,7 +381,7 @@ NULL
 #' # 
 #' svc$assume_role(
 #'   ExternalId = "123ABC",
-#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
 #'   RoleArn = "arn:aws:iam::123456789012:role/demo",
 #'   RoleSessionName = "testAssumeRoleSession",
 #'   Tags = list(
@@ -709,7 +709,7 @@ sts_assume_role <- function(RoleArn, RoleSessionName, PolicyArns = NULL, Policy 
 #'   DurationSeconds = 3600L,
 #'   PrincipalArn = "arn:aws:iam::123456789012:saml-provider/SAML-test",
 #'   RoleArn = "arn:aws:iam::123456789012:role/TestSaml",
-#'   SAMLAssertion = "VERYLONGENCODEDASSERTIONEXAMPLExzYW1sOkF1ZGllbmNlPmJsYW5rPC9zYW1sO..."
+#'   SAMLAssertion = "VERYLONGENCODEDASSERTIONEXAMPLExzYW1sOkF1ZGllbmNlPmJsYW5..."
 #' )
 #' }
 #'
@@ -1059,11 +1059,11 @@ sts_assume_role_with_saml <- function(RoleArn, PrincipalArn, SAMLAssertion, Poli
 #' # 
 #' svc$assume_role_with_web_identity(
 #'   DurationSeconds = 3600L,
-#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
 #'   ProviderId = "www.amazon.com",
 #'   RoleArn = "arn:aws:iam::123456789012:role/FederatedWebIdentityRole",
 #'   RoleSessionName = "app1",
-#'   WebIdentityToken = "Atza%7CIQEBLjAsAhRFiXuWpUXuRvQ9PZL3GMFcYevydwIUFAHZwXZXXXXXXXXJ..."
+#'   WebIdentityToken = "Atza%7CIQEBLjAsAhRFiXuWpUXuRvQ9PZL3GMFcYevydwIUFAHZwX..."
 #' )
 #' }
 #'
@@ -1608,7 +1608,7 @@ sts_get_caller_identity <- function() {
 #' svc$get_federation_token(
 #'   DurationSeconds = 3600L,
 #'   Name = "testFedUserSession",
-#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
 #'   Tags = list(
 #'     list(
 #'       Key = "Project",

--- a/paws/R/sts_service.R
+++ b/paws/R/sts_service.R
@@ -40,7 +40,7 @@ NULL
 #' # 
 #' svc$assume_role(
 #'   ExternalId = "123ABC",
-#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"Allow\",\"Act...",
+#'   Policy = "\{\"Version\":\"2012-10-17\",\"Statement\":[\{\"Sid\":\"Stmt1\",\"Effect\":\"A...",
 #'   RoleArn = "arn:aws:iam::123456789012:role/demo",
 #'   RoleSessionName = "testAssumeRoleSession",
 #'   Tags = list(


### PR DESCRIPTION
* Update category package versions to 0.1.11.
* Shorten long lines in examples.
* Add escapes to some arguments in examples where quotes or braces are unmatched.