### PR TITLE
Fix/build query string

### DIFF
--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -63,6 +63,11 @@ build_query_string <- function(params){
   # Remove empty elements from params
   params_filter <- Filter(Negate(query_empty), params)
 
+  # Exit function if params_filter is empty to prevent Warning message:
+  # In is.na(x) : is.na() applied to non-(list or vector) of type 'NULL'
+  # in older versions of R
+  if (length(params_filter) == 0) return("")
+
   # convert query elements and escape them
   params_filter <- lapply(
     params_filter, function(element) {query_escape(query_convert(element))}

--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -66,7 +66,7 @@ build_query_string <- function(params){
   # Exit function if params_filter is empty to prevent Warning message:
   # In is.na(x) : is.na() applied to non-(list or vector) of type 'NULL'
   # in older versions of R
-  if (length(params_filter) == 0) return("")
+  if (query_empty(params_filter)) return("")
 
   # convert query elements and escape them
   params_filter <- lapply(


### PR DESCRIPTION
On older versions of R, `build_query_string` raises a warning message:
```r
In is.na(x) : is.na() applied to non-(list or vector) of type 'NULL'
```
This is down to `sort(names(params_filter))` when params_filter is equal to `list()` or `NULL`.  To fix this we can exit function similar to previous initerations:
```r
if (query_empty(params_filter)) return("")
```
