### PR TITLE
Fix the REST build handler for services with lower case parameter names

### DIFF
--- a/paws.common/R/handlers_rest.R
+++ b/paws.common/R/handlers_rest.R
@@ -16,11 +16,6 @@ rest_build_location_elements <- function(request, values, build_get_query) {
   for (field_name in names(values)) {
     field <- values[[field_name]]
 
-    # Ignore unexported fields.
-    if (substr(field_name, 1, 1) == tolower(substr(field_name, 1, 1))) {
-      next
-    }
-
     if (is_valid(field)) {
       name <- tag_get(field, "locationName")
       if (name == "") {

--- a/paws.common/tests/testthat/test_handlers_rest.R
+++ b/paws.common/tests/testthat/test_handlers_rest.R
@@ -50,3 +50,25 @@ test_that("build request with URL requiring escaping", {
   expect_equal(r$url$path, "/mybucket/my/cool+thing space/object世界")
   expect_equal(r$url$raw_path, "/mybucket/my/cool%2Bthing%20space/object%E4%B8%96%E7%95%8C")
 })
+
+test_that("build request with URL", {
+  op1 <- Operation(
+    name = "OperationName",
+    http_method = "GET",
+    http_path = "/{foo}"
+  )
+  op_input1 <- function(foo) {
+    args <- list(foo = foo)
+    interface <- Structure(
+      foo = Scalar(type = "string", .tags = list(location = "uri"))
+    )
+    return(populate(args, interface))
+  }
+  input <- op_input1(
+    foo = "bar"
+  )
+  req <- new_request(svc, op1, input, NULL)
+  req <- build(req)
+  r <- req$http_request
+  expect_equal(r$url$path, "/bar")
+})


### PR DESCRIPTION
Don't skip lower case field names for REST location elements, which came from a misunderstanding of the protocol. For example, `lexmodelbuildingservice$create_bot_version(name, checksum)` currently fails due incorrectly skipping the `name` field.

Addresses #411.