### PR TITLE
Remove Unicode line terminators from documentation

### DIFF
--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -425,6 +425,9 @@ clean_markdown <- function(markdown) {
   # Unicode character codes: \\uxxxx to `U+xxxx`
   result <- gsub("\\\\\\\\u([0-9a-fA-F]{4})", "`U+\\1`", result)
 
+  # Remove certain characters not allowed by LaTeX.
+  result <- gsub("\U2028", "", result)
+
   # @ symbol, escaped for Roxygen.
   # See http://r-pkgs.had.co.nz/man.html#roxygen-comments.
   result <- gsub("@", "@@", result)

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -581,6 +581,11 @@ test_that("convert", {
   text <- "<p><code>{foo</code>}</p>"
   expected <- "`\\{foo`\\}"
   expect_equal(convert(text), expected)
+
+  # Unicode line terminator is not allowed in LaTeX.
+  text <- "<p>foo\U2028</p>"
+  expected <- "foo"
+  expect_equal(convert(text), expected)
 })
 
 test_that("check links", {


### PR DESCRIPTION
Fix LaTeX errors that appeared in the last paws.compute, caused by non-printable Unicode line terminator U+2028 copied from the AWS documentation, with error message:

! LaTeX Error: Unicode character   (U+2028)
               not set up for use with LaTeX.

See https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-gcc/paws.compute-00check.html

Test plan:
1. Regenerate Paws: `make build`.
2. Check for line terminator. `grep $'\u2028' cran` (no results):
```sh
Davids-MacBook-Air:paws davidkretch$ grep -r $'\u2028' cran
Davids-MacBook-Air:paws davidkretch$ 
```