### PR TITLE
bug fix: correct operation name

### DIFF
--- a/make.paws/DESCRIPTION
+++ b/make.paws/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: make.paws
 Type: Package
 Title: Generate Paws AWS SDKs for R
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: c(
     person("David", "Kretch", email = "david.kretch@gmail.com", role = "aut"),
     person("Adam", "Banker", email = "adam.banker39@gmail.com", role = "aut"),

--- a/make.paws/inst/extdata/operation_name_override.yml
+++ b/make.paws/inst/extdata/operation_name_override.yml
@@ -1,3 +1,7 @@
 ---
 - name: UploadPartCopy
   override: CopyPart
+- name: ListParts
+  override: ListPartsRequest
+- name: ListMultipartUploads
+  override: ListMultipartUploadsRequest


### PR DESCRIPTION
Following methods returned unpopulated lists: 
    - list_multipart_uploads
    - list_parts
Addresses Issue: https://github.com/paws-r/paws/issues/608