### PR TITLE
fix params without values

### DIFF
--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -79,7 +79,7 @@ parse_query_string <- function(query) {
   for (el in strsplit(query, "&")[[1]]) {
     pair <- strsplit(el, "=")[[1]]
     key <- pair[1]
-    value <- pair[2]
+    value <- if(length(pair)>1){pair[2]}else{""}
     result[[key]] <- c(result[[key]], query_unescape(value))
   }
   return(result)

--- a/paws.common/tests/testthat/test_url.R
+++ b/paws.common/tests/testthat/test_url.R
@@ -9,3 +9,11 @@ test_that("parsing and building URLs", {
   expected <- input
   expect_equal(actual, expected)
 })
+
+test_that("parse and build query strings", {
+  # One parameter with a value, one without a value.
+  input <- "bar=baz&foo="
+  actual <- build_query_string(parse_query_string(input))
+  expected <- input
+  expect_equal(actual, expected)
+})


### PR DESCRIPTION
Some AWS endpoints take parameters without values (e.g `paws::s3()$get_bucket_website`)

This PR fixes the below error and other endpoints with valueless parameters
```R
s3$get_bucket_website("some bucket")
Error: InvalidArgument (HTTP 400). The website parameter must not have a value
```