### PR TITLE
check for AWS_DEFAULT_REGION as environmental variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you are using Linux, you will need to install the following OS packages:
 
 ## Credentials
 
-You'll need to set up your AWS credentials and region. Paws supports setting 
+You'll need to set up your AWS credentials and region. Paws supports setting
 these per-service, or using R and OS environment variables, AWS credential
 files, and IAM roles. See [docs/credentials.md](docs/credentials.md) for more
 info.
@@ -118,7 +118,7 @@ There are also examples for [EC2](examples/ec2.R), [S3](examples/s3.R),
 
 ## Related packages
 
-* [`cognitoR`](https://github.com/chi2labs/cognitoR) provides 
+* [`cognitoR`](https://github.com/chi2labs/cognitoR) provides
   authentication for Shiny applications using Amazon Cognito.
 * [`noctua`](https://dyfanjones.github.io/noctua/) is an interface to the
 [Athena](https://aws.amazon.com/athena/) serverless interactive query

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -88,7 +88,7 @@ environment variable `AWS_SHARED_CREDENTIALS_FILE`.
 
 ## Set credentials for an individual service
 
-You can set credentials for an individual service by specifying them as 
+You can set credentials for an individual service by specifying them as
 arguments when you create the service object. These take precedence over
 credentials set using any other method.
 
@@ -140,7 +140,7 @@ use the credentials from the attached role.
 
 ---
 
-    
+
 ## Get credentials from a command line process
 
 You can get credentials from a command line process by specifying the process
@@ -156,7 +156,7 @@ like the following:
       "Version": 1,
       "AccessKeyId": "your AWS access key",
       "SecretAccessKey": "your AWS secret access key",
-      "SessionToken": "your session token", 
+      "SessionToken": "your session token",
       "Expiration": "ISO8601 expiration time"
     }
 
@@ -211,7 +211,7 @@ the name of the other profile in `source_profile`.
     source_profile=my-other-profile
 
 Paws will look in both the AWS shared credentials file and the AWS config file
-for the source profile. The source profile can use any method to provide 
+for the source profile. The source profile can use any method to provide
 credentials.
 
 If you put these settings in a config profile other than `default`, you will
@@ -259,7 +259,8 @@ For a reference to all available options, [see the reference section](#reference
 ## Set region for all services with an environment variable
 
 You can set the region for all services using an environment variable. Paws
-will look for region in both OS or R environment variables.
+will look for region in both OS or R environment variables using either
+`AWS_REGION` or `AWS_DEFAULT_REGION`.
 
 You can use R to set region with the following command:
 
@@ -267,6 +268,11 @@ You can use R to set region with the following command:
 Sys.setenv(
     AWS_REGION = "us-east-2"
 )
+# or
+Sys.setenv(
+    AWS_DEFAULT_REGION = "us-east-2"
+)
+
 ```
 
 ---
@@ -368,7 +374,7 @@ them in this order:
 
 1.  [In settings provided to an individual service](#service-settings)
 2.  [In environment variables](#environment-variables)
-3.  In the [AWS shared credentials file](#shared-credentials-file) and 
+3.  In the [AWS shared credentials file](#shared-credentials-file) and
     [AWS config file](#config-file)
 4.  In an EC2 instance or container IAM role
 
@@ -383,7 +389,7 @@ setting in a config file.
 
 Paws supports the following settings provided as arguments to a service:
 
-* `access_key_id` - Specifies the AWS access key used as part of the 
+* `access_key_id` - Specifies the AWS access key used as part of the
   credentials to authenticate the request.
 
 * `secret_access_key` - Specifies the AWS secret key used as part of the
@@ -402,7 +408,7 @@ Paws supports the following settings provided as arguments to a service:
 
 * `region` - Specifies the AWS region to send the request to.
 
-They must be provided to the service in the following structure. It is 
+They must be provided to the service in the following structure. It is
 allowable to specify only some of the settings, e.g. only `region`.
 
 ``` r
@@ -429,32 +435,32 @@ svc <- paws::svc(
 
 Paws supports the following settings in environment variables.
 
-* `AWS_ACCESS_KEY_ID` - Specifies the AWS access key used as part of the 
+* `AWS_ACCESS_KEY_ID` - Specifies the AWS access key used as part of the
   credentials to authenticate the request.
-  
+
 * `AWS_CONFIG_FILE` - Specifies the location of the file used to store
   configuration profiles. The default path is `~/.aws/config`.
-  
+
 * `AWS_CREDENTIAL_EXPIRATION` - The expiration time of the credentials
   contained in the environment variables `AWS_ACCESS_KEY_ID`,
   `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`. The expiration time must
   be specified in ISO 8601 format, e.g. `"2021-02-19T04:42:29Z"`.
-  
+
 * `AWS_EC2_METADATA_DISABLED` - Disables the use of the Amazon EC2 instance
   metadata service (IMDS) when set to `"true"` (case insensitive) or `"1"`.
-  
+
 * `AWS_PROFILE` - Specifies the name of the profile with the credentials and
   options to use.
-  
-* `AWS_REGION` - Specifies the AWS region to send the request to.
-  
+
+* `AWS_REGION`/`AWS_DEFAULT_REGION` - Specifies the AWS region to send the request to.
+
 * `AWS_SECRET_ACCESS_KEY` - Specifies the AWS secret key used as part of the
   credentials to authenticate the request.
 
 * `AWS_SESSION_TOKEN` - Specifies the session token value that is required if
   you are using temporary security credentials that you retrieved directly
   from AWS STS operations.
-  
+
 * `AWS_SHARED_CREDENTIALS_FILES` - Specifies the location of the file used to
   store access keys. The default path is `~/.aws/credentials`.
 
@@ -469,7 +475,7 @@ variable `AWS_SHARED_CREDENTIALS_FILE`.
 
 Paws supports the following settings in the AWS shared credentials file.
 
-* `aws_access_key_id` - Specifies the AWS access key used as part of the 
+* `aws_access_key_id` - Specifies the AWS access key used as part of the
   credentials to authenticate the request.
 
 * `aws_secret_access_key` - Specifies the AWS secret key used as part of the
@@ -485,7 +491,7 @@ specify another location using environment variable `AWS_CONFIG_FILE`.
 
 Paws supports the following settings in the AWS config file.
 
-* `credential_process` - Specifies an external command to be run to generate 
+* `credential_process` - Specifies an external command to be run to generate
   or retrieve authentication credentials. The command must return the
   credentials in a specific format. For more information about how to use this
   setting, see [Sourcing credentials with an external process](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html).
@@ -506,22 +512,22 @@ Paws supports the following settings in the AWS config file.
     * `EcsContainer` – Specifies that the SDK is to use the IAM role attached
       to the ECS container as source credentials.
 
-* `mfa_serial` - The identification number of an MFA device to use when 
+* `mfa_serial` - The identification number of an MFA device to use when
   assuming a role. This is mandatory only if the trust policy of the role being
   assumed includes a condition that requires MFA authentication. The value can
   be either a serial number for a hardware device (such as GAHT12345678) or an
   Amazon Resource Name (ARN) for a virtual MFA device (such as
   `arn:aws:iam::123456789012:mfa/user`).
 
-* `region` - Specifies the AWS Region to send requests to for commands 
+* `region` - Specifies the AWS Region to send requests to for commands
   requested using this profile.
 
-* `role_arn` - Specifies the Amazon Resource Name (ARN) of an IAM role that you 
+* `role_arn` - Specifies the Amazon Resource Name (ARN) of an IAM role that you
   want to use to run SDK commands. You must also specify one of the
   following parameters to identify the credentials that have permission to
   assume this role: `source_profile`, `credential_source`.
 
-* `source_profile` - Specifies a named profile with long-term credentials that 
+* `source_profile` - Specifies a named profile with long-term credentials that
   the SDK can use to assume a role that you specified with the `role_arn`
   parameter. You cannot specify both `source_profile` and `credential_source`
   in the same profile.

--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: paws.common
 Type: Package
 Title: Paws Low-Level Amazon Web Services API
-Version: 0.3.12.9999
+Version: 0.3.13.9999
 Authors@R: c(
         person("David", "Kretch", email = "david.kretch@gmail.com", role = c("aut", "cre")),
         person("Adam", "Banker", email = "adam.banker39@gmail.com", role = "aut"),
@@ -29,7 +29,7 @@ Suggests:
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org
 Roxygen: list(markdown = TRUE, roclets = c("rd", "namespace", "collate"))
 RoxygenNote: 7.1.1
-Collate: 
+Collate:
     'struct.R'
     'handlers.R'
     'iniutil.R'

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -24,7 +24,7 @@ get_config <- function() {
   call <- sys.call(-1)[[1]]
   # Ensure we correctly identify the service object (e.g. `svc`) when the
   # operation is called through `do.call`, e.g. `do.call(svc$operation, args)`.
-  if (is.function(call)){
+  if (is.function(call)) {
     call <- sys.call(-2)[[2]]
   }
   if (is.name(call)) {
@@ -32,7 +32,9 @@ get_config <- function() {
   }
   object <- eval(call[[2]], envir = calling_env)
   config <- object$.internal$config
-  if (is.null(config)) return(Config())
+  if (is.null(config)) {
+    return(Config())
+  }
   return(config)
 }
 
@@ -82,7 +84,6 @@ get_config <- function() {
 #'     endpoint = "https://foo.com"
 #'   )
 #' )
-#'
 #' @export
 set_config <- function(svc, cfgs = list()) {
   shape <- tag_annotate(Config())
@@ -109,30 +110,42 @@ get_aws_path <- function() {
 
 get_config_file_path <- function() {
   path <- get_env("AWS_CONFIG_FILE")
-  if (path != "" && file.exists(path)) return(path)
+  if (path != "" && file.exists(path)) {
+    return(path)
+  }
 
   path <- file.path(get_aws_path(), "config")
-  if (file.exists(path)) return(path)
+  if (file.exists(path)) {
+    return(path)
+  }
 
   return(NULL)
 }
 
 get_credentials_file_path <- function() {
   path <- get_env("AWS_SHARED_CREDENTIALS_FILE")
-  if (path != "" && file.exists(path)) return(path)
+  if (path != "" && file.exists(path)) {
+    return(path)
+  }
 
   path <- file.path(get_aws_path(), "credentials")
-  if (file.exists(path)) return(path)
+  if (file.exists(path)) {
+    return(path)
+  }
 
   return(NULL)
 }
 
 get_env <- function(variable) {
   value <- Sys.getenv(variable)
-  if (value != "") return(value)
+  if (value != "") {
+    return(value)
+  }
 
   value <- get_os_env(variable)
-  if (value != "") return(value)
+  if (value != "") {
+    return(value)
+  }
 
   return("")
 }
@@ -140,7 +153,6 @@ get_env <- function(variable) {
 # Get the value of an OS environment variable.
 # NOTE: Does not work on Windows.
 get_os_env <- function(var) {
-
   if (.Platform$OS.type == "unix") {
     value <- system(sprintf("echo $%s", var), intern = T)
   } else {
@@ -152,8 +164,9 @@ get_os_env <- function(var) {
 
 # Get the AWS profile to use. If none, return "default".
 get_profile_name <- function(profile = "") {
-
-  if (!is.null(profile) && profile != "") return(profile)
+  if (!is.null(profile) && profile != "") {
+    return(profile)
+  }
 
   profile <- get_env("AWS_PROFILE")
 
@@ -170,16 +183,21 @@ get_instance_metadata <- function(query_path = "") {
     return(NULL)
   }
 
-  metadata_url <- file.path("http://169.254.169.254/latest/meta-data",
-                           query_path)
+  metadata_url <- file.path(
+    "http://169.254.169.254/latest/meta-data",
+    query_path
+  )
   metadata_request <-
     new_http_request("GET", metadata_url, timeout = 1)
 
-  metadata_response <- tryCatch({
-    issue(metadata_request)
-  }, error = function (e){
-    NULL
-  })
+  metadata_response <- tryCatch(
+    {
+      issue(metadata_request)
+    },
+    error = function(e) {
+      NULL
+    }
+  )
 
   if (is.null(metadata_response) || metadata_response$status_code != 200) {
     return(NULL)
@@ -192,16 +210,19 @@ get_instance_metadata <- function(query_path = "") {
 # For profiles other than default, the profile name is prefaced by "profile".
 # See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html
 check_config_file_region <- function(profile = "") {
-
   config_path <- get_config_file_path()
-  if (is.null(config_path)) return(NULL)
+  if (is.null(config_path)) {
+    return(NULL)
+  }
 
   profile <- get_profile_name(profile)
   if (profile != "default") profile <- paste("profile", profile)
 
   config_values <- read_ini(config_path)
 
-  if (is.null(config_values[[profile]])) return(NULL)
+  if (is.null(config_values[[profile]])) {
+    return(NULL)
+  }
 
   region <- config_values[[profile]]$region
 
@@ -210,9 +231,16 @@ check_config_file_region <- function(profile = "") {
 
 # Get the AWS region.
 get_region <- function(profile = "") {
-
   region <- get_env("AWS_REGION")
-  if (region != "") return(region)
+  if (region != "") {
+    return(region)
+  }
+
+  # Check if default region is specified
+  region <- get_env("AWS_DEFAULT_REGION")
+  if (region != "") {
+    return(region)
+  }
 
   region <- check_config_file_region(profile)
 


### PR DESCRIPTION
This closes issue #459.

When checking for region environmental variables check for `AWS_DEFAULT_REGION` after `AWS_REGION`. Bumped the minor version number, but unsure what the best practice here. Also tried to add some notes about being able to include this in the docs, specifically in `credentials.md`. It also auto-formatted some of the function calls in my current R VScode environment, but I could also switch these back as well.