### PR TITLE
overwrite file when writing to disk

### DIFF
--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -2,6 +2,7 @@
 * add expiration parameter to creds
 * add signature_version to config
 * add the ability to paginate paws methods (#30)
+* overwrite file destination when writing to disk. This mimics python's boto3 sdk behaviour.
 
 # paws.common 0.5.8
 * fix mismatch apparent method as.list.struct (#634)

--- a/paws.common/R/net.R
+++ b/paws.common/R/net.R
@@ -122,7 +122,7 @@ issue <- function(http_request) {
   # utilize httr to write to disk
   dest <- NULL
   if (!is.null(http_request$dest)) {
-    dest <- httr::write_disk(http_request$dest)
+    dest <- httr::write_disk(http_request$dest, TRUE)
   }
   r <- with_paws_verbose(
     httr::VERB(


### PR DESCRIPTION
minor change:

Allow to overwrite file when downloading to disk. This mimics boto3 behaviour.