### PR TITLE
bug fix: ensure config is collected correctly when running from do.call (#449)

### DIFF
--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: paws.common
 Type: Package
 Title: Paws Low-Level Amazon Web Services API
-Version: 0.3.12
+Version: 0.3.12.9999
 Authors@R: c(
         person("David", "Kretch", email = "david.kretch@gmail.com", role = c("aut", "cre")),
         person("Adam", "Banker", email = "adam.banker39@gmail.com", role = "aut"),

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -22,8 +22,8 @@ NULL
 get_config <- function() {
   calling_env <- parent.frame(2)
   call <- sys.call(-1)[[1]]
-  # ensure config is collected correctly when
-  # higherlevel function is called in do.call
+  # Ensure we correctly identify the service object (e.g. `svc`) when the
+  # operation is called through `do.call`, e.g. `do.call(svc$operation, args)`.
   if (is.function(call)){
     call <- sys.call(-2)[[2]]
   }

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -22,6 +22,11 @@ NULL
 get_config <- function() {
   calling_env <- parent.frame(2)
   call <- sys.call(-1)[[1]]
+  # ensure config is collected correctly when
+  # higherlevel function is called in do.call
+  if (is.function(call)){
+    call <- sys.call(-2)[[2]]
+  }
   if (is.name(call)) {
     return(Config())
   }

--- a/paws.common/tests/testthat/test_config.R
+++ b/paws.common/tests/testthat/test_config.R
@@ -8,6 +8,8 @@ test_that("get_config", {
 
   actual <- svc$operation()
   expect_equivalent(actual$region, 123)
+  # check if config is returned when executed in a do.call
+  expect_equivalent(do.call(svc$operation, list()), svc$operation())
 
   f <- function() {
     svc$operation()

--- a/paws.common/tests/testthat/test_config.R
+++ b/paws.common/tests/testthat/test_config.R
@@ -8,7 +8,8 @@ test_that("get_config", {
 
   actual <- svc$operation()
   expect_equivalent(actual$region, 123)
-  # check if config is returned when executed in a do.call
+
+  # Check if config is returned when executed in a `do.call`.
   expect_equivalent(do.call(svc$operation, list()), svc$operation())
 
   f <- function() {


### PR DESCRIPTION
Hi all,

This is to ensure that the config is collected correctly when higherlevel paws functions are called in a `do.call`. For example:

```R
s3 = paws::s3(config = list(region = "us-east-1"))

param = list(
  Bucket = "sagemaker-sample-files",
  Key = "datasets/tabular/uci_abalone/abalone.libsvm"
)

response = do.call(s3$get_object, param)
```