### PR TITLE
When building XML, drop parameters that have no provided arguments

### DIFF
--- a/paws.common/R/xmlutil.R
+++ b/paws.common/R/xmlutil.R
@@ -96,7 +96,7 @@ xml_build_structure <- function(params) {
 
     parsed <- xml_build(child)
 
-    if (length(parsed) > 0) {
+    if (!is_empty(parsed)) {
       location_name <- tag_get(child, "locationName")
       if (location_name == "") location_name <- name
 

--- a/paws.common/tests/testthat/test_handlers_restxml.R
+++ b/paws.common/tests/testthat/test_handlers_restxml.R
@@ -502,6 +502,38 @@ test_that("newline in XML", {
   expect_equal(r, '<OperationRequest xmlns="https://foo/"><Description xmlns="https://foo/">foo&#xA;bar</Description></OperationRequest>')
 })
 
+
+test_that("parameters with no provided arguments are dropped", {
+  op_test <- Operation(name = "OperationRequest")
+  op_input_test <- function(Nested) {
+    args <- list(Nested = Nested)
+    interface <- Structure(
+      Nested = Structure(
+        Foo = Structure(
+          Bar = Scalar(type = "string")
+        ),
+        Baz = List(
+          Structure(Qux = Scalar(type = "string"))
+        )
+      ),
+      .tags = list(locationName = "OperationRequest")
+    )
+    return(populate(args, interface))
+  }
+
+  input <- op_input_test(
+    Nested = list(
+      Foo = list(
+        Bar = "abc123"
+      )
+    )
+  )
+  req <- new_request(svc, op_test, input, NULL)
+  req <- build(req)
+  r <- req$body
+  expect_equal(r, '<OperationRequest><Nested><Foo><Bar>abc123</Bar></Foo></Nested></OperationRequest>')
+})
+
 #-------------------------------------------------------------------------------
 
 # Unmarshal tests


### PR DESCRIPTION
Previously, if an operation had an input of the form `{"Param1": 123, "Param2": [{"a": ...}]}`, and `Param2` had no provided arguments, `xml_build_structure` would still output XML for it, which in turn would get rejected by AWS. In this example, it would output `<Param1>123</Param1></Param2>`.

In this update, we check if the list is empty and all its elements are also empty, and if so, skip it. With this update, the above example would output `<Param1>123</Param1>`.

Addresses #438.