### PR TITLE
Fix links to subcategory packages

### DIFF
--- a/make.paws/R/cran_sub_category.R
+++ b/make.paws/R/cran_sub_category.R
@@ -20,7 +20,13 @@
      }, FUN.VALUE = logical(1)
    )
    categories <- categories[active]
-   write_source_collection(sdk_dir, package_dir, categories, service_names)
+   write_source_collection(
+     sdk_dir,
+     package_dir,
+     categories,
+     service_names,
+     expand_doc_links = TRUE
+   )
    write_documentation(package_dir)
    write_imports_collection(package_dir, version, get_category_packages(categories))
  }

--- a/make.paws/tests/testthat/test_cran_collection.R
+++ b/make.paws/tests/testthat/test_cran_collection.R
@@ -1,0 +1,5 @@
+test_that("add_package_name_to_links", {
+  input <- "aaa \n link[=target1]{foo1} \n link[=target2]{foo2} \n b"
+  expected <- "aaa \n link[package:target1]{foo1} \n link[package:target2]{foo2} \n b"
+  expect_equal(add_package_name_to_links(input, "package"), expected)
+})


### PR DESCRIPTION
Links to functions in subcategory packages trigger warnings in CRAN check. This fixes the warnings by adding the package names the functions come from.