### PR TITLE
Fix parsing of ini files

### DIFF
--- a/paws.common/R/iniutil.R
+++ b/paws.common/R/iniutil.R
@@ -8,9 +8,9 @@ extract_ini_profile <- function(item) {
 extract_ini_parameter <- function(item) {
   split_index <- regexpr("=", item)
   parameter <- list()
-  key <- substring(item, 1, split_index)
-  value <- substring(item, split_index + 1)
-  parameter[[trimws(key)]] <- trimws(value)
+  key <- trimws(substring(item, 1, split_index - 1))
+  value <- trimws(substring(item, split_index + 1))
+  parameter[[key]] <- value
   return(parameter)
 }
 

--- a/paws.common/tests/testthat/data_ini
+++ b/paws.common/tests/testthat/data_ini
@@ -21,3 +21,7 @@ arg2=bar_value2
 [equalsign]
 arg1=value1==
 arg2=value2
+
+[spaces]
+arg1 = value1
+arg2 = value2

--- a/paws.common/tests/testthat/test_iniutil.R
+++ b/paws.common/tests/testthat/test_iniutil.R
@@ -1,15 +1,15 @@
 test_that("Reads in default profile", {
   content <- read_ini("data_ini")
   profile <- "default"
-  expect_equal(content[[profile]]$arg1, "value1")
-  expect_equal(content[[profile]]$arg2, "value2")
+  expect_equal(content[[profile]][["arg1"]], "value1")
+  expect_equal(content[[profile]][["arg2"]], "value2")
 })
 
 test_that("Reads in alternative profile", {
   content <- read_ini("data_ini")
   profile <- "foo"
-  expect_equal(content[[profile]]$arg1, "foo_value1")
-  expect_equal(content[[profile]]$arg2, "foo_value2")
+  expect_equal(content[[profile]][["arg1"]], "foo_value1")
+  expect_equal(content[[profile]][["arg2"]], "foo_value2")
 })
 
 test_that("Ignores lines starting with # and ;", {
@@ -21,13 +21,20 @@ test_that("Ignores lines starting with # and ;", {
 test_that("Reads in profile with space in name", {
   content <- read_ini("data_ini")
   profile <- "profile bar"
-  expect_equal(content[[profile]]$arg1, "bar_value1")
-  expect_equal(content[[profile]]$arg2, "bar_value2")
+  expect_equal(content[[profile]][["arg1"]], "bar_value1")
+  expect_equal(content[[profile]][["arg2"]], "bar_value2")
 })
 
 test_that("Reads in values with equal signs", {
   content <- read_ini("data_ini")
   profile <- "equalsign"
-  expect_equal(content[[profile]]$arg1, "value1==")
-  expect_equal(content[[profile]]$arg2, "value2")
+  expect_equal(content[[profile]][["arg1"]], "value1==")
+  expect_equal(content[[profile]][["arg2"]], "value2")
+})
+
+test_that("Reads in values with spaces around the equal sign", {
+  content <- read_ini("data_ini")
+  profile <- "spaces"
+  expect_equal(content[[profile]][["arg1"]], "value1")
+  expect_equal(content[[profile]][["arg2"]], "value2")
 })


### PR DESCRIPTION
Fix parsing of ini files. Previously, this included the `=` in the key, and passed tests because of partial argument matching.

Addresses #419.