### PR TITLE
Add an option to close HTTP connections instead of reusing them

### DIFF
--- a/paws.common/R/client.R
+++ b/paws.common/R/client.R
@@ -11,6 +11,7 @@ Config <- struct(
   enforce_should_retry_check = FALSE,
   region = "",
   disable_ssl = FALSE,
+  close_connection = FALSE,
   max_retries = -1,
   timeout = 60,
   retryer = NULL,

--- a/paws.common/R/net.R
+++ b/paws.common/R/net.R
@@ -47,7 +47,7 @@ HttpResponse <- struct(
 )
 
 # Returns an HTTP request given a method, URL, and an optional body.
-new_http_request <- function(method, url, body = NULL, timeout = NULL) {
+new_http_request <- function(method, url, body = NULL, close = FALSE, timeout = NULL) {
   if (method == "") {
     method <- "GET"
   }
@@ -64,6 +64,7 @@ new_http_request <- function(method, url, body = NULL, timeout = NULL) {
     header = list(), # TODO
     body = body,
     host = u$host,
+    close = close,
     timeout = timeout
   )
   return(req)
@@ -89,6 +90,9 @@ issue <- function(http_request) {
   method <- http_request$method
   url <- build_url(http_request$url)
   headers <- unlist(http_request$header)
+  if (http_request$close) {
+    headers["Connection"] <- "close"
+  }
   body <- http_request$body
   timeout <- httr::config(connecttimeout = http_request$timeout)
   if (is.null(http_request$timeout)) timeout <- NULL

--- a/paws.common/R/net.R
+++ b/paws.common/R/net.R
@@ -47,6 +47,12 @@ HttpResponse <- struct(
 )
 
 # Returns an HTTP request given a method, URL, and an optional body.
+#
+# @param method The HTTP method to use for the request.
+# @param url The URL to send the request to.
+# @param body The body to send in the request, in bytes.
+# @param close Whether to immediately close the connection, or else reuse connections.
+# @param timeout How long to wait for an initial response.
 new_http_request <- function(method, url, body = NULL, close = FALSE, timeout = NULL) {
   if (method == "") {
     method <- "GET"

--- a/paws.common/R/request.R
+++ b/paws.common/R/request.R
@@ -108,7 +108,13 @@ new_request <- function(client, operation, params, data) {
     method <- "POST"
   }
 
-  http_req <- new_http_request(method, "", NULL, client$config$timeout)
+  http_req <- new_http_request(
+    method = method,
+    url = "",
+    body = NULL,
+    close = client$config$close_connection,
+    timeout = client$config$timeout
+  )
 
   http_req$url <- parse_url(
     paste0(client$client_info$endpoint, operation$http_path)


### PR DESCRIPTION
Adds an option to immediately close all HTTP connections, instead of the default behavior in which cURL will reuse connections made to the same host for all requests within 5 seconds.

For example:

```r
s3 <- paws::s3(config = list(close_connection = TRUE))
s$foo()
```

Addresses #431.