### PR TITLE
Use path style S3 URLs when using custom endpoints or the s3_force_path_style option

### DIFF
--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -65,8 +65,10 @@ update_endpoint_for_s3_config <- function(request) {
 
   if (request$operation$name %in% c("GetBucketLocation")) return(request)
 
-  request$http_request$url <-
-    move_bucket_to_host(request$http_request$url, bucket_name)
+  if (!request$config$s3_force_path_style) {
+    request$http_request$url <-
+      move_bucket_to_host(request$http_request$url, bucket_name)
+  }
 
   return(request)
 }

--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -65,7 +65,11 @@ update_endpoint_for_s3_config <- function(request) {
 
   if (request$operation$name %in% c("GetBucketLocation")) return(request)
 
-  if (!request$config$s3_force_path_style) {
+  use_virtual_host_style <- TRUE
+  if (request$config$s3_force_path_style) use_virtual_host_style <- FALSE
+  if (request$config$endpoint != "") use_virtual_host_style <- FALSE
+
+  if (use_virtual_host_style) {
     request$http_request$url <-
       move_bucket_to_host(request$http_request$url, bucket_name)
   }

--- a/paws.common/tests/testthat/test_custom_s3.R
+++ b/paws.common/tests/testthat/test_custom_s3.R
@@ -25,15 +25,24 @@ test_that("update_endpoint_for_s3_config", {
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "foo-bar.s3.amazonaws.com")
 
+  # Use a path style URL if the config specifies path style.
   req <- build_request(bucket = "foo-bar", operation = "ListObjects")
   req$config$s3_force_path_style <- TRUE
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "s3.amazonaws.com")
 
+  # Use a path style URL if the config has a custom endpoint.
+  req <- build_request(bucket = "foo-bar", operation = "ListObjects")
+  req$config$endpoint <- "localhost:9000"
+  result <- update_endpoint_for_s3_config(req)
+  expect_equal(result$http_request$url$host, "s3.amazonaws.com")
+
+  # Use a path style URL if the bucket name is not DNS compatible.
   req <- build_request(bucket = "foo.bar", operation = "ListObjects")
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "s3.amazonaws.com")
 
+  # Use a path style URL for GetBucketLocation specifically.
   req <- build_request(bucket = "foo-bar", operation = "GetBucketLocation")
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "s3.amazonaws.com")

--- a/paws.common/tests/testthat/test_custom_s3.R
+++ b/paws.common/tests/testthat/test_custom_s3.R
@@ -25,6 +25,11 @@ test_that("update_endpoint_for_s3_config", {
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "foo-bar.s3.amazonaws.com")
 
+  req <- build_request(bucket = "foo-bar", operation = "ListObjects")
+  req$config$s3_force_path_style <- TRUE
+  result <- update_endpoint_for_s3_config(req)
+  expect_equal(result$http_request$url$host, "s3.amazonaws.com")
+
   req <- build_request(bucket = "foo.bar", operation = "ListObjects")
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "s3.amazonaws.com")


### PR DESCRIPTION
* Use path style URLs for S3 when using custom endpoints, (e.g. localhost:9000/mybucket). This is useful when using software like MinIO. When not using custom endpoints, Paws will in general use "virtual hosted" URLs (e.g. mybucket.s3.amazonaws.com) except in special cases.

* Use path style URLs for S3 when using the new `s3_force_path_style` option when calling `paws::s3()`, e.g.:
    ```r
    s3 <- paws::s3(config = list(
        s3_force_path_style = TRUE
    ))
    ```

Addresses #404.