### PR TITLE
Remove nested <i> nodes in documentation

### DIFF
--- a/cran/paws.application.integration/R/swf_operations.R
+++ b/cran/paws.application.integration/R/swf_operations.R
@@ -3156,7 +3156,7 @@ swf_record_activity_task_heartbeat <- function(taskToken, details = NULL) {
 #' 
 #' For more information about setting task priority, see [Setting Task
 #' Priority](https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html)
-#' in the *in the *Amazon SWF Developer Guide*.*.
+#' in the in the *Amazon SWF Developer Guide*.
 #' @param defaultTaskScheduleToStartTimeout If set, specifies the default maximum duration that a task of this
 #' activity type can wait before being assigned to a worker. This default
 #' can be overridden when scheduling an activity task using the

--- a/cran/paws.application.integration/man/swf_register_activity_type.Rd
+++ b/cran/paws.application.integration/man/swf_register_activity_type.Rd
@@ -64,7 +64,7 @@ Java's \code{Integer.MIN_VALUE} (-2147483648) to \code{Integer.MAX_VALUE}
 (2147483647). Higher numbers indicate higher priority.
 
 For more information about setting task priority, see \href{https://docs.aws.amazon.com/amazonswf/latest/developerguide/programming-priority.html}{Setting Task Priority}
-in the \emph{in the \emph{Amazon SWF Developer Guide}.}.}
+in the in the \emph{Amazon SWF Developer Guide}.}
 
 \item{defaultTaskScheduleToStartTimeout}{If set, specifies the default maximum duration that a task of this
 activity type can wait before being assigned to a worker. This default

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -300,6 +300,7 @@ clean_html_node <- function(node, links = c()) {
     code = clean_html_code(node, links),
     dt = clean_html_dt(node),
     dd = clean_html_dd(node),
+    i = clean_html_i(node),
     text = clean_html_text(node)
   )
   for (child in xml2::xml_contents(node)) {
@@ -401,6 +402,21 @@ clean_html_dt <- function(node) {
 # Replace definition list nodes with paragraph nodes.
 clean_html_dd <- function(node) {
   xml2::xml_name(node) <- "p"
+}
+
+# Remove all nested <i> nodes, by changing them to nodes with no formatting.
+# CRAN does not allow nested <i> in R documentation.
+# We arbitrarily remove all the inner <i> nodes because it's easier.
+clean_html_i <- function(node) {
+  remove_html_i <- function(x) {
+    xml2::xml_name(x) <- "span" # Use node type that gets no formatting.
+    for (child in xml2::xml_contents(x)) {
+      remove_html_i(child)
+    }
+  }
+  for (child in xml2::xml_contents(node)) {
+    remove_html_i(child)
+  }
 }
 
 clean_html_text <- function(node) {

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -586,6 +586,11 @@ test_that("convert", {
   text <- "<p>foo\U2028</p>"
   expected <- "foo"
   expect_equal(convert(text), expected)
+
+  # Nested <i> are not allowed by CRAN.
+  text <- "<i>foo <i>bar</i></i>"
+  expected <- "*foo bar*"
+  expect_equal(convert(text), expected)
 })
 
 test_that("check links", {


### PR DESCRIPTION
Remove nested <i> nodes in documentation -- CRAN does not allow them but unfortunately we get them.