### PR TITLE
enable anonymous credentials

### DIFF
--- a/paws.common/R/credential_providers.R
+++ b/paws.common/R/credential_providers.R
@@ -14,6 +14,14 @@ Creds <- struct(
   provider_name = ""
 )
 
+# Set anonymous credentials
+anonymous_provider <- function(anonymous){
+  if(!anonymous){
+    return(NULL)
+  }
+  return(Creds())
+}
+
 # Retrieve credentials stored in R or OS environment variables.
 env_provider <- function() {
   access_key_id <- get_env("AWS_ACCESS_KEY_ID")

--- a/paws.common/R/credentials.R
+++ b/paws.common/R/credentials.R
@@ -6,7 +6,9 @@ Credentials <- struct(
   creds = Creds(),
   profile = "",
   force_refresh = FALSE,
+  anonymous = FALSE,
   provider = list(
+    anonymous_provider,
     env_provider,
     credentials_file_provider,
     config_file_provider,
@@ -36,7 +38,7 @@ get_credentials <- function(credentials) {
 is_credentials_provided <- function(creds, window = 5 * 60){
   if (is.null(creds)) return(FALSE)
   if (!is.null(creds$access_token) && creds$access_token != "") {
-      return(TRUE)
+    return(TRUE)
   }
   if (is.null(creds$access_key_id) || creds$access_key_id == "") {
     return(FALSE)

--- a/paws.common/R/signer_v4.R
+++ b/paws.common/R/signer_v4.R
@@ -108,14 +108,10 @@ v4_sign_request_handler <- function(request) {
 sign_sdk_request_with_curr_time <- function(request,
                                             curr_time_fn = Sys.time,
                                             opts = NULL) {
-
-  # TODO: Implement anonymous access.
-  # if (request$config$credentials == CREDENTIALS$anonymous_credentials) {
-  #   return(NULL)
-  # }
-
-  region <- request$client_info$signing_region
-  if (region == "") {
+  # ensure region is not set for anonymous
+  if (isTRUE(request$config$credentials$anonymous)) {
+    region <- ""
+  } else if (request$client_info$signing_region == "") {
     region <- request$config$region
   }
 

--- a/paws.common/R/signer_v4.R
+++ b/paws.common/R/signer_v4.R
@@ -468,8 +468,8 @@ get_uri_path <- function(url) {
 # Clear down headers for anonymous credentials
 # https://github.com/aws/aws-sdk-go/blob/a7b02935e4fefa40f175f4d2143ec9c88a5f90f5/aws/signer/v4/v4_test.go#L321-L355
 anonymous_headers <- function(headers){
-  found = grepl("X-Amz-*", names(headers))
-  headers[found] = ""
-  headers["Authorization"] = ""
+  found <- grepl("X-Amz-*", names(headers))
+  headers[found] <- ""
+  headers["Authorization"] <- ""
   return(headers)
 }

--- a/paws.common/R/signer_v4.R
+++ b/paws.common/R/signer_v4.R
@@ -108,10 +108,8 @@ v4_sign_request_handler <- function(request) {
 sign_sdk_request_with_curr_time <- function(request,
                                             curr_time_fn = Sys.time,
                                             opts = NULL) {
-  # ensure region is not set for anonymous
-  if (isTRUE(request$config$credentials$anonymous)) {
-    region <- ""
-  } else if (request$client_info$signing_region == "") {
+  region <- request$client_info$signing_region
+  if (region == "") {
     region <- request$config$region
   }
 

--- a/paws.common/tests/testthat/test_signer_v4.R
+++ b/paws.common/tests/testthat/test_signer_v4.R
@@ -158,7 +158,7 @@ test_that("Test anonymous credentials", {
     service_name = "s3"
   )
   client <- new_service(metadata, new_handlers("restxml", "s3"), Config())
-  client$config$credentials <- test_creds
+  client$config$credentials <- anonymous_test_creds
   client$client_info$signing_region <- "us-east-1"
 
   op <- new_operation("ListBuckets", "GET", "/", list())

--- a/paws.common/tests/testthat/test_signer_v4.R
+++ b/paws.common/tests/testthat/test_signer_v4.R
@@ -137,3 +137,38 @@ test_that("presign", {
   expect_equal(q[["X-Amz-Date"]], "19700101T000000Z")
   expect_equal(q[["X-Amz-Target"]], "prefix.Operation")
 })
+
+
+test_creds <- Credentials(
+  anonymous = TRUE,
+  provider = list(
+    function() {
+      list(
+        access_key_id = "",
+        secret_access_key = "",
+        session_token = "",
+        provider_name = ""
+      )
+    }
+  )
+)
+
+test_that("Test anonymous credentials", {
+  metadata <- list(
+    endpoints = list("*" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE)),
+    service_name = "s3"
+  )
+  client <- new_service(metadata, new_handlers("restxml", "s3"), Config())
+  client$config$credentials <- test_creds
+  client$client_info$signing_region <- "us-east-1"
+
+  op <- new_operation("ListBuckets", "GET", "/", list())
+  params <- list()
+  data <- tag_add(list(Buckets = list()), list(type = "structure"))
+  req <- new_request(client, op, params, data)
+  res <- v4_sign_request_handler(req)
+
+  expect_equal(res$http_request$header[["Authorization"]], "")
+  expect_equal(res$http_request$header[["X-Amz-Date"]], "")
+  expect_equal(res$http_request$header[["X-Amz-Content-Sha256"]], "")
+})

--- a/paws.common/tests/testthat/test_signer_v4.R
+++ b/paws.common/tests/testthat/test_signer_v4.R
@@ -138,8 +138,7 @@ test_that("presign", {
   expect_equal(q[["X-Amz-Target"]], "prefix.Operation")
 })
 
-
-test_creds <- Credentials(
+anonymous_test_creds <- Credentials(
   anonymous = TRUE,
   provider = list(
     function() {


### PR DESCRIPTION
This PR enable anonymous credentials to be used when connecting to public s3 buckets: This PR address the following tickets:
- https://github.com/paws-r/paws/issues/489
- https://github.com/paws-r/paws/issues/512
- https://github.com/paws-r/paws/issues/478