### PR TITLE
Support S3 redirects

### DIFF
--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -2,6 +2,7 @@
 
 * Fix Content-Md5 being modified by user
 * Add logging system to help with debugging paws issues
+* Add s3 redirects from error message
 
 # paws.common 0.5.1
 

--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -2,7 +2,7 @@
 
 * Fix Content-Md5 being modified by user
 * Add logging system to help with debugging paws issues
-* Add s3 redirects from error message
+* Automatically redirect S3 requests when they are initially made to the wrong region; previously these requests would fail
 
 # paws.common 0.5.1
 

--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -347,10 +347,8 @@ s3_redirect_from_error <- function(request){
 # but they aren't all universally available for use. This will try to
 # find region from response elements, but will fall back to calling
 # HEAD on the bucket if all else fails.
-# :param bucket: The bucket to find the region for. This is necessary if
-#     the region is not available in the error response.
-# :param response: A response representing a service request that failed
-#     due to incorrect region configuration.
+# param response: HttpResponse
+# param error: Error
 s3_get_bucket_region <- function(response, error){
   # First try to source the region from the headers.
   response_headers <- response$header

--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -275,15 +275,15 @@ s3_redirect_from_error <- function(request){
   # if we sign a Head* request with the wrong region,
   # we'll get a 400 Bad Request but we won't get a
   # body saying it's an "AuthorizationHeaderMalformed".
-  is_special_head_object = (
+  is_special_head_object <- (
     error_code %in% c('301', '400') & request$operation$name == 'HeadObject'
   )
-  is_special_head_bucket = (
+  is_special_head_bucket <- (
     error_code %in% c('301', '400')
     & request$operation$name == 'HeadBucket'
     & 'x-amz-bucket-region' %in% names(request$http_response$header)
   )
-  is_wrong_signing_region = (
+  is_wrong_signing_region <- (
     error$Code == 'AuthorizationHeaderMalformed' & 'Region' %in% names(error)
   )
   is_redirect_status <- request$http_response$status_code %in% c(301, 302, 307)
@@ -364,7 +364,9 @@ s3_get_bucket_region <- function(response, error){
 # Splice a new endpoint into an existing URL. Note that some endpoints
 # from the endpoint provider have a path component which will be
 # discarded by this function.
-set_request_url <- function(original_endpoint, new_endpoint, use_new_scheme=TRUE){
+set_request_url <- function(original_endpoint,
+                            new_endpoint,
+                            use_new_scheme = TRUE){
   new_endpoint_components <- httr::parse_url(new_endpoint)
   original_endpoint_components <- httr::parse_url(original_endpoint)
   scheme <- original_endpoint_components$scheme

--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -1,5 +1,6 @@
 #' @include service.R
 #' @include stream.R
+#' @include util.R
 NULL
 
 ################################################################################
@@ -185,11 +186,33 @@ s3_unmarshal_error <- function(request) {
     decode_xml(request$http_response$body),
     error = function(e) NULL
   )
+  # Bucket exists in a different region, and request needs
+  # to be made to the correct region.
+  if (request$http_response$status_code == 301) {
+    error_msg <- list()
+    error_msg[[1]] <- sprintf(
+      "incorrect region, the bucket is not in '%s' region at endpoint '%s'",
+      request$config$region,
+      request$config$endpoint
+    )
+    if (nzchar(v <- request$http_response$header[["x-amz-bucket-region"]] %||% "")) {
+      error_msg[[2]] <- sprintf(", bucket is in '%s' region", v)
+    }
+    request$error <- Error(
+      "BucketRegionError",
+      paste(error_msg, collapse = ""),
+      request$http_response$status_code,
+      request$request_id
+    )
+    return(request)
+  }
 
   if (is.null(data)) {
-    request$error <- Error("SerializationError",
-                           "failed to read from query HTTP response body",
-                           request$http_response$status_code)
+    request$error <- Error(
+      "SerializationError",
+      "failed to read from query HTTP response body",
+      request$http_response$status_code
+    )
     return(request)
   }
 
@@ -204,8 +227,163 @@ s3_unmarshal_error <- function(request) {
     return(request)
   }
 
-  request$error <- Error(code, message, request$http_response$status_code, error_response)
+  request$error <- Error(
+    code, message, request$http_response$status_code, error_response
+  )
   return(request)
+}
+
+################################################################################
+
+s3_endpoints <- list(
+  "us-gov-west-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+  "us-west-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+  "us-west-2" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+  "eu-west-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+  "ap-southeast-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+  "ap-southeast-2" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+  "ap-northeast-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+  "sa-east-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+  "us-east-1" = list(endpoint = "s3.amazonaws.com", global = FALSE),
+  "*" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+  "cn-*" = list(endpoint = "s3.{region}.amazonaws.com.cn", global = FALSE),
+  "us-iso-*" = list(endpoint = "s3.{region}.c2s.ic.gov", global = FALSE),
+  "us-isob-*" = list(endpoint = "s3.{region}.sc2s.sgov.gov", global = FALSE)
+)
+
+# Developed from botocore S3RegionRedirectorv2:
+# https://github.com/boto/botocore/blob/de6dfccdb68e70005ed2a73dc5d04bc1e97f0541/botocore/utils.py#L1509
+
+# An S3 request sent to the wrong region will return an error that
+# contains the endpoint the request should be sent to. This handler
+# will add the redirect information to the signing context and then
+# redirect the request.
+s3_redirect_from_error <- function(request){
+  if (is.null(request$http_response)) {
+      return(request)
+  }
+  if (isTRUE(request$context$s3_redirect)) {
+    log_debug(
+      'S3 request was previously redirected, not redirecting.'
+    )
+    return(request)
+  }
+  error_code <- request$http_response$status_code
+  error <- decode_xml(request$http_response$body)$Error
+
+  # We have to account for 400 responses because
+  # if we sign a Head* request with the wrong region,
+  # we'll get a 400 Bad Request but we won't get a
+  # body saying it's an "AuthorizationHeaderMalformed".
+  is_special_head_object = (
+    error_code %in% c('301', '400') & request$operation$name == 'HeadObject'
+  )
+  is_special_head_bucket = (
+    error_code %in% c('301', '400')
+    & request$operation$name == 'HeadBucket'
+    & 'x-amz-bucket-region' %in% names(request$http_response$header)
+  )
+  is_wrong_signing_region = (
+    error$Code == 'AuthorizationHeaderMalformed' & 'Region' %in% names(error)
+  )
+  is_redirect_status <- request$http_response$status_code %in% c(301, 302, 307)
+  is_permanent_redirect <- error_code == 'PermanentRedirect'
+  if (!any(
+    c(
+      is_special_head_object,
+      is_wrong_signing_region,
+      is_permanent_redirect,
+      is_special_head_bucket,
+      is_redirect_status
+    )
+  )) {
+    return(request)
+  }
+  bucket_name <- bucket_name_from_req_params(request)
+  new_region <- s3_get_bucket_region(request$http_response, error)
+  if (is.null(new_region)) {
+    log_debug(paste(
+      "S3 client configured for region %s but the bucket %s is not",
+      "in that region and the proper region could not be",
+      "automatically determined."),
+      request$client_info$signing_region, bucket_name
+    )
+    return(request)
+  }
+  log_debug(paste(
+    "S3 client configured for region %s but the bucket %s is in region",
+    "%s; Please configure the proper region to avoid multiple",
+    "unnecessary redirects and signing attempts."),
+    request$client_info$signing_region, bucket_name, new_region
+  )
+  # Update client_info for redirect
+  request$client_info$signing_region <- new_region
+  # Re-resolve endpoint with new region and modify request_dict with
+  # the new URL, auth scheme, and signing context.
+  ep_info <- resolver_endpoint(
+    service = "s3",
+    region = new_region,
+    endpoints = s3_endpoints
+  )
+  request$client_info$endpoint <- set_request_url(
+    request$client_info$endpoint, ep_info$endpoint
+  )
+  request$http_request$url <- parse_url(
+    paste0(request$client_info$endpoint, request$operation$http_path)
+  )
+  request$built <- FALSE
+  # re-sign redirect request
+  request <- sign(request)
+
+  # re-send redirect request
+  request <- send(request)
+
+  request$context$s3_redirect <- TRUE
+
+  return(request)
+}
+
+# There are multiple potential sources for the new region to redirect to,
+# but they aren't all universally available for use. This will try to
+# find region from response elements, but will fall back to calling
+# HEAD on the bucket if all else fails.
+# :param bucket: The bucket to find the region for. This is necessary if
+#     the region is not available in the error response.
+# :param response: A response representing a service request that failed
+#     due to incorrect region configuration.
+s3_get_bucket_region <- function(response, error){
+  # First try to source the region from the headers.
+  response_headers <- response$header
+  if ('x-amz-bucket-region' %in% names(response_headers)){
+      return(response_headers[['x-amz-bucket-region']])
+  }
+  # Next, check the error body
+  region <- error$Region
+  return(region)
+}
+
+
+# Splice a new endpoint into an existing URL. Note that some endpoints
+# from the endpoint provider have a path component which will be
+# discarded by this function.
+set_request_url <- function(original_endpoint, new_endpoint, use_new_scheme=TRUE){
+  new_endpoint_components <- httr::parse_url(new_endpoint)
+  original_endpoint_components <- httr::parse_url(original_endpoint)
+  scheme <- original_endpoint_components$scheme
+  if (use_new_scheme) {
+    scheme <- new_endpoint_components$scheme
+  }
+  final_endpoint_components <- structure(list(
+      scheme = scheme,
+      hostname = new_endpoint_components$hostname %||% "",
+      path = original_endpoint_components$path %||% "",
+      query = original_endpoint_components$query %||% "",
+      fragment = "",
+      raw_path = "",
+      raw_query = ""), class = "url"
+  )
+  final_endpoint <- build_url(final_endpoint_components)
+  return(final_endpoint)
 }
 
 ################################################################################
@@ -219,6 +397,7 @@ customizations$s3 <- function(handlers) {
                                        convert_file_to_raw)
   handlers$build <- handlers_add_back(handlers$build,
                                       content_md5)
+  handlers$send <- handlers_add_back(handlers$send, s3_redirect_from_error)
   handlers$unmarshal <- handlers_add_front(handlers$unmarshal,
                                            s3_unmarshal_select_object_content)
   handlers$unmarshal <- handlers_add_back(handlers$unmarshal,

--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -269,7 +269,11 @@ s3_redirect_from_error <- function(request){
     return(request)
   }
   error_code <- request$http_response$status_code
-  if(error_code == 200){
+
+  # Exit s3_redirect_from_error function if initial request is successful
+  # https://docs.aws.amazon.com/waf/latest/developerguide/customizing-the-response-status-codes.html
+  http_success_code <- c(200, 201, 202, 204, 206)
+  if(error_code %in% http_success_code){
     return(request)
   }
   error <- decode_xml(request$http_response$body)$Error

--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -42,15 +42,15 @@ parse_url <- function(url) {
 # Build a URL from a Url object.
 # <scheme>://<net_loc>/<path>;<params>?<query>#<fragment>
 build_url <- function(url) {
-  if (url$scheme != "" && url$host != "") {
+  if (nzchar(url$scheme) && nzchar(url$host)) {
     l <- paste0(url$scheme, "://", url$host)
   } else {
     return("")
   }
-  if (url$raw_path != "") l <- paste0(l, url$raw_path)
-  else if (url$path != "") l <- paste0(l, url$path)
-  if (url$raw_query != "") l <- paste(l, url$raw_query, sep = "?")
-  if (url$fragment != "") l <- paste0(l, "#", url$fragment)
+  prefix <- function(prefix, x) {if (nzchar(x)) paste0(prefix, x)}
+  l <- paste0(l, if (nzchar(url$raw_path)) url$raw_path else url$path,
+    prefix("?", url$raw_query), prefix("#", url$fragment)
+  )
   return(l)
 }
 

--- a/paws.common/R/util.R
+++ b/paws.common/R/util.R
@@ -107,3 +107,6 @@ call_with_args <- function(f, data) {
   }
   return(do.call(f, as.list(data)[args]))
 }
+
+# helper function to make it easy to replace NULLs with default value
+`%||%` <- function(x,y) if(is.null(x)) y else x

--- a/paws.common/tests/testthat/helper.R
+++ b/paws.common/tests/testthat/helper.R
@@ -1,0 +1,60 @@
+# Basic extension of mockery::mock function
+# Allows side_effect functions, for example a simple pass function:
+# pass <- mock2(side_effect = function(...) list(...))
+# f <- function(x, y = NULL, z = NULL) stop("error")
+# g <- function(...) do.call(f, list(...))
+# mockery::stub(g, 'f', pass)
+#
+# g(x = "yo")
+# g(x = "yo", y= "foo")
+# g(x = "yo", y= "foo", z = "var")
+#
+# mock_arg(pass)
+# $x
+# [1] "yo"
+#
+# $y
+# [1] "hi"
+#
+# $z
+# [1] "bye"
+mock2 <- function(..., cycle = FALSE, side_effect = NULL, envir = parent.frame()){
+  return_values <- eval(substitute(alist(...)))
+  return_values_env <- envir
+  call_no <- 0
+  calls <- list()
+  args <- list()
+  mock <- function(...){
+    call_no <<- call_no + 1
+    calls[[call_no]] <<- match.call()
+    args[[call_no]] <<- list(...)
+    if (length(return_values)) {
+      if (call_no > length(return_values) && !cycle)
+        stop("too many calls to mock object and cycle set to FALSE", call.=FALSE)
+      value <- return_values[[
+        (call_no - 1)%%length(return_values) + 1
+      ]]
+      return(eval(value, envir = return_values_env))
+    }
+
+    if(!is.null(side_effect)){
+      return(side_effect(...))
+    }
+  }
+  class(mock) <- "mock"
+  return(mock)
+}
+
+
+# retrieves a list of all arguments used for the last mocked function call
+mock_arg <- function(m){
+  env <- environment(m)
+  if (env$call_no == 0)
+    return(NULL)
+  return(env$args[[env$call_no]])
+}
+
+# counts the number of times the mocked function was called
+mock_call_no <- function(m){
+  environment(m)$call_no
+}

--- a/paws.common/tests/testthat/test_custom_s3.R
+++ b/paws.common/tests/testthat/test_custom_s3.R
@@ -343,12 +343,14 @@ test_that("redirect request from http response error", {
     )
   )
 
-  pass <- function(x) return(x)
+  pass <- mock2(side_effect = function(...) as.list(...))
   mockery::stub(s3_redirect_from_error, "sign", pass)
   mockery::stub(s3_redirect_from_error, "send", pass)
 
   actual <- s3_redirect_from_error(req)
-  expect_equal(actual$context$s3_redirect, TRUE)
+  sign_args <- mockery::mock_args(pass)[[1]]
+  expect_true(sign_args[[1]]$context$s3_redirect)
+  expect_false(sign_args[[1]]$built)
   expect_equal(actual$client_info$endpoint, "https://s3.eu-east-2.amazonaws.com")
   expect_equal(actual$http_request$url$host, "s3.eu-east-2.amazonaws.com")
 })

--- a/paws.common/tests/testthat/test_custom_s3.R
+++ b/paws.common/tests/testthat/test_custom_s3.R
@@ -281,6 +281,19 @@ test_that("ignore redirect when no http response is given", {
   expect_equal(actual, req)
 })
 
+test_that("ignore redirect when http status is successful", {
+  for (status in c(200, 201, 202, 204, 206)) {
+    req <- build_request(bucket = "foo", operation = "ListObjects")
+    req$http_response <- paws.common:::HttpResponse(
+      status_code = status,
+      body = raw(0),
+      header = list()
+    )
+    actual <- s3_redirect_from_error(req)
+    expect_equal(actual, req)
+  }
+})
+
 test_that("ignore redirect if already redirected", {
   req <- build_request(bucket = "foo", operation = "ListObjects")
   req$http_response <- paws.common:::HttpResponse(

--- a/paws.common/tests/testthat/test_custom_s3.R
+++ b/paws.common/tests/testthat/test_custom_s3.R
@@ -331,11 +331,13 @@ test_that("redirect request from http response error", {
   )
 
   pass <- function(x) return(x)
+  mockery::stub(s3_redirect_from_error, "sign", pass)
   mockery::stub(s3_redirect_from_error, "send", pass)
 
   actual <- s3_redirect_from_error(req)
   expect_equal(actual$context$s3_redirect, TRUE)
-  expect_equal(actual$http_request$url$host, "foo.s3.eu-east-2.amazonaws.com")
+  expect_equal(actual$client_info$endpoint, "https://s3.eu-east-2.amazonaws.com")
+  expect_equal(actual$http_request$url$host, "s3.eu-east-2.amazonaws.com")
 })
 
 test_that("redirect error with region", {


### PR DESCRIPTION
This PR supports AWS S3 redirects:

Previously paws would error when a S3 redirect was required:
``` r
options(paws.log_level = 3L)
s3 <- paws::s3(config = list(region = "eu-west-1"))
out <- s3$list_objects_v2(
  Bucket = "voltrondata-labs-datasets",
  Prefix = "nyc-taxi/year=2019/"
)
#> INFO [2022-11-21 17:52:01.878]: -> GET /?list-type=2&prefix=nyc-taxi%2Fyear%3D2019%2F HTTP/1.1
#> -> Host: voltrondata-labs-datasets.s3.eu-west-1.amazonaws.com
#> -> Accept-Encoding: deflate, gzip
#> -> Accept: application/json, text/xml, application/xml, */*
#> -> User-Agent: paws/0.5.1.9000 (R4.2.1; darwin20; aarch64)
#> -> Content-Length: 0
#> -> X-Amz-Date: 20221121T175201Z
#> -> X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
#> -> Authorization: AWS4-HMAC-SHA256 Credential=dummy/20221121/eu-west-1/s3/aws4_request, SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date, Signature=1ca8f3f9b72c069e00d5f5ea0f124c7e3e38ba543192132b9f8bdb1591526b4d
#> -> 
#> INFO [2022-11-21 17:52:01.910]: <- HTTP/1.1 301 Moved Permanently
#> INFO [2022-11-21 17:52:01.910]: <- x-amz-bucket-region: us-east-2
#> INFO [2022-11-21 17:52:01.910]: <- x-amz-request-id: 2KBPJJJBEY46JE0B
#> INFO [2022-11-21 17:52:01.910]: <- x-amz-id-2: 22Qv0pTpE9NcisolICpGyCOWkptRzwHMjHz5xtuSU63w8mj0DJdvx3KK3tFqyfBfR8FXaNAGB+A=
#> INFO [2022-11-21 17:52:01.910]: <- Content-Type: application/xml
#> INFO [2022-11-21 17:52:01.910]: <- Transfer-Encoding: chunked
#> INFO [2022-11-21 17:52:01.911]: <- Date: Mon, 21 Nov 2022 17:52:01 GMT
#> INFO [2022-11-21 17:52:01.911]: <- Server: AmazonS3
#> INFO [2022-11-21 17:52:01.911]: <- 
#> Error: PermanentRedirect (HTTP 301). The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.
```

<sup>Created on 2022-11-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Now paws will update http request similar to how botocore redirects (https://github.com/boto/botocore/blob/de07ce2c10bbd03b7ff75e283229a355baeeca63/botocore/utils.py#L1532-L1638)

``` r
options(paws.log_level = 3L)
s3 <- paws::s3(config = list(region = "eu-west-1"))
out <- s3$list_objects_v2(
  Bucket = "voltrondata-labs-datasets",
  Prefix = "nyc-taxi/year=2019/"
)
#> INFO [2022-11-21 17:52:31.565]: -> GET /?list-type=2&prefix=nyc-taxi%2Fyear%3D2019%2F HTTP/1.1
#> -> Host: voltrondata-labs-datasets.s3.eu-west-1.amazonaws.com
#> -> Accept-Encoding: deflate, gzip
#> -> Accept: application/json, text/xml, application/xml, */*
#> -> User-Agent: paws/0.5.1.9000 (R4.2.1; darwin20; aarch64)
#> -> Content-Length: 0
#> -> X-Amz-Date: 20221121T175231Z
#> -> X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
#> -> Authorization: AWS4-HMAC-SHA256 Credential=dummy/20221121/eu-west-1/s3/aws4_request, SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date, Signature=3b37f2b427a9bde5b3eb47c630c41feef03e528e99d2d2840a8f7aaa5ddd5051
#> -> 
#> INFO [2022-11-21 17:52:31.602]: <- HTTP/1.1 301 Moved Permanently
#> INFO [2022-11-21 17:52:31.602]: <- x-amz-bucket-region: us-east-2
#> INFO [2022-11-21 17:52:31.602]: <- x-amz-request-id: GMYN89SMTJ7SNJCN
#> INFO [2022-11-21 17:52:31.602]: <- x-amz-id-2: pxCP+uXZ5KjEKkJ+1eVZY9or9sMWS0KduOH8uG1DDuUOEgPSs4KGJ2WgZ4XfenRPPSwXNBAXfgI=
#> INFO [2022-11-21 17:52:31.602]: <- Content-Type: application/xml
#> INFO [2022-11-21 17:52:31.602]: <- Transfer-Encoding: chunked
#> INFO [2022-11-21 17:52:31.602]: <- Date: Mon, 21 Nov 2022 17:52:31 GMT
#> INFO [2022-11-21 17:52:31.602]: <- Server: AmazonS3
#> INFO [2022-11-21 17:52:31.602]: <- 
#> INFO [2022-11-21 17:52:32.028]: -> GET /?list-type=2&prefix=nyc-taxi%2Fyear%3D2019%2F HTTP/1.1
#> -> Host: voltrondata-labs-datasets.s3.us-east-2.amazonaws.com
#> -> Accept-Encoding: deflate, gzip
#> -> Accept: application/json, text/xml, application/xml, */*
#> -> User-Agent: paws/0.5.1.9000 (R4.2.1; darwin20; aarch64)
#> -> Content-Length: 0
#> -> X-Amz-Date: 20221121T175231Z
#> -> X-Amz-Content-Sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
#> -> Authorization: AWS4-HMAC-SHA256 Credential=dummy/20221121/us-east-2/s3/aws4_request, SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date, Signature=87d7227d9cfba69f387752633b87e914a188ba7dc3947815ac73caa842bd367e
#> -> 
#> INFO [2022-11-21 17:52:32.182]: <- HTTP/1.1 200 OK
#> INFO [2022-11-21 17:52:32.182]: <- x-amz-id-2: C9dObnR/abPDJNOKe2sYiH+Q6G87wChGqdIUR6R6UhdZHQCU9FixtRPe9pdZ9qzlYkgjF45gNEM=
#> INFO [2022-11-21 17:52:32.182]: <- x-amz-request-id: SER7Y6MJ2EDPW73D
#> INFO [2022-11-21 17:52:32.182]: <- Date: Mon, 21 Nov 2022 17:52:33 GMT
#> INFO [2022-11-21 17:52:32.182]: <- x-amz-bucket-region: us-east-2
#> INFO [2022-11-21 17:52:32.182]: <- Content-Type: application/xml
#> INFO [2022-11-21 17:52:32.182]: <- Transfer-Encoding: chunked
#> INFO [2022-11-21 17:52:32.182]: <- Server: AmazonS3
#> INFO [2022-11-21 17:52:32.182]: <- 
```

<sup>Created on 2022-11-21 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
