### PR TITLE
Manually fix disallowed characters

### DIFF
--- a/cran/paws.analytics/R/glue_operations.R
+++ b/cran/paws.analytics/R/glue_operations.R
@@ -10983,7 +10983,7 @@ glue_resume_workflow_run <- function(Name, RunId, NodeIds) {
 #' comparing string values, such as when `Key=Name`, a fuzzy match
 #' algorithm is used. The `Key` field (for example, the value of the `Name`
 #' field) is split on certain punctuation characters, for example, -, :,
-#' \#, etc. into tokens. Then each token is exact-match compared with the
+#' #, etc. into tokens. Then each token is exact-match compared with the
 #' `Value` member of `PropertyPredicate`. For example, if `Key=Name` and
 #' `Value=link`, tables named `customer-link` and `xx-link-yy` are
 #' returned, but `xxlinkyy` is not returned.

--- a/cran/paws.analytics/man/glue_search_tables.Rd
+++ b/cran/paws.analytics/man/glue_search_tables.Rd
@@ -21,7 +21,7 @@ for time fields, and can be omitted for other field types. Also, when
 comparing string values, such as when \code{Key=Name}, a fuzzy match
 algorithm is used. The \code{Key} field (for example, the value of the \code{Name}
 field) is split on certain punctuation characters, for example, -, :,
-\#, etc. into tokens. Then each token is exact-match compared with the
+#, etc. into tokens. Then each token is exact-match compared with the
 \code{Value} member of \code{PropertyPredicate}. For example, if \code{Key=Name} and
 \code{Value=link}, tables named \code{customer-link} and \code{xx-link-yy} are
 returned, but \code{xxlinkyy} is not returned.}

--- a/cran/paws.application.integration/R/mq_operations.R
+++ b/cran/paws.application.integration/R/mq_operations.R
@@ -1306,7 +1306,7 @@ mq_reboot_broker <- function(BrokerId) {
 #' https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html
 #' @param HostInstanceType The host instance type of the broker to upgrade to. For a list of
 #' supported instance types, see
-#' https://docs.aws.amazon.com/amazon-mq/latest/developer-guide//broker.html\#broker-instance-types
+#' https://docs.aws.amazon.com/amazon-mq/latest/developer-guide//broker.html#broker-instance-types
 #' @param LdapServerMetadata The metadata of the LDAP server used to authenticate and authorize
 #' connections to the broker.
 #' @param Logs Enables Amazon CloudWatch logging for brokers.

--- a/cran/paws.application.integration/man/mq_update_broker.Rd
+++ b/cran/paws.application.integration/man/mq_update_broker.Rd
@@ -25,7 +25,7 @@ https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-engine.html}
 
 \item{HostInstanceType}{The host instance type of the broker to upgrade to. For a list of
 supported instance types, see
-https://docs.aws.amazon.com/amazon-mq/latest/developer-guide//broker.html\#broker-instance-types}
+https://docs.aws.amazon.com/amazon-mq/latest/developer-guide//broker.html#broker-instance-types}
 
 \item{LdapServerMetadata}{The metadata of the LDAP server used to authenticate and authorize
 connections to the broker.}

--- a/cran/paws.compute/R/ec2_operations.R
+++ b/cran/paws.compute/R/ec2_operations.R
@@ -5644,7 +5644,7 @@ ec2_create_internet_gateway <- function(TagSpecifications = NULL, DryRun = NULL)
 #' @description
 #' Creates a 2048-bit RSA key pair with the specified name. Amazon EC2
 #' stores the public key and displays the private key for you to save to a
-#' file. The private key is returned as an unencrypted PEM encoded PKCS\#1
+#' file. The private key is returned as an unencrypted PEM encoded PKCS#1
 #' private key. If a key with the specified name already exists, Amazon EC2
 #' returns an error.
 #' 
@@ -7937,7 +7937,7 @@ ec2_create_route_table <- function(DryRun = NULL, VpcId, TagSpecifications = NUL
 #' Constraints for EC2-Classic: ASCII characters
 #' 
 #' Constraints for EC2-VPC: a-z, A-Z, 0-9, spaces, and
-#' ._-:/()\#,@@\[\]+=&;\{\}!$*
+#' ._-:/()#,@@\[\]+=&;\{\}!$*
 #' @param GroupName &#91;required&#93; The name of the security group.
 #' 
 #' Constraints: Up to 255 characters in length. Cannot start with `sg-`.
@@ -7945,7 +7945,7 @@ ec2_create_route_table <- function(DryRun = NULL, VpcId, TagSpecifications = NUL
 #' Constraints for EC2-Classic: ASCII characters
 #' 
 #' Constraints for EC2-VPC: a-z, A-Z, 0-9, spaces, and
-#' ._-:/()\#,@@\[\]+=&;\{\}!$*
+#' ._-:/()#,@@\[\]+=&;\{\}!$*
 #' @param VpcId \[EC2-VPC\] The ID of the VPC. Required for EC2-VPC.
 #' @param TagSpecifications The tags to assign to the security group.
 #' @param DryRun Checks whether you have the required permissions for the action, without

--- a/cran/paws.compute/R/ecr_operations.R
+++ b/cran/paws.compute/R/ecr_operations.R
@@ -1289,22 +1289,22 @@ ecr_get_lifecycle_policy <- function(registryId = NULL, repositoryName) {
 #' assumed.
 #' @param repositoryName &#91;required&#93; The name of the repository.
 #' @param imageIds The list of imageIDs to be included.
-#' @param nextToken The `nextToken` value returned from a previous paginated 
+#' @param nextToken The `nextToken` value returned from a previous paginated
 #' `GetLifecyclePolicyPreviewRequest` request where `maxResults` was used
-#' and the  results exceeded the value of that parameter. Pagination
-#' continues from the end of the  previous results that returned the
-#' `nextToken` value. This value is  `null` when there are no more results
+#' and the results exceeded the value of that parameter. Pagination
+#' continues from the end of the previous results that returned the
+#' `nextToken` value. This value is `null` when there are no more results
 #' to return. This option cannot be used when you specify images with
 #' `imageIds`.
 #' @param maxResults The maximum number of repository results returned by
-#' `GetLifecyclePolicyPreviewRequest` in  paginated output. When this
-#' parameter is used, `GetLifecyclePolicyPreviewRequest` only returns 
-#' `maxResults` results in a single page along with a `nextToken`  response
+#' `GetLifecyclePolicyPreviewRequest` in paginated output. When this
+#' parameter is used, `GetLifecyclePolicyPreviewRequest` only returns
+#' `maxResults` results in a single page along with a `nextToken` response
 #' element. The remaining results of the initial request can be seen by
-#' sending  another `GetLifecyclePolicyPreviewRequest` request with the
-#' returned `nextToken`  value. This value can be between 1 and 1000. If
-#' this  parameter is not used, then `GetLifecyclePolicyPreviewRequest`
-#' returns up to  100 results and a `nextToken` value, if  applicable. This
+#' sending another `GetLifecyclePolicyPreviewRequest` request with the
+#' returned `nextToken` value. This value can be between 1 and 1000. If
+#' this parameter is not used, then `GetLifecyclePolicyPreviewRequest`
+#' returns up to 100 results and a `nextToken` value, if applicable. This
 #' option cannot be used when you specify images with `imageIds`.
 #' @param filter An optional parameter that filters results based on image tag status and
 #' all tags, if tagged.
@@ -1902,7 +1902,7 @@ ecr_put_image_tag_mutability <- function(registryId = NULL, repositoryName, imag
 #'   lifecyclePolicyText)
 #'
 #' @param registryId The AWS account ID associated with the registry that contains the
-#' repository. If you do  not specify a registry, the default registry is
+#' repository. If you do not specify a registry, the default registry is
 #' assumed.
 #' @param repositoryName &#91;required&#93; The name of the repository to receive the policy.
 #' @param lifecyclePolicyText &#91;required&#93; The JSON repository policy text to apply to the repository.

--- a/cran/paws.compute/man/ec2_create_key_pair.Rd
+++ b/cran/paws.compute/man/ec2_create_key_pair.Rd
@@ -36,7 +36,7 @@ A list with the following syntax:\preformatted{list(
 \description{
 Creates a 2048-bit RSA key pair with the specified name. Amazon EC2
 stores the public key and displays the private key for you to save to a
-file. The private key is returned as an unencrypted PEM encoded PKCS\#1
+file. The private key is returned as an unencrypted PEM encoded PKCS#1
 private key. If a key with the specified name already exists, Amazon EC2
 returns an error.
 

--- a/cran/paws.compute/man/ec2_create_security_group.Rd
+++ b/cran/paws.compute/man/ec2_create_security_group.Rd
@@ -15,7 +15,7 @@ Constraints: Up to 255 characters in length
 Constraints for EC2-Classic: ASCII characters
 
 Constraints for EC2-VPC: a-z, A-Z, 0-9, spaces, and
-._-:/()\#,@[]+=&;\{\}!$*}
+._-:/()#,@[]+=&;\{\}!$*}
 
 \item{GroupName}{[required] The name of the security group.
 
@@ -24,7 +24,7 @@ Constraints: Up to 255 characters in length. Cannot start with \verb{sg-}.
 Constraints for EC2-Classic: ASCII characters
 
 Constraints for EC2-VPC: a-z, A-Z, 0-9, spaces, and
-._-:/()\#,@[]+=&;\{\}!$*}
+._-:/()#,@[]+=&;\{\}!$*}
 
 \item{VpcId}{[EC2-VPC] The ID of the VPC. Required for EC2-VPC.}
 

--- a/cran/paws.compute/man/ecr_get_lifecycle_policy_preview.Rd
+++ b/cran/paws.compute/man/ecr_get_lifecycle_policy_preview.Rd
@@ -17,23 +17,23 @@ assumed.}
 
 \item{imageIds}{The list of imageIDs to be included.}
 
-\item{nextToken}{The \code{nextToken} value returned from a previous paginated 
+\item{nextToken}{The \code{nextToken} value returned from a previous paginated
 \code{GetLifecyclePolicyPreviewRequest} request where \code{maxResults} was used
-and the  results exceeded the value of that parameter. Pagination
-continues from the end of the  previous results that returned the
-\code{nextToken} value. This value is  \code{null} when there are no more results
+and the results exceeded the value of that parameter. Pagination
+continues from the end of the previous results that returned the
+\code{nextToken} value. This value is \code{null} when there are no more results
 to return. This option cannot be used when you specify images with
 \code{imageIds}.}
 
 \item{maxResults}{The maximum number of repository results returned by
-\code{GetLifecyclePolicyPreviewRequest} in  paginated output. When this
-parameter is used, \code{GetLifecyclePolicyPreviewRequest} only returns 
-\code{maxResults} results in a single page along with a \code{nextToken}  response
+\code{GetLifecyclePolicyPreviewRequest} in paginated output. When this
+parameter is used, \code{GetLifecyclePolicyPreviewRequest} only returns
+\code{maxResults} results in a single page along with a \code{nextToken} response
 element. The remaining results of the initial request can be seen by
-sending  another \code{GetLifecyclePolicyPreviewRequest} request with the
-returned \code{nextToken}  value. This value can be between 1 and 1000. If
-this  parameter is not used, then \code{GetLifecyclePolicyPreviewRequest}
-returns up to  100 results and a \code{nextToken} value, if  applicable. This
+sending another \code{GetLifecyclePolicyPreviewRequest} request with the
+returned \code{nextToken} value. This value can be between 1 and 1000. If
+this parameter is not used, then \code{GetLifecyclePolicyPreviewRequest}
+returns up to 100 results and a \code{nextToken} value, if applicable. This
 option cannot be used when you specify images with \code{imageIds}.}
 
 \item{filter}{An optional parameter that filters results based on image tag status and

--- a/cran/paws.compute/man/ecr_put_lifecycle_policy.Rd
+++ b/cran/paws.compute/man/ecr_put_lifecycle_policy.Rd
@@ -9,7 +9,7 @@ ecr_put_lifecycle_policy(registryId, repositoryName,
 }
 \arguments{
 \item{registryId}{The AWS account ID associated with the registry that contains the
-repository. If you do  not specify a registry, the default registry is
+repository. If you do not specify a registry, the default registry is
 assumed.}
 
 \item{repositoryName}{[required] The name of the repository to receive the policy.}

--- a/cran/paws.database/R/dynamodb_operations.R
+++ b/cran/paws.database/R/dynamodb_operations.R
@@ -203,7 +203,7 @@ dynamodb_batch_execute_statement <- function(Statements) {
 #'     -   To prevent special characters in an attribute name from being
 #'         misinterpreted in an expression.
 #' 
-#'     Use the **\#** character in an expression to dereference an
+#'     Use the **#** character in an expression to dereference an
 #'     attribute name. For example, consider the following attribute name:
 #' 
 #'     -   `Percentile`
@@ -1778,7 +1778,7 @@ dynamodb_delete_backup <- function(BackupArn) {
 #' -   To prevent special characters in an attribute name from being
 #'     misinterpreted in an expression.
 #' 
-#' Use the **\#** character in an expression to dereference an attribute
+#' Use the **#** character in an expression to dereference an attribute
 #' name. For example, consider the following attribute name:
 #' 
 #' -   `Percentile`
@@ -3941,7 +3941,7 @@ dynamodb_export_table_to_point_in_time <- function(TableArn, ExportTime = NULL, 
 #' -   To prevent special characters in an attribute name from being
 #'     misinterpreted in an expression.
 #' 
-#' Use the **\#** character in an expression to dereference an attribute
+#' Use the **#** character in an expression to dereference an attribute
 #' name. For example, consider the following attribute name:
 #' 
 #' -   `Percentile`
@@ -4669,7 +4669,7 @@ dynamodb_list_tags_of_resource <- function(ResourceArn, NextToken = NULL) {
 #' -   To prevent special characters in an attribute name from being
 #'     misinterpreted in an expression.
 #' 
-#' Use the **\#** character in an expression to dereference an attribute
+#' Use the **#** character in an expression to dereference an attribute
 #' name. For example, consider the following attribute name:
 #' 
 #' -   `Percentile`
@@ -5242,7 +5242,7 @@ dynamodb_put_item <- function(TableName, Item, Expected = NULL, ReturnValues = N
 #' -   To prevent special characters in an attribute name from being
 #'     misinterpreted in an expression.
 #' 
-#' Use the **\#** character in an expression to dereference an attribute
+#' Use the **#** character in an expression to dereference an attribute
 #' name. For example, consider the following attribute name:
 #' 
 #' -   `Percentile`
@@ -6311,7 +6311,7 @@ dynamodb_restore_table_to_point_in_time <- function(SourceTableArn = NULL, Sourc
 #' -   To prevent special characters in an attribute name from being
 #'     misinterpreted in an expression.
 #' 
-#' Use the **\#** character in an expression to dereference an attribute
+#' Use the **#** character in an expression to dereference an attribute
 #' name. For example, consider the following attribute name:
 #' 
 #' -   `Percentile`
@@ -7954,7 +7954,7 @@ dynamodb_update_global_table_settings <- function(GlobalTableName, GlobalTableBi
 #' -   To prevent special characters in an attribute name from being
 #'     misinterpreted in an expression.
 #' 
-#' Use the **\#** character in an expression to dereference an attribute
+#' Use the **#** character in an expression to dereference an attribute
 #' name. For example, consider the following attribute name:
 #' 
 #' -   `Percentile`

--- a/cran/paws.database/R/elasticache_operations.R
+++ b/cran/paws.database/R/elasticache_operations.R
@@ -907,7 +907,7 @@ elasticache_copy_snapshot <- function(SourceSnapshotName, TargetSnapshotName, Ta
 #' -   Must be at least 16 characters and no more than 128 characters in
 #'     length.
 #' 
-#' -   The only permitted printable special characters are !, &, \#, $, ^,
+#' -   The only permitted printable special characters are !, &, #, $, ^,
 #'     &lt;, &gt;, and -. Other printable special characters cannot be used
 #'     in the AUTH token.
 #' 
@@ -1742,7 +1742,7 @@ elasticache_create_global_replication_group <- function(GlobalReplicationGroupId
 #' -   Must be at least 16 characters and no more than 128 characters in
 #'     length.
 #' 
-#' -   The only permitted printable special characters are !, &, \#, $, ^,
+#' -   The only permitted printable special characters are !, &, #, $, ^,
 #'     &lt;, &gt;, and -. Other printable special characters cannot be used
 #'     in the AUTH token.
 #' 

--- a/cran/paws.database/man/dynamodb_batch_get_item.Rd
+++ b/cran/paws.database/man/dynamodb_batch_get_item.Rd
@@ -29,7 +29,7 @@ attribute name in an expression.
 misinterpreted in an expression.
 }
 
-Use the \strong{\#} character in an expression to dereference an
+Use the \strong{#} character in an expression to dereference an
 attribute name. For example, consider the following attribute name:
 \itemize{
 \item \code{Percentile}

--- a/cran/paws.database/man/dynamodb_delete_item.Rd
+++ b/cran/paws.database/man/dynamodb_delete_item.Rd
@@ -78,7 +78,7 @@ name in an expression.
 misinterpreted in an expression.
 }
 
-Use the \strong{\#} character in an expression to dereference an attribute
+Use the \strong{#} character in an expression to dereference an attribute
 name. For example, consider the following attribute name:
 \itemize{
 \item \code{Percentile}

--- a/cran/paws.database/man/dynamodb_get_item.Rd
+++ b/cran/paws.database/man/dynamodb_get_item.Rd
@@ -52,7 +52,7 @@ name in an expression.
 misinterpreted in an expression.
 }
 
-Use the \strong{\#} character in an expression to dereference an attribute
+Use the \strong{#} character in an expression to dereference an attribute
 name. For example, consider the following attribute name:
 \itemize{
 \item \code{Percentile}

--- a/cran/paws.database/man/dynamodb_put_item.Rd
+++ b/cran/paws.database/man/dynamodb_put_item.Rd
@@ -95,7 +95,7 @@ name in an expression.
 misinterpreted in an expression.
 }
 
-Use the \strong{\#} character in an expression to dereference an attribute
+Use the \strong{#} character in an expression to dereference an attribute
 name. For example, consider the following attribute name:
 \itemize{
 \item \code{Percentile}

--- a/cran/paws.database/man/dynamodb_query.Rd
+++ b/cran/paws.database/man/dynamodb_query.Rd
@@ -234,7 +234,7 @@ name in an expression.
 misinterpreted in an expression.
 }
 
-Use the \strong{\#} character in an expression to dereference an attribute
+Use the \strong{#} character in an expression to dereference an attribute
 name. For example, consider the following attribute name:
 \itemize{
 \item \code{Percentile}

--- a/cran/paws.database/man/dynamodb_scan.Rd
+++ b/cran/paws.database/man/dynamodb_scan.Rd
@@ -171,7 +171,7 @@ name in an expression.
 misinterpreted in an expression.
 }
 
-Use the \strong{\#} character in an expression to dereference an attribute
+Use the \strong{#} character in an expression to dereference an attribute
 name. For example, consider the following attribute name:
 \itemize{
 \item \code{Percentile}

--- a/cran/paws.database/man/dynamodb_update_item.Rd
+++ b/cran/paws.database/man/dynamodb_update_item.Rd
@@ -174,7 +174,7 @@ name in an expression.
 misinterpreted in an expression.
 }
 
-Use the \strong{\#} character in an expression to dereference an attribute
+Use the \strong{#} character in an expression to dereference an attribute
 name. For example, consider the following attribute name:
 \itemize{
 \item \code{Percentile}

--- a/cran/paws.database/man/elasticache_create_cache_cluster.Rd
+++ b/cran/paws.database/man/elasticache_create_cache_cluster.Rd
@@ -288,7 +288,7 @@ Password constraints:
 \item Must be only printable ASCII characters.
 \item Must be at least 16 characters and no more than 128 characters in
 length.
-\item The only permitted printable special characters are !, &, \#, $, ^,
+\item The only permitted printable special characters are !, &, #, $, ^,
 <, >, and -. Other printable special characters cannot be used
 in the AUTH token.
 }

--- a/cran/paws.database/man/elasticache_create_replication_group.Rd
+++ b/cran/paws.database/man/elasticache_create_replication_group.Rd
@@ -326,7 +326,7 @@ Password constraints:
 \item Must be only printable ASCII characters.
 \item Must be at least 16 characters and no more than 128 characters in
 length.
-\item The only permitted printable special characters are !, &, \#, $, ^,
+\item The only permitted printable special characters are !, &, #, $, ^,
 <, >, and -. Other printable special characters cannot be used
 in the AUTH token.
 }

--- a/cran/paws.internet.of.things/R/iot_operations.R
+++ b/cran/paws.internet.of.things/R/iot_operations.R
@@ -1174,7 +1174,7 @@ iot_create_custom_metric <- function(metricName, displayName = NULL, metricType,
 #' @param type &#91;required&#93; Specifies the type of dimension. Supported types: `TOPIC_FILTER.`
 #' @param stringValues &#91;required&#93; Specifies the value or list of values for the dimension. For
 #' `TOPIC_FILTER` dimensions, this is a pattern used to match the MQTT
-#' topic (for example, "admin/\#").
+#' topic (for example, "admin/#").
 #' @param tags Metadata that can be used to manage the dimension.
 #' @param clientRequestToken &#91;required&#93; Each dimension must have a unique client request token. If you try to
 #' create a new dimension with the same token as a dimension that already
@@ -13927,7 +13927,7 @@ iot_update_custom_metric <- function(metricName, displayName) {
 #' the type and value to make it easy to remember what it does.
 #' @param stringValues &#91;required&#93; Specifies the value or list of values for the dimension. For
 #' `TOPIC_FILTER` dimensions, this is a pattern used to match the MQTT
-#' topic (for example, "admin/\#").
+#' topic (for example, "admin/#").
 #'
 #' @return
 #' A list with the following syntax:

--- a/cran/paws.internet.of.things/man/iot_create_dimension.Rd
+++ b/cran/paws.internet.of.things/man/iot_create_dimension.Rd
@@ -15,7 +15,7 @@ the type and value to make it easy to remember what it does.}
 
 \item{stringValues}{[required] Specifies the value or list of values for the dimension. For
 \code{TOPIC_FILTER} dimensions, this is a pattern used to match the MQTT
-topic (for example, "admin/\#").}
+topic (for example, "admin/#").}
 
 \item{tags}{Metadata that can be used to manage the dimension.}
 

--- a/cran/paws.internet.of.things/man/iot_update_dimension.Rd
+++ b/cran/paws.internet.of.things/man/iot_update_dimension.Rd
@@ -12,7 +12,7 @@ the type and value to make it easy to remember what it does.}
 
 \item{stringValues}{[required] Specifies the value or list of values for the dimension. For
 \code{TOPIC_FILTER} dimensions, this is a pattern used to match the MQTT
-topic (for example, "admin/\#").}
+topic (for example, "admin/#").}
 }
 \value{
 A list with the following syntax:\preformatted{list(

--- a/cran/paws.management/R/cloudwatchlogs_operations.R
+++ b/cran/paws.management/R/cloudwatchlogs_operations.R
@@ -212,7 +212,7 @@ cloudwatchlogs_create_export_task <- function(taskName = NULL, logGroupName, log
 #' 
 #' -   Log group names consist of the following characters: a-z, A-Z, 0-9,
 #'     '_' (underscore), '-' (hyphen), '/' (forward slash), '.' (period),
-#'     and '\#' (number sign)
+#'     and '#' (number sign)
 #' 
 #' When you create a log group, by default the log events in the log group
 #' never expire. To set a retention policy so that events expire and are

--- a/cran/paws.management/R/licensemanager_operations.R
+++ b/cran/paws.management/R/licensemanager_operations.R
@@ -511,8 +511,8 @@ licensemanager_create_license <- function(LicenseName, ProductName, ProductSKU, 
 #' @param LicenseCount Number of licenses managed by the license configuration.
 #' @param LicenseCountHardLimit Indicates whether hard or soft license enforcement is used. Exceeding a
 #' hard limit blocks the launch of new instances.
-#' @param LicenseRules License rules. The syntax is \#name=value (for example,
-#' \#allowedTenancy=EC2-DedicatedHost). The available rules vary by
+#' @param LicenseRules License rules. The syntax is #name=value (for example,
+#' #allowedTenancy=EC2-DedicatedHost). The available rules vary by
 #' dimension, as follows.
 #' 
 #' -   `Cores` dimension: `allowedTenancy` | `licenseAffinityToHost` |

--- a/cran/paws.management/R/opsworkscm_operations.R
+++ b/cran/paws.management/R/opsworkscm_operations.R
@@ -311,7 +311,7 @@ opsworkscm_create_backup <- function(ServerName, Description = NULL, Tags = NULL
 #'     user in the Chef Automate web-based dashboard. The password length
 #'     is a minimum of eight characters, and a maximum of 32. The password
 #'     can contain letters, numbers, and special characters
-#'     (!/@@\#$%^&+=_). The password must contain at least one lower case
+#'     (!/@@#$%^&+=_). The password must contain at least one lower case
 #'     letter, one upper case letter, one number, and one special
 #'     character. When no CHEF_AUTOMATE_ADMIN_PASSWORD is set, one is
 #'     generated and returned in the response.

--- a/cran/paws.management/man/cloudwatchlogs_create_log_group.Rd
+++ b/cran/paws.management/man/cloudwatchlogs_create_log_group.Rd
@@ -27,7 +27,7 @@ You must use the following guidelines when naming a log group:
 \item Log group names can be between 1 and 512 characters long.
 \item Log group names consist of the following characters: a-z, A-Z, 0-9,
 '_' (underscore), '-' (hyphen), '/' (forward slash), '.' (period),
-and '\#' (number sign)
+and '#' (number sign)
 }
 
 When you create a log group, by default the log events in the log group

--- a/cran/paws.management/man/licensemanager_create_license_configuration.Rd
+++ b/cran/paws.management/man/licensemanager_create_license_configuration.Rd
@@ -20,8 +20,8 @@ licensemanager_create_license_configuration(Name, Description,
 \item{LicenseCountHardLimit}{Indicates whether hard or soft license enforcement is used. Exceeding a
 hard limit blocks the launch of new instances.}
 
-\item{LicenseRules}{License rules. The syntax is \#name=value (for example,
-\#allowedTenancy=EC2-DedicatedHost). The available rules vary by
+\item{LicenseRules}{License rules. The syntax is #name=value (for example,
+#allowedTenancy=EC2-DedicatedHost). The available rules vary by
 dimension, as follows.
 \itemize{
 \item \code{Cores} dimension: \code{allowedTenancy} | \code{licenseAffinityToHost} |

--- a/cran/paws.management/man/opsworkscm_create_server.Rd
+++ b/cran/paws.management/man/opsworkscm_create_server.Rd
@@ -73,7 +73,7 @@ and returned in the response.
 user in the Chef Automate web-based dashboard. The password length
 is a minimum of eight characters, and a maximum of 32. The password
 can contain letters, numbers, and special characters
-(!/@\#$\%^&+=_). The password must contain at least one lower case
+(!/@#$\%^&+=_). The password must contain at least one lower case
 letter, one upper case letter, one number, and one special
 character. When no CHEF_AUTOMATE_ADMIN_PASSWORD is set, one is
 generated and returned in the response.

--- a/cran/paws.migration/R/databasemigrationservice_operations.R
+++ b/cran/paws.migration/R/databasemigrationservice_operations.R
@@ -1478,7 +1478,7 @@ databasemigrationservice_create_replication_subnet_group <- function(Replication
 #' Date Example: --cdc-start-position “2018-03-08T12:12:12”
 #' 
 #' Checkpoint Example: --cdc-start-position
-#' "checkpoint:V1\#27\#mysql-bin-changelog.157832:1975:-1:2002:677883278264080:mysql-bin-changelog.157832:1876\#0\#0\#*\#0\#93"
+#' "checkpoint:V1#27#mysql-bin-changelog.157832:1975:-1:2002:677883278264080:mysql-bin-changelog.157832:1876#0#0#*#0#93"
 #' 
 #' LSN Example: --cdc-start-position “mysql-bin-changelog.000024:373”
 #' 
@@ -5945,7 +5945,7 @@ databasemigrationservice_modify_replication_subnet_group <- function(Replication
 #' Date Example: --cdc-start-position “2018-03-08T12:12:12”
 #' 
 #' Checkpoint Example: --cdc-start-position
-#' "checkpoint:V1\#27\#mysql-bin-changelog.157832:1975:-1:2002:677883278264080:mysql-bin-changelog.157832:1876\#0\#0\#*\#0\#93"
+#' "checkpoint:V1#27#mysql-bin-changelog.157832:1975:-1:2002:677883278264080:mysql-bin-changelog.157832:1876#0#0#*#0#93"
 #' 
 #' LSN Example: --cdc-start-position “mysql-bin-changelog.000024:373”
 #' 
@@ -6487,7 +6487,7 @@ databasemigrationservice_remove_tags_from_resource <- function(ResourceArn, TagK
 #' Date Example: --cdc-start-position “2018-03-08T12:12:12”
 #' 
 #' Checkpoint Example: --cdc-start-position
-#' "checkpoint:V1\#27\#mysql-bin-changelog.157832:1975:-1:2002:677883278264080:mysql-bin-changelog.157832:1876\#0\#0\#*\#0\#93"
+#' "checkpoint:V1#27#mysql-bin-changelog.157832:1975:-1:2002:677883278264080:mysql-bin-changelog.157832:1876#0#0#*#0#93"
 #' 
 #' LSN Example: --cdc-start-position “mysql-bin-changelog.000024:373”
 #' 

--- a/cran/paws.migration/R/datasync_operations.R
+++ b/cran/paws.migration/R/datasync_operations.R
@@ -542,7 +542,7 @@ datasync_create_location_object_storage <- function(ServerHostname, ServerPort =
 #' Creates an endpoint for an Amazon S3 bucket.
 #' 
 #' For more information, see
-#' https://docs.aws.amazon.com/datasync/latest/userguide/create-locations-cli.html\#create-location-s3-cli
+#' https://docs.aws.amazon.com/datasync/latest/userguide/create-locations-cli.html#create-location-s3-cli
 #' in the *AWS DataSync User Guide*.
 #'
 #' @usage

--- a/cran/paws.migration/man/databasemigrationservice_create_replication_task.Rd
+++ b/cran/paws.migration/man/databasemigrationservice_create_replication_task.Rd
@@ -54,7 +54,7 @@ The value can be in date, checkpoint, or LSN/SCN format.
 Date Example: --cdc-start-position “2018-03-08T12:12:12”
 
 Checkpoint Example: --cdc-start-position
-"checkpoint:V1\#27\#mysql-bin-changelog.157832:1975:-1:2002:677883278264080:mysql-bin-changelog.157832:1876\#0\#0\#*\#0\#93"
+"checkpoint:V1#27#mysql-bin-changelog.157832:1975:-1:2002:677883278264080:mysql-bin-changelog.157832:1876#0#0#*#0#93"
 
 LSN Example: --cdc-start-position “mysql-bin-changelog.000024:373”
 

--- a/cran/paws.migration/man/databasemigrationservice_modify_replication_task.Rd
+++ b/cran/paws.migration/man/databasemigrationservice_modify_replication_task.Rd
@@ -47,7 +47,7 @@ The value can be in date, checkpoint, or LSN/SCN format.
 Date Example: --cdc-start-position “2018-03-08T12:12:12”
 
 Checkpoint Example: --cdc-start-position
-"checkpoint:V1\#27\#mysql-bin-changelog.157832:1975:-1:2002:677883278264080:mysql-bin-changelog.157832:1876\#0\#0\#*\#0\#93"
+"checkpoint:V1#27#mysql-bin-changelog.157832:1975:-1:2002:677883278264080:mysql-bin-changelog.157832:1876#0#0#*#0#93"
 
 LSN Example: --cdc-start-position “mysql-bin-changelog.000024:373”
 

--- a/cran/paws.migration/man/databasemigrationservice_start_replication_task.Rd
+++ b/cran/paws.migration/man/databasemigrationservice_start_replication_task.Rd
@@ -28,7 +28,7 @@ The value can be in date, checkpoint, or LSN/SCN format.
 Date Example: --cdc-start-position “2018-03-08T12:12:12”
 
 Checkpoint Example: --cdc-start-position
-"checkpoint:V1\#27\#mysql-bin-changelog.157832:1975:-1:2002:677883278264080:mysql-bin-changelog.157832:1876\#0\#0\#*\#0\#93"
+"checkpoint:V1#27#mysql-bin-changelog.157832:1975:-1:2002:677883278264080:mysql-bin-changelog.157832:1876#0#0#*#0#93"
 
 LSN Example: --cdc-start-position “mysql-bin-changelog.000024:373”
 

--- a/cran/paws.migration/man/datasync_create_location_s3.Rd
+++ b/cran/paws.migration/man/datasync_create_location_s3.Rd
@@ -45,7 +45,7 @@ A list with the following syntax:\preformatted{list(
 Creates an endpoint for an Amazon S3 bucket.
 
 For more information, see
-https://docs.aws.amazon.com/datasync/latest/userguide/create-locations-cli.html\#create-location-s3-cli
+https://docs.aws.amazon.com/datasync/latest/userguide/create-locations-cli.html#create-location-s3-cli
 in the \emph{AWS DataSync User Guide}.
 }
 \section{Request syntax}{

--- a/cran/paws.networking/R/apigatewayv2_operations.R
+++ b/cran/paws.networking/R/apigatewayv2_operations.R
@@ -1111,7 +1111,7 @@ apigatewayv2_create_route_response <- function(ApiId, ModelSelectionExpression =
 #' @param StageName &#91;required&#93; The name of the stage.
 #' @param StageVariables A map that defines the stage variables for a Stage. Variable names can
 #' have alphanumeric and underscore characters, and the values must match
-#' \[A-Za-z0-9-._~:/?\#&=,\]+.
+#' \[A-Za-z0-9-._~:/?#&=,\]+.
 #' @param Tags The collection of tags. Each tag element is associated with a given
 #' resource.
 #'
@@ -5221,7 +5221,7 @@ apigatewayv2_update_route_response <- function(ApiId, ModelSelectionExpression =
 #' characters.
 #' @param StageVariables A map that defines the stage variables for a Stage. Variable names can
 #' have alphanumeric and underscore characters, and the values must match
-#' \[A-Za-z0-9-._~:/?\#&=,\]+.
+#' \[A-Za-z0-9-._~:/?#&=,\]+.
 #'
 #' @return
 #' A list with the following syntax:

--- a/cran/paws.networking/man/apigatewayv2_create_stage.Rd
+++ b/cran/paws.networking/man/apigatewayv2_create_stage.Rd
@@ -31,7 +31,7 @@ WebSocket APIs.}
 
 \item{StageVariables}{A map that defines the stage variables for a Stage. Variable names can
 have alphanumeric and underscore characters, and the values must match
-[A-Za-z0-9-._~:/?\#&=,]+.}
+[A-Za-z0-9-._~:/?#&=,]+.}
 
 \item{Tags}{The collection of tags. Each tag element is associated with a given
 resource.}

--- a/cran/paws.networking/man/apigatewayv2_update_stage.Rd
+++ b/cran/paws.networking/man/apigatewayv2_update_stage.Rd
@@ -33,7 +33,7 @@ characters.}
 
 \item{StageVariables}{A map that defines the stage variables for a Stage. Variable names can
 have alphanumeric and underscore characters, and the values must match
-[A-Za-z0-9-._~:/?\#&=,]+.}
+[A-Za-z0-9-._~:/?#&=,]+.}
 }
 \value{
 A list with the following syntax:\preformatted{list(

--- a/cran/paws.security.identity/R/iam_operations.R
+++ b/cran/paws.security.identity/R/iam_operations.R
@@ -11043,7 +11043,7 @@ iam_update_access_key <- function(UserName = NULL, AccessKeyId, Status) {
 #' @param RequireSymbols Specifies whether IAM user passwords must contain at least one of the
 #' following non-alphanumeric characters:
 #' 
-#' ! @@ \# $ % ^ & * ( ) _ + - = \[ \] \{ \} | '
+#' ! @@ # $ % ^ & * ( ) _ + - = \[ \] \{ \} | '
 #' 
 #' If you do not specify a value for this parameter, then the operation
 #' uses the default value of `false`. The result is that passwords do not

--- a/cran/paws.security.identity/man/iam_update_account_password_policy.Rd
+++ b/cran/paws.security.identity/man/iam_update_account_password_policy.Rd
@@ -18,7 +18,7 @@ uses the default value of \code{6}.}
 \item{RequireSymbols}{Specifies whether IAM user passwords must contain at least one of the
 following non-alphanumeric characters:
 
-! @ \# $ \% ^ & * ( ) _ + - = [ ] \{ \} | '
+! @ # $ \% ^ & * ( ) _ + - = [ ] \{ \} | '
 
 If you do not specify a value for this parameter, then the operation
 uses the default value of \code{false}. The result is that passwords do not


### PR DESCRIPTION
## This PR

Manually remove characters that are causing notes and warnings in CRAN check, namely:
* `\#` -- replace with `#`
* `\u2028` Unicode line separator -- remove entirely

e.g. https://www.r-project.org/nosvn/R.check/r-devel-windows-x86_64/paws.compute-00check.html
```
checking Rd files ... [65s] NOTE
checkRd: (-1) ec2_create_key_pair.Rd:39: Escaped LaTeX specials: \#
checkRd: (-1) ec2_create_security_group.Rd:18: Escaped LaTeX specials: \#
checkRd: (-1) ec2_create_security_group.Rd:27: Escaped LaTeX specials: \#
```

```
checking PDF version of manual ... [90s] WARNING
LaTeX errors when creating PDF version.
This typically indicates Rd problems.
LaTeX errors found:
! Package inputenc Error: Unicode character   (U+2028)
(inputenc) not set up for use with LaTeX.
```

## Test plan
Run CRAN check on all packages:
```r
checks <- list()
sink(tempfile())
for (package in list.dirs("../cran", recursive = FALSE)) {
  checks[[package]] <- devtools::check(package, cran = TRUE)
}
sink()

for (package in names(checks)) {
  cat(package)
  cat(": ")
  errors <- errors_warnings[[package]]$errors
  warnings <- errors_warnings[[package]]$warnings
  if (length(errors) == 0 && length(warnings) == 0) {
    cat("None")
  } else {
    cat("\n")
    cat(errors)
    cat("\n")
    cat(warnings)
  }
  cat("\n")
}
```

Output:
```
../cran/paws: 

checking dependencies in R code ... WARNING
Missing or unexported object: ‘paws.security.identity::sso’ checking Rd cross-references ... WARNING
Missing link or links in documentation object 'sso.Rd':
  ‘sso_get_role_credentials’ ‘sso_list_account_roles’
  ‘sso_list_accounts’ ‘sso_logout’

See section 'Cross-references' in the 'Writing R Extensions' manual.
../cran/paws.analytics: None
../cran/paws.application.integration: None
../cran/paws.business.applications: None
../cran/paws.compute: None
../cran/paws.cost.management: None
../cran/paws.customer.engagement: None
../cran/paws.database: None
../cran/paws.developer.tools: None
../cran/paws.end.user.computing: None
../cran/paws.game.development: None
../cran/paws.internet.of.things: None
../cran/paws.machine.learning: None
../cran/paws.management: None
../cran/paws.media.services: None
../cran/paws.migration: None
../cran/paws.mobile: None
../cran/paws.networking: None
../cran/paws.robotics: None
../cran/paws.security.identity: None
../cran/paws.storage: None
```