### PR TITLE
Support IMDSv2

### DIFF
--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
 Suggests:
     covr,
     crayon,
+    mockery,
     rstudioapi,
     testthat
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -208,8 +208,10 @@ get_instance_metadata <- function(query_path = "") {
       NULL
     }
   )
-  if (!(is.null(metadata_token_response) && metadata_token_response$status_code != 200)) {
-      token=rawToChar(metadata_token_response["body"])
+  if (!(is.null(metadata_token_response)) && metadata_token_response$status_code == 200) {
+      if (length(metadata_token_response["body"])>0) {
+          token=rawToChar(metadata_token_response["body"])
+      } 
   }
   metadata_url <- file.path(
     "http://169.254.169.254/latest/meta-data",

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -193,7 +193,12 @@ get_instance_metadata <- function(query_path = "") {
     "http://169.254.169.254/latest/api/token"
   )
  metadata_token_request <-
-    new_http_request("PUT", metadata_token_url, timeout = 1, header=c("X-aws-ec2-metadata-token-ttl-seconds"= tokentimeout))
+    new_http_request(
+        "PUT", 
+        metadata_token_url, 
+        timeout = 1, 
+        header=c("X-aws-ec2-metadata-token-ttl-seconds"= tokentimeout)
+    )
 
   metadata_token_response <- tryCatch(
     {
@@ -203,16 +208,21 @@ get_instance_metadata <- function(query_path = "") {
       NULL
     }
   )
-  if (!((is.null(metadata_token_response) && metadata_token_response$status_code != 200))) {
+  if (!(is.null(metadata_token_response) && metadata_token_response$status_code != 200)) {
       token=rawToChar(metadata_token_response["body"])
   }
   metadata_url <- file.path(
     "http://169.254.169.254/latest/meta-data",
     query_path
   )
-  if (!(token=="")) {
+  if (token!="") {
   metadata_request <-
-    new_http_request("GET", metadata_url, timeout = 1, header=c("X-aws-ec2-metadata-token"= token))
+    new_http_request(
+        "GET", 
+        metadata_url, 
+        timeout = 1, 
+        header=c("X-aws-ec2-metadata-token"= token)
+    )
   } else { # use IMDSv1 in case IMDSv2 is not available - not recommended - very insecure
   metadata_request <-
     new_http_request("GET", metadata_url, timeout = 1)

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -175,7 +175,8 @@ get_profile_name <- function(profile = "") {
   return(profile)
 }
 
-# Gets the instance metadata by making an http request.
+# Gets the instance metadata by making an http request to an instance metadata services
+# Please see security recommendations by AWS: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
 get_instance_metadata <- function(query_path = "") {
   token_ttl <- '21600' # same approach as in boto3: https://github.com/boto/botocore/blob/master/botocore/utils.py#L376
   # Do not get metadata when the disabled setting is on.
@@ -221,7 +222,7 @@ get_instance_metadata <- function(query_path = "") {
         timeout = 1, 
         header=c("X-aws-ec2-metadata-token"= token)
     )
-  } else { # use IMDSv1 in case IMDSv2 is not available - not recommended - very insecure
+  } else {
   metadata_request <-
     new_http_request("GET", metadata_url, timeout = 1)
   }

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -177,16 +177,12 @@ get_profile_name <- function(profile = "") {
 
 # Gets the instance metadata by making an http request.
 get_instance_metadata <- function(query_path = "") {
-
+  token_ttl <- '21600' # same approach as in boto3: https://github.com/boto/botocore/blob/master/botocore/utils.py#L376
   # Do not get metadata when the disabled setting is on.
   if (trimws(tolower(get_env("AWS_EC2_METADATA_DISABLED"))) %in% c("true", "1")) {
     return(NULL)
   }
   # Get token timeout for IMDSv2 tokens
-  tokentimeout=trimws(tolower(get_env("PAWS_EC2_IMDSV2_TOKEN_TIMEOUT_SECONDS")))
-  if (is.na(as.numeric(tokentimeout))) {
-        tokentimeout="30"
-  }
   token <-  "" # Token to be used in case of more secure IMDSv2 authentication
   #try IMDSv2  (more information): https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
    metadata_token_url <-  file.path(
@@ -197,7 +193,7 @@ get_instance_metadata <- function(query_path = "") {
         "PUT", 
         metadata_token_url, 
         timeout = 1, 
-        header=c("X-aws-ec2-metadata-token-ttl-seconds"= tokentimeout)
+        header=c("X-aws-ec2-metadata-token-ttl-seconds"= token_ttl)
     )
 
   metadata_token_response <- tryCatch(

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -183,7 +183,7 @@ get_instance_metadata <- function(query_path = "") {
     return(NULL)
   }
   # Get token timeout for IMDSv2 tokens
-  tokentimeout=trimws(tolower(get_env("PAWS_EC2_IMDSV2_TOKEN_TIMEOUT")))
+  tokentimeout=trimws(tolower(get_env("PAWS_EC2_IMDSV2_TOKEN_TIMEOUT_SECONDS")))
   if (is.na(as.numeric(tokentimeout))) {
         tokentimeout="30"
   }

--- a/paws.common/R/net.R
+++ b/paws.common/R/net.R
@@ -55,6 +55,7 @@ HttpResponse <- struct(
 # @param close Whether to immediately close the connection, or else reuse connections.
 # @param timeout How long to wait for an initial response.
 # @param dest Control where the response body is written
+# @param header list of HTTP headers to add to the request
 new_http_request <- function(method, url, body = NULL, close = FALSE, timeout = NULL, dest = NULL, header = list()) {
   if (method == "") {
     method <- "GET"

--- a/paws.common/R/net.R
+++ b/paws.common/R/net.R
@@ -55,7 +55,7 @@ HttpResponse <- struct(
 # @param close Whether to immediately close the connection, or else reuse connections.
 # @param timeout How long to wait for an initial response.
 # @param dest Control where the response body is written
-new_http_request <- function(method, url, body = NULL, close = FALSE, timeout = NULL, dest = NULL) {
+new_http_request <- function(method, url, body = NULL, close = FALSE, timeout = NULL, dest = NULL, header = list()) {
   if (method == "") {
     method <- "GET"
   }
@@ -69,7 +69,7 @@ new_http_request <- function(method, url, body = NULL, close = FALSE, timeout = 
     proto = "HTTP/1.1",
     proto_major = 1,
     proto_minor = 1,
-    header = list(), # TODO
+    header = header,
     body = body,
     host = u$host,
     close = close,


### PR DESCRIPTION
Support IDMSv2.

Tested with Sagemaker Notebooks with IMDSv2 enforced.

Configuration:
~~Optionally, set the environment variable "PAWS_EC2_IMDSV2_TOKEN_TIMEOUT_SECONDS" to the number of seconds after which the token should expire. The default (30 seconds) should be sufficient for nearly all use cases~~ no configuration we use the same method as in boto3

Solves: https://github.com/paws-r/paws/issues/441

