### PR TITLE
Fix code gen bugs

### DIFF
--- a/make.paws/R/cran_category.R
+++ b/make.paws/R/cran_category.R
@@ -49,14 +49,18 @@ get_categories <- function() {
 
 # Return a vector of existing packages, excluding those that are not
 # generated because they currently have no supported APIs.
-get_category_packages <- function(categories) {
+get_category_packages <- function(categories, get_parents = FALSE) {
   packages <- c()
   for (category in categories) {
     if (length(category$services) > 0) {
-      packages <- c(packages, get_category_package_name(category))
+      if (get_parents && !is.null(category$parent))
+        package <- get_package_name(category$parent)
+      else
+        package <- get_package_name(category$name)
+      packages <- c(packages, package)
     }
   }
-  packages
+  unique(packages)
 }
 
 # Copy all files for the API given in name.

--- a/make.paws/R/cran_collection.R
+++ b/make.paws/R/cran_collection.R
@@ -84,6 +84,7 @@ get_client_docs <- function(path, service) {
   client_line <- grep(sprintf("^%s", service), lines)
   blank_line <- which.max(lines[1:client_line] == "")
   docs <- lines[(blank_line+1):(client_line-1)]
+  docs <- delete_internal_links(docs) # Avoid broken link CRAN check warnings.
   paste(docs, collapse = "\n")
 }
 
@@ -115,6 +116,16 @@ service_exists <- function(path, service) {
 add_package_name_to_links <- function(docs, package) {
   regex <- "link\\[\\=([^\\[]*)\\]"
   replacement <- sprintf("link[%s:\\1]", package)
+  docs <- gsub(regex, replacement, docs)
+  return(docs)
+}
+
+# Delete internal links, e.g.
+# [`create_members`][securityhub_create_members] -->
+# `create_members`
+delete_internal_links <- function(docs) {
+  regex <- "\\[(`[a-z_]+`)\\]\\[[a-z_]+\\]"
+  replacement <- "\\1"
   docs <- gsub(regex, replacement, docs)
   return(docs)
 }

--- a/make.paws/R/cran_sub_category.R
+++ b/make.paws/R/cran_sub_category.R
@@ -1,72 +1,48 @@
 # Make the categories from collection of sub-categories
- make_category_collection <- function(sdk_dir, out_dir, categories, package, service_names) {
-   version <- get_version(sdk_dir)
-   package <- sprintf("paws.%s", package)
-   package_dir <- file.path(out_dir, package)
-   write_skeleton_category(package_dir)
-   write_description_category(
-     package_dir,
-     package,
-     title = unique(unlist(sapply(categories, function(cat) cat$title))),
-     description = paste0(
-       lapply(categories, function(cat) cat$category_description), collapse = ""
-     ),
-     version = version,
-     imports = c()
-   )
-   # Create packages that contain services
-   active <- vapply(categories, function(cat) {
-     !is.null(cat$services)
-     }, FUN.VALUE = logical(1)
-   )
-   categories <- categories[active]
-   write_source_collection(
-     sdk_dir,
-     package_dir,
-     categories,
-     service_names,
-     expand_doc_links = TRUE
-   )
-   write_documentation(package_dir)
-   write_imports_collection(package_dir, version, get_category_packages(categories))
- }
+make_category_collection <- function(sdk_dir, out_dir, categories, package, service_names) {
+  version <- get_version(sdk_dir)
+  package <- sprintf("paws.%s", package)
+  package_dir <- file.path(out_dir, package)
+  write_skeleton_category(package_dir)
+  write_description_category(
+    package_dir,
+    package,
+    title = unique(unlist(sapply(categories, function(cat) cat$title))),
+    description = paste0(
+      lapply(categories, function(cat) cat$category_description), collapse = ""
+    ),
+    version = version,
+    imports = c()
+  )
+  # Create packages that contain services
+  active <- vapply(categories, function(cat) {
+    !is.null(cat$services)
+  }, FUN.VALUE = logical(1)
+  )
+  categories <- categories[active]
+  write_source_collection(
+    sdk_dir,
+    package_dir,
+    categories,
+    service_names,
+    expand_doc_links = TRUE
+  )
+  write_documentation(package_dir)
+  write_imports_collection(package_dir, version, get_category_packages(categories))
+}
 
- # Identify sub-categories
- find_sub_categories <- function(categories){
-   return(vapply(categories, function(cat) {
-       !is.null(cat$category_description)
-     }, logical(1))
-   )
- }
+# Identify sub-categories
+find_sub_categories <- function(categories){
+  return(vapply(categories, function(cat) {
+    !is.null(cat$category_description)
+  }, logical(1))
+  )
+}
 
- # Group sub-categories
- group_categories <- function(categories){
-   grp <- sapply(categories, function(cat) {
-     gsub(".p[0-9]+$", "", cat$name)
-   })
-   return(split(categories, grp))
- }
-
- make_category_from_sub_category <- function(categories){
-   found <- find_sub_categories(categories)
-   sub_categories <- categories[found]
-   grp_sub_cats <- group_categories(sub_categories)
-   cats <- names(grp_sub_cats)
-   # Build each categories metadata from sub-categories
-   cat_meta <- setNames(vector(mode = "list", length = length(cats)), cats)
-   for (cat in cats){
-     cat_meta[[cat]]$name <- cat
-     cat_meta[[cat]]$services <- unlist(sapply(
-       grp_sub_cats[[cat]], function(sub_cat) sub_cat$services
-     ))
-     cat_meta[[cat]]$title <- unique(unlist(sapply(
-       grp_sub_cats[[cat]], function(sub_cat) sub_cat$title
-     )))
-     cat_meta[[cat]]$description <- paste0(
-       lapply(grp_sub_cats[[cat]], function(sub_cat) {
-         sub_cat$category_description
-       }), collapse = ""
-     )
-   }
-   return(c(categories[!found], unname(cat_meta)))
- }
+# Group sub-categories
+group_categories <- function(categories){
+  grp <- sapply(categories, function(cat) {
+    gsub(".p[0-9]+$", "", cat$name)
+  })
+  return(split(categories, grp))
+}

--- a/make.paws/R/custom/s3.R
+++ b/make.paws/R/custom/s3.R
@@ -137,7 +137,7 @@ s3_download_file <- function(Bucket, Key, Filename, IfMatch = NULL, IfModifiedSi
 #' @title Generate a presigned url given a client, its method, and arguments
 #'
 #' @usage
-#' s3_generate_signed_url(client_method, params=list(), expires_in=3600,
+#' s3_generate_presigned_url(client_method, params=list(), expires_in=3600,
 #' http_method = NULL)
 #'
 #' @param client_method (character): The client method to presign for

--- a/make.paws/R/make_sdk.R
+++ b/make.paws/R/make_sdk.R
@@ -73,9 +73,6 @@ make_sdk <- function(
     for(cat in names(grp_sub_cats)){
       make_category_collection(temp_dir, out_sdk_dir, grp_sub_cats[[cat]], cat, api_names)
     }
-
-    # rebuild categories from sub-categories for paws
-    categories <- make_category_from_sub_category(categories)
   }
 
   make_collection(temp_dir, out_sdk_dir, categories, api_names)

--- a/make.paws/R/process_api.R
+++ b/make.paws/R/process_api.R
@@ -72,7 +72,8 @@ make_custom_operations_files <- function(api) {
   from <- system_file(sprintf("src/custom/%s.R", package), package = methods::getPackageName())
   filename <- paste0(package, "_custom.R")
   if (from != "" && file.exists(from)) {
-    result[[file.path(CODE_DIR, filename)]] <- readLines(from)
+    contents <- readLines(from)
+    result[[file.path(CODE_DIR, filename)]] <- paste(contents, collapse = "\n")
   }
   return(result)
 }

--- a/make.paws/R/utils.R
+++ b/make.paws/R/utils.R
@@ -21,7 +21,7 @@ parse_operations <- function(text) {
   operations <- list()
   for (op_text in split(text, ids)) {
     operation <- parse_operation(op_text)
-    if (is.null(operation$name) || operation$name == "NULL") {
+    if (is.null(operation)) {
       next
     }
     operations[[operation$name]] <- operation
@@ -35,6 +35,7 @@ parse_operation <- function(text) {
   comment_lines <- startsWith(text, "#'")
   comment <- text[comment_lines]
   code <- text[!comment_lines]
+  if (length(code) == 0 || all(code == "") || code[1] == "NULL") return(NULL)
   func <- strsplit(code[1], " ")[[1]][1]
   name <- substring(func, regexpr("_", func)+1)
   operation <- list(

--- a/make.paws/inst/extdata/packages.yml
+++ b/make.paws/inst/extdata/packages.yml
@@ -189,49 +189,62 @@
     'groundstation' API for control satellite communications, downlink and
     process satellite data applications <https://aws.amazon.com/>.
 
-- name: management
+- name: management.p1
   services:
+    - amp
     - application-autoscaling
-    - applicationcostprofiler
     - application-insights
-    - servicecatalog-appregistry
+    - applicationcostprofiler
     - auditmanager
     - autoscaling
     - autoscaling-plans
     - cloudformation
     - cloudtrail
-    - monitoring
+    - config
     - events
     - evidently
-    - logs
-    - rum
-    - config
     - finspace
+    - grafana
     - health
     - license-manager
     - license-manager-user-subscriptions
-    - grafana
+    - logs
+  title: "'Amazon Web Services' Management & Governance Services"
+  description: >-
+    This is the backend package for 'paws.management'. Please use 
+    'paws.management' to access 'Amazon Web Services' management services.
+  category_description: >-
+    Interface to 'Amazon Web Services' management and governance services,
+    including 'CloudWatch' application and infrastructure monitoring, 'Auto
+    Scaling' for automatically scaling resources, and more
+    <https://aws.amazon.com/>.
+  parent: management
+
+- name: management.p2
+  services:
+    - monitoring
     - opsworks
     - opsworkscm
     - organizations
     - pi
-    - amp
     - resiliencehub
     - resource-groups
     - resourcegroupstaggingapi
-    - servicecatalog
+    - rum
     - service-quotas
+    - servicecatalog
+    - servicecatalog-appregistry
     - ssm
     - ssm-contacts
     - ssm-incidents
     - support
     - synthetics
   title: "'Amazon Web Services' Management & Governance Services"
-  description:  >-
-    Interface to 'Amazon Web Services' management and governance services,
-    including 'CloudWatch' application and infrastructure monitoring, 'Auto
-    Scaling' for automatically scaling resources, and more
-    <https://aws.amazon.com/>.
+  description: >-
+    This is the backend package for 'paws.management'. Please use 
+    'paws.management' to access 'Amazon Web Services' management services.
+  category_description: ""
+  parent: management
 
 - name: media.services
   services:


### PR DESCRIPTION
* Actually update the cran/paws/R/paws.R documentation links, rather than only the links in the subcategory packages, which I had erroneously assumed would be copied over.
* Delete internal links in a service's documentation, e.g. a link in the SecurityHub documentation to a function within SecurityHub. These get broken with the new sub-category packages and cause CRAN check warnings.
* Fix the code that handles the custom code includes, e.g. s3_custom.R. 
    * The parser would fail and cause code generation to crash. 
    * Also, fix the extra line breaks previously added on every other line of the custom code file when it's copied.
* Split paws.management into two sub-categories to avoid size CRAN check notes (>5MB).
* Fix the indentation in cran_subcategory.R.

## Test plan:
1. Regenerate packages with `make build`.
2. Install new packages.
3. Run CRAN check on all generated packages.