### PR TITLE
Fix timestamps in S3

### DIFF
--- a/paws.common/R/handlers_rest.R
+++ b/paws.common/R/handlers_rest.R
@@ -196,7 +196,7 @@ rest_unmarshal_header <- function(value, type) {
     jsonvalue = json_to_list,
     long = as.numeric,
     string = as.character,
-    timestamp = function(x) as_timestamp(x, format = "rfc1123"),
+    timestamp = function(x) as_timestamp(x, format = "rfc822"),
     as.character
   )
   result <- convert(value)

--- a/paws.common/tests/testthat/test_handlers_restxml.R
+++ b/paws.common/tests/testthat/test_handlers_restxml.R
@@ -732,6 +732,23 @@ test_that("unmarshal timestamp", {
   expect_equal(out$Timestamp, unix_time(0))
 })
 
+test_that("unmarshal timestamp in header", {
+  op_output <- Structure(
+    Timestamp = Scalar(type = "timestamp", .tags = list(location = "header"))
+  )
+  req <- new_request(svc, op, NULL, op_output)
+  req$http_response <- HttpResponse(
+    status_code = 200,
+    body = charToRaw("<OperationNameResponse></OperationNameResponse>")
+  )
+  req$http_response$header[["Timestamp"]] <- "Wed, 02 Oct 2002 13:00:00 GMT"
+  req <- unmarshal_meta(req)
+  req <- unmarshal(req)
+  out <- req$data
+  expected <- as.POSIXct("2002-10-02 13:00:00 GMT", tz = "GMT")
+  expect_equal(as.integer(out$Timestamp), as.integer(expected))
+})
+
 op_output11 <- Structure(
   Body = Scalar(type = "string"),
   Header = Scalar(type = "string", .tags = list(location = "header"))
@@ -754,6 +771,7 @@ test_that("unmarshal elements in header and body", {
 op_output12 <- Structure(
   Timestamp = Scalar(type = "timestamp")
 )
+
 test_that("unmarshal error", {
   req <- new_request(svc, op, NULL, op_output12)
   req$http_response <- HttpResponse(


### PR DESCRIPTION
Interpret timestamps in S3 responses using the correct timestamp format, RFC 822, e.g. "Wed, 02 Oct 2002 13:00:00 GMT".  See #467.