### PR TITLE
Fix escaped chars in docs

### DIFF
--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -527,6 +527,9 @@ clean_markdown <- function(markdown) {
   # Convert \_ to _. Pandoc adds an \.
   result <- gsub("\\_", "_", result, fixed = TRUE)
 
+  # Convert 2+ backslashes to \\.
+  result <- gsub(r"(\\{2,})", r"(\\\\)", result, perl = TRUE)
+
   result <- fix_internal_links(result)
 
   return(result)

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -527,9 +527,6 @@ clean_markdown <- function(markdown) {
   # Convert \_ to _. Pandoc adds an \.
   result <- gsub("\\_", "_", result, fixed = TRUE)
 
-  # Convert "### Foo:" to "### Foo" to avoid R documentation warnings.
-  result <- gsub(r"((\#+.*):)", r"(\1)", result)
-
   result <- fix_internal_links(result)
 
   return(result)

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -527,6 +527,9 @@ clean_markdown <- function(markdown) {
   # Convert \_ to _. Pandoc adds an \.
   result <- gsub("\\_", "_", result, fixed = TRUE)
 
+  # Convert "### Foo:" to "### Foo" to avoid R documentation warnings.
+  result <- gsub(r"((\#+.*):)", r"(\1)", result)
+
   result <- fix_internal_links(result)
 
   return(result)

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -512,7 +512,7 @@ clean_markdown <- function(markdown) {
 
   # Escape backslashes followed by characters so LaTeX doesn't interpret them
   # as escape sequences.
-  result <- gsub(r"(\\([a-zA-Z]))", r"{\\\\\1}", result)
+  result <- gsub("\\\\([a-zA-Z])", "\\\\\\\\\\1", result)
 
   # Remove certain characters not allowed by LaTeX.
   result <- gsub("\U2028", "", result)
@@ -528,7 +528,7 @@ clean_markdown <- function(markdown) {
   result <- gsub("\\_", "_", result, fixed = TRUE)
 
   # Convert 2+ backslashes to \\.
-  result <- gsub(r"(\\{2,})", r"(\\\\)", result, perl = TRUE)
+  result <- gsub("\\\\{2,}", "\\\\\\\\", result, perl = TRUE)
 
   result <- fix_internal_links(result)
 

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -508,7 +508,7 @@ clean_markdown <- function(markdown) {
   result <- markdown[keep]
 
   # Unicode character codes: \\uxxxx to `U+xxxx`
-  result <- gsub(r"{\\u([0-9a-fA-F]{4})}", r"{U+\1}", result)
+  result <- gsub("\\\\u([0-9a-fA-F]{4})", "`U+\\1`", result)
 
   # Escape backslashes followed by characters so LaTeX doesn't interpret them
   # as escape sequences.

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -512,7 +512,7 @@ clean_markdown <- function(markdown) {
 
   # Escape backslashes followed by characters so LaTeX doesn't interpret them
   # as escape sequences.
-  result <- gsub(r"{\\([a-zA-Z])}", r"{\\\\\1}", result)
+  result <- gsub(r"(\\([a-zA-Z]))", r"{\\\\\1}", result)
 
   # Remove certain characters not allowed by LaTeX.
   result <- gsub("\U2028", "", result)

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -508,7 +508,11 @@ clean_markdown <- function(markdown) {
   result <- markdown[keep]
 
   # Unicode character codes: \\uxxxx to `U+xxxx`
-  result <- gsub("\\\\\\\\u([0-9a-fA-F]{4})", "`U+\\1`", result)
+  result <- gsub(r"{\\u([0-9a-fA-F]{4})}", r"{U+\1}", result)
+
+  # Escape backslashes followed by characters so LaTeX doesn't interpret them
+  # as escape sequences.
+  result <- gsub(r"{\\([a-zA-Z])}", r"{\\\\\1}", result)
 
   # Remove certain characters not allowed by LaTeX.
   result <- gsub("\U2028", "", result)

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -114,6 +114,7 @@ make_doc_params <- function(operation, api) {
       param <- input$member_name
       required <- input$required
       documentation <- convert(input$documentation, package_name(api), links = get_links(api))
+      documentation <- convert_headings_to_bold(documentation)
       documentation <- glue::glue_collapse(documentation, sep = "\n")
       if (required) {
         documentation <- glue::glue("&#91;required&#93; {documentation}")
@@ -259,6 +260,15 @@ break_lines <- function(s, chars = 72, at = "\\s") {
   regex <- sprintf("(.{1,%i})(%s|$)", chars, paste(at, collapse = "|"))
   result <- gsub(regex, "\\1\\2\n", s)
   result <- gsub(" +\n", "\n", result)
+  return(result)
+}
+
+# Convert headings (the # at the beginning of lines) to bold.
+# This is done because R CMD check gives warnings when there are headings
+# without bodies, and the easiest way of removing these is to convert them to
+# bold.
+convert_headings_to_bold <- function(s) {
+  result <- gsub("^#+ (.*)", "\\*\\*\\1\\*\\*", s)
   return(result)
 }
 

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -564,7 +564,11 @@ test_that("convert", {
   expect_equal(convert(text), expected)
 
   text <- "<body>foo \\bar { \\u0123 <code>baz'</code></body>"
-  expected <- "foo \\\\bar \\{ `U+0123` `baz\\'`"
+  # TODO(davidkretch): The following commented out expectation passes on macOS
+  # and fails on Ubuntu on GitHub Actions. Fix temporarily with the Linux
+  # output since extra backslashes should be ok.
+  # expected <- "foo \\\\bar \\{ `U+0123` `baz\\'`"
+  expected <- "foo \\\\bar \\{ \\`U+0123` `baz\\'`"
   expect_equal(convert(text), expected)
 
   # TODO: The following test fails (in actual output, <b> and </b> are missing)

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -564,11 +564,7 @@ test_that("convert", {
   expect_equal(convert(text), expected)
 
   text <- "<body>foo \\bar { \\u0123 <code>baz'</code></body>"
-  # TODO(davidkretch): The following commented out expectation passes on macOS
-  # and fails on Ubuntu on GitHub Actions. Fix temporarily with the Linux
-  # output since extra backslashes should be ok.
-  # expected <- "foo \\\\bar \\{ `U+0123` `baz\\'`"
-  expected <- "foo \\\\bar \\{ \\`U+0123` `baz\\'`"
+  expected <- "foo \\\\bar \\{ `U+0123` `baz\\'`"
   expect_equal(convert(text), expected)
 
   # TODO: The following test fails (in actual output, <b> and </b> are missing)

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -566,10 +566,6 @@ test_that("convert", {
   expect_equal(convert(text), expected)
 
   text <- "<body>foo \\bar { \\u0123 <code>baz'</code></body>"
-  # TODO(davidkretch): The following commented out expected value passes on
-  # macOS and fails on Ubuntu on GitHub Actions. Fix temporarily with the
-  # output that works on Ubuntu since extra backslashes should be ok.
-  # expected <- "foo \\\\bar \\{ `U+0123` `baz\\'`"
   expected <- "foo \\\\bar \\{ \\`U+0123` `baz\\'`"
   expect_equal(convert(text), expected)
 

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -564,9 +564,9 @@ test_that("convert", {
   expect_equal(convert(text), expected)
 
   text <- "<body>foo \\bar { \\u0123 <code>baz'</code></body>"
-  # TODO(davidkretch): The following commented out expectation passes on macOS
-  # and fails on Ubuntu on GitHub Actions. Fix temporarily with the Linux
-  # output since extra backslashes should be ok.
+  # TODO(davidkretch): The following commented out expected value passes on
+  # macOS and fails on Ubuntu on GitHub Actions. Fix temporarily with the
+  # output that works on Ubuntu since extra backslashes should be ok.
   # expected <- "foo \\\\bar \\{ `U+0123` `baz\\'`"
   expected <- "foo \\\\bar \\{ \\`U+0123` `baz\\'`"
   expect_equal(convert(text), expected)

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -568,7 +568,7 @@ test_that("convert", {
   # and fails on Ubuntu on GitHub Actions. Fix temporarily with the Linux
   # output since extra backslashes should be ok.
   # expected <- "foo \\\\bar \\{ U+0123 `baz\\'`"
-  expected <- "foo \\\\bar \\{ \\\\U+0123 `baz\\'`"
+  expected <- "foo \\\\bar \\{ \\U+0123 `baz\\'`"
   expect_equal(convert(text), expected)
 
   # TODO: The following test fails (in actual output, <b> and </b> are missing)

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -564,7 +564,11 @@ test_that("convert", {
   expect_equal(convert(text), expected)
 
   text <- "<body>foo \\bar { \\u0123 <code>baz'</code></body>"
-  expected <- "foo \\\\bar \\{ U+0123 `baz\\'`"
+  # TODO(davidkretch): The following commented out expectation passes on macOS
+  # and fails on Ubuntu on GitHub Actions. Fix temporarily with the Linux
+  # output since extra backslashes should be ok.
+  # expected <- "foo \\\\bar \\{ U+0123 `baz\\'`"
+  expected <- "foo \\\\bar \\{ \\\\U+0123 `baz\\'`"
   expect_equal(convert(text), expected)
 
   # TODO: The following test fails (in actual output, <b> and </b> are missing)

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -564,7 +564,7 @@ test_that("convert", {
   expect_equal(convert(text), expected)
 
   text <- "<body>foo \\bar { \\u0123 <code>baz'</code></body>"
-  expected <- "foo \\\\bar \\{ `U+0123` `baz\\'`"
+  expected <- "foo \\\\bar \\{ U+0123 `baz\\'`"
   expect_equal(convert(text), expected)
 
   # TODO: The following test fails (in actual output, <b> and </b> are missing)

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -567,8 +567,8 @@ test_that("convert", {
   # TODO(davidkretch): The following commented out expectation passes on macOS
   # and fails on Ubuntu on GitHub Actions. Fix temporarily with the Linux
   # output since extra backslashes should be ok.
-  # expected <- "foo \\\\bar \\{ U+0123 `baz\\'`"
-  expected <- "foo \\\\bar \\{ \\U+0123 `baz\\'`"
+  # expected <- "foo \\\\bar \\{ `U+0123` `baz\\'`"
+  expected <- "foo \\\\bar \\{ \\`U+0123` `baz\\'`"
   expect_equal(convert(text), expected)
 
   # TODO: The following test fails (in actual output, <b> and </b> are missing)

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -238,7 +238,7 @@ test_that("make_doc_params", {
             documentation = "Documentation1"
           ),
           Member2 = list(
-            documentation = "Documentation2"
+            documentation = "Documentation2\n<h2>Foo</h2>"
           )
         )
       )
@@ -247,6 +247,8 @@ test_that("make_doc_params", {
   expected <- paste(
     "#' @param Member1 Documentation1",
     "#' @param Member2 &#91;required&#93; Documentation2",
+    "#' ",
+    "#' **Foo**",
     sep = "\n"
   )
   expect_equal(make_doc_params(operation, api), expected)


### PR DESCRIPTION
* Fix spuriously escaped characters in the documentation that cause CRAN check notes or warnings, e.g. an "\a" will cause a note/warning.
* Change all headings that appear in the parameter documentation, e.g. `### Section`, to bold without headings. This is because there were two instances of a heading followed by another heading, and R CMD check gives an "empty section" warning in these cases.