### PR TITLE
Bug/xml builder

### DIFF
--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: paws.common
 Type: Package
 Title: Paws Low-Level Amazon Web Services API
-Version: 0.5.2.9000
+Version: 0.5.3
 Authors@R: c(
         person("David", "Kretch", email = "david.kretch@gmail.com", role = "aut"),
         person("Adam", "Banker", email = "adam.banker39@gmail.com", role = "aut"),

--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: paws.common
 Type: Package
 Title: Paws Low-Level Amazon Web Services API
-Version: 0.5.2
+Version: 0.5.2.9000
 Authors@R: c(
         person("David", "Kretch", email = "david.kretch@gmail.com", role = "aut"),
         person("Adam", "Banker", email = "adam.banker39@gmail.com", role = "aut"),

--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -1,3 +1,7 @@
+# paws.common 0.5.3
+
+* Fixed bugs introduced in`xml_build` in previous version (#569).
+
 # paws.common 0.5.2
 
 * Fix Content-Md5 being modified by user

--- a/paws.common/R/jsonutil.R
+++ b/paws.common/R/jsonutil.R
@@ -87,8 +87,7 @@ json_build_structure <- function(values) {
 
     buf <- sprintf('"%s":%s', name, json_build_any(field))
 
-    v <- c(v, buf)
-
+    v[[length(v) + 1]] <- buf
   }
 
   v <- sprintf("{%s}", paste(v, collapse = ","))
@@ -105,7 +104,7 @@ json_build_map <- function(values) {
   for (key in sort(names(values))) {
     value <- values[[key]]
     buf <- sprintf('"%s":%s', key, json_build_any(value))
-    v <- c(v, buf)
+    v[[length(v) + 1]] <- buf
   }
   v <- sprintf("{%s}", paste(v, collapse = ","))
   return(v)

--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -91,7 +91,8 @@ parse_query_string <- function(query) {
     pair <- strsplit(el, "=")[[1]]
     key <- pair[1]
     value <- if(length(pair)>1){pair[2]}else{""}
-    result[[key]] <- c(result[[key]], query_unescape(value))
+    res_len <- length(result[[key]])
+    result[[key]][res_len + 1] <- query_unescape(value)
   }
   return(result)
 }

--- a/paws.common/R/xmlutil.R
+++ b/paws.common/R/xmlutil.R
@@ -104,14 +104,14 @@ xml_build_structure <- function(params) {
       flattened <- tag_get(child, "flattened") != ""
 
       if (flattened) {
-        result <- c(result, parsed)
+        result[[length(result) + 1]] <- parsed
       } else {
         result[[location_name]] <- parsed
       }
     }
   }
   # Check cache list for default elements
-  if (all(sapply(parsed_result, is_empty_logical))) return(NULL)
+  if (all(sapply(parsed_result, is_empty_xml))) return(NULL)
   return(result)
 }
 

--- a/paws.common/cran-comments.md
+++ b/paws.common/cran-comments.md
@@ -6,7 +6,9 @@
 
 ## R CMD check results
 
-There were no ERRORs or WARNINGs.
+There were one NOTE, no ERRORs or WARNINGs.
+
+NOTE: Days since last update: 5
 
 We apologize for submitting another update within 30 days. We would like to
 fix a serious bug introduced in the last version.

--- a/paws.common/cran-comments.md
+++ b/paws.common/cran-comments.md
@@ -6,7 +6,7 @@
 
 ## R CMD check results
 
-There were one NOTE, no ERRORs or WARNINGs.
+There was one NOTE, no ERRORs or WARNINGs.
 
 NOTE: Days since last update: 5
 

--- a/paws.common/cran-comments.md
+++ b/paws.common/cran-comments.md
@@ -8,6 +8,9 @@
 
 There were no ERRORs or WARNINGs.
 
+We apologize for submitting another update within 30 days. We would like to
+fix a serious bug introduced in the last version.
+
 ## Downstream dependencies
 
 Ran R CMD check on all downstream dependencies. All pass.

--- a/paws.common/tests/testthat/test_xmlutil.R
+++ b/paws.common/tests/testthat/test_xmlutil.R
@@ -35,7 +35,7 @@ test_that("check xml build", {
 })
 
 test_that("check nested xml build", {
-  params_nested <-   structure(list(
+  params_nested <- structure(list(
       nested = structure(list(
         foo = structure(logical(0), tags = list(type = "string")),
         bar = structure(list())
@@ -47,4 +47,21 @@ test_that("check nested xml build", {
   )
   actual <- xml_build(params_nested)
   expect_equal(actual, list(nested = list(bar = list())))
+})
+
+test_that("check nested xml build with nested default parameters", {
+  params_nested <- structure(list(
+      nested = structure(list(
+          foo = structure(list(
+            bar = structure(logical(0))
+          ), tags = list(type = "string")),
+          cho = ""
+        ),
+        tags = list(type = "structure")
+      )
+    ),
+    tags = list(type = "structure")
+  )
+  actual <- xml_build(params_nested)
+  expect_equal(actual, list(nested = list(cho = list(""))))
 })


### PR DESCRIPTION
This is to address bug https://github.com/paws-r/paws/issues/569 introduce in paws.common: 0.5.1

This also addresses list appending. The goal of this to try and reduce amount of memory used and increase performance.

``` r
# copy self and append new element
method1 <- function(x=""){
  data <- numeric()
  for (i in 1:x) {
    data <- c(data, i)
  }
  return(data)
}

# append into last element +1
method2 <- function(x){
  data <- numeric()
  for (i in 1:x) {
    data[[length(data) + 1]] <- i
  }
  return(data)
}

# append on index
method3 <- function(x){
  data <- numeric()
  for (i in 1:x) {
    data[[i]] <- i
  }
  return(data)
}

# pre size list and then append on index
method4 <- function(x){
  data <- numeric(length = x)
  for (i in 1:x) {
    data[[i]] <- i
  }
  return(data)
}

x <- 1e3
bm <- bench::mark(
  method1(x),
  method2(x),
  method3(x),
  method4(x)
)

ggplot2::autoplot(bm)
#> Loading required namespace: tidyr
```

![](https://i.imgur.com/55MDrzC.png)<!-- -->

``` r

bm
#> # A tibble: 4 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 method1(x)  658.3µs  966.6µs     1050.    7.91MB    83.4 
#> 2 method2(x)  137.9µs  162.7µs     5952.  402.89KB    61.5 
#> 3 method3(x)   96.6µs  117.2µs     8172.  186.07KB    62.4 
#> 4 method4(x)   21.6µs   23.4µs    42194.   29.91KB     4.22
```

<sup>Created on 2022-12-05 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Ideally we would like to use method 3 and 4. However for initial implementation will use method 2 as it reduces memory allocation and runs fast enough.
