### PR TITLE
Support S3 access points

### DIFF
--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -63,8 +63,13 @@ is_access_point <- function(bucket_name) {
 }
 
 # Parse the S3 access point ARN and return the corresponding endpoint.
-# Access point endpoint format: {accesspointName}-{accountId}.s3-accesspoint.{region}.{dnsSuffix}
-# Example: myaccesspoint-012345678901.s3-accesspoint.us-west-2.amazonaws.com
+# See https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html
+#
+# ARN format: arn:aws:s3:{region}:{account-id}:accesspoint/{accesspoint-name}
+# Access point endpoint format: {accesspoint-name}-{account-id}.s3-accesspoint.{region}.{dnsSuffix}
+# Example:
+#   In: arn:aws:s3:us-west-2:123456789012:accesspoint/test
+#   Out: test-123456789012.s3-accesspoint.us-west-2.amazonaws.com
 get_access_point_endpoint <- function(access_point) {
   part <- strsplit(access_point, ":|/")[[1]]
   region <- part[4]

--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -56,10 +56,40 @@ move_bucket_to_host <- function(url, bucket) {
   return(url)
 }
 
+# Check if a given bucket name is an S3 access point.
+is_access_point <- function(bucket_name) {
+  regex <- "^(.+):(.+):(.+):(.+):(.+):(.+)$"
+  return(grepl(regex, bucket_name))
+}
+
+# Parse the S3 access point ARN and return the corresponding endpoint.
+# Access point endpoint format: {accesspointName}-{accountId}.s3-accesspoint.{region}.{dnsSuffix}
+# Example: myaccesspoint-012345678901.s3-accesspoint.us-west-2.amazonaws.com
+get_access_point_endpoint <- function(access_point) {
+  part <- strsplit(access_point, ":|/")[[1]]
+  region <- part[4]
+  account <- part[5]
+  name <- part[7]
+  endpoint <- sprintf("%s-%s.s3-accesspoint.%s.amazonaws.com", name, account, region)
+  return(endpoint)
+}
+
+remove_bucket_from_url <- function(url) {
+  url$path <- gsub("\\{Bucket+?\\}", "", url$path)
+  if (url$path == "") url$path <- "/"
+  return(url)
+}
+
 update_endpoint_for_s3_config <- function(request) {
   bucket_name <- bucket_name_from_req_params(request)
 
   if (is.null(bucket_name)) return(request)
+
+  if (is_access_point(bucket_name)) {
+    request$http_request$url$host <- get_access_point_endpoint(bucket_name)
+    request$http_request$url <- remove_bucket_from_url(request$http_request$url)
+    return(request)
+  }
 
   if (!host_compatible_bucket_name(bucket_name)) return(request)
 

--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -66,7 +66,7 @@ is_access_point <- function(bucket_name) {
 # See https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html
 #
 # ARN format: arn:aws:s3:{region}:{account-id}:accesspoint/{accesspoint-name}
-# Access point endpoint format: {accesspoint-name}-{account-id}.s3-accesspoint.{region}.{dnsSuffix}
+# Access point endpoint format: {accesspoint-name}-{account-id}.s3-accesspoint.{region}.{dns-suffix}
 # Example:
 #   In: arn:aws:s3:us-west-2:123456789012:accesspoint/test
 #   Out: test-123456789012.s3-accesspoint.us-west-2.amazonaws.com

--- a/paws.common/tests/testthat/test_custom_s3.R
+++ b/paws.common/tests/testthat/test_custom_s3.R
@@ -207,3 +207,19 @@ test_that("s3_unmarshal_select_object_content", {
   out <- req$data
   expect_equivalent(out$Payload$Records$Payload, "1\n2\n3\n")
 })
+
+test_that("S3 access points", {
+  access_point_arn <- "arn:aws:s3:us-west-2:123456789012:accesspoint/test"
+  host <- "test-123456789012.s3-accesspoint.us-west-2.amazonaws.com"
+
+  req <- build_request(bucket = access_point_arn, operation = "ListObjects")
+  actual <- update_endpoint_for_s3_config(req)
+  expect_equal(actual$http_request$url$host, host)
+
+  access_point_arn <- "arn:aws:s3:us-west-2:123456789012:accesspoint/test/object/unit-01"
+  host <- "test-123456789012.s3-accesspoint.us-west-2.amazonaws.com"
+
+  req <- build_request(bucket = access_point_arn, operation = "ListObjects")
+  actual <- update_endpoint_for_s3_config(req)
+  expect_equal(actual$http_request$url$host, host)
+})


### PR DESCRIPTION
Support S3 access points for all S3 operations that accept buckets. For example:

```r
s3 <- paws::s3()
s3$list_objects("arn:aws:s3:us-east-1:123456789012:accesspoint/foo")
```

Addresses #403.