### PR TITLE
Support user-configurable connection timeout

### DIFF
--- a/paws.common/R/client.R
+++ b/paws.common/R/client.R
@@ -12,6 +12,7 @@ Config <- struct(
   region = "",
   disable_ssl = FALSE,
   max_retries = -1,
+  timeout = 60,
   retryer = NULL,
   disable_param_validation = FALSE,
   disable_compute_checksums = FALSE,

--- a/paws.common/R/net.R
+++ b/paws.common/R/net.R
@@ -90,7 +90,8 @@ issue <- function(http_request) {
   url <- build_url(http_request$url)
   headers <- unlist(http_request$header)
   body <- http_request$body
-  timeout <- if (!is.null(http_request$timeout)) httr::timeout(http_request$timeout)
+  timeout <- httr::config(connecttimeout = http_request$timeout)
+  if (is.null(http_request$timeout)) timeout <- NULL
 
   if (url == "") {
     stop("no url provided")

--- a/paws.common/R/request.R
+++ b/paws.common/R/request.R
@@ -108,7 +108,7 @@ new_request <- function(client, operation, params, data) {
     method <- "POST"
   }
 
-  http_req <- new_http_request(method, "", NULL)
+  http_req <- new_http_request(method, "", NULL, client$config$timeout)
 
   http_req$url <- parse_url(
     paste0(client$client_info$endpoint, operation$http_path)

--- a/paws.common/tests/testthat/test_net.R
+++ b/paws.common/tests/testthat/test_net.R
@@ -9,6 +9,29 @@ test_that("issue", {
   expect_equal(body$slideshow$title, "Sample Slide Show")
 })
 
+test_that("timeout", {
+  req <- HttpRequest(
+    method = "GET",
+    url = parse_url("https://example.com:81"),
+    timeout = 1
+  )
+  quietly <- function(expr) suppressMessages(tryCatch(expr, error = function(e) {}))
+  time <- system.time({
+    quietly(issue(req))
+  })
+  expect_equivalent(time["elapsed"], 1, tolerance = 0.5)
+})
+
+test_that("timeout does not affect established connections", {
+  req <- HttpRequest(
+    method = "GET",
+    url = parse_url("https://httpbin.org/delay/3"),
+    timeout = 1
+  )
+  resp <- issue(req)
+  expect_equal(resp$status_code, 200)
+})
+
 test_that("don't decompress the body when already decompressed", {
   req <- HttpRequest(
     method = "GET",


### PR DESCRIPTION
Add support and a default value for the following config option:

* `timeout`: How long to wait in seconds for an acknowledgement of an HTTP request before failing. Default = 60.

This is user configurable by adding arguments to the service call, e.g.

```
svc <- paws::svc(config = list(timeout = 10))
```

Partly addresses #406.