### PR TITLE
supported nested content within ini file (#667)

### DIFF
--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -1,3 +1,6 @@
+# paws.common 0.6.0.9000
+* support nested content within ini files (#667) [Configuration and credential file settings](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-s3)
+
 # paws.common 0.6.0
 * use known interface when parsing xml (@619) improving performance by 3-6x. Thanks to @mgirlich for raising, implementing initial method and testing.
 * add expiration parameter to creds

--- a/paws.common/R/iniutil.R
+++ b/paws.common/R/iniutil.R
@@ -9,7 +9,6 @@ extract_ini_parameter <- function(item) {
 }
 
 # Read in values from an ini file
-# Read in values from an ini file
 read_ini <- function(file_name) {
   if (!file.exists(file_name)) {
     stopf("Unable to find file: %s", file_name)

--- a/paws.common/R/iniutil.R
+++ b/paws.common/R/iniutil.R
@@ -1,43 +1,76 @@
 #' @include util.R
 
-# Get the profile name from an ini file
-extract_ini_profile <- function(item) {
-  profile <- gsub("\\[|\\]", "", item)
-  return(profile)
-}
-
 # Get a parameter and its value
 extract_ini_parameter <- function(item) {
-  split_index <- regexpr("=", item)
-  parameter <- list()
-  key <- trimws(substring(item, 1, split_index - 1))
-  value <- trimws(substring(item, split_index + 1))
-  parameter[[key]] <- value
+  item <- trimws(item)
+  parameter <- list(item[2])
+  names(parameter) <- item[1]
   return(parameter)
 }
 
+# Read in values from an ini file
 # Read in values from an ini file
 read_ini <- function(file_name) {
   if (!file.exists(file_name)) {
     stopf("Unable to find file: %s", file_name)
   }
   content <- scan(file_name, what = "", sep = "\n", quiet = T)
-  profiles <- list()
-  current_profile <- ""
+
   # An empty credentials file is valid when using SSO
   # In that case, length(content) is 0.  Don't loop
   # in such a case, since 'grepl(..., content[i])'
   # will return logical(0), causing the 'if' to error out
-  for (i in seq_len(length(content))) {
-    if (grepl("(^;)|(^#)", content[i])) {
-      next
-    } else if (grepl("^\\[.*\\]", content[i])) {
-      current_profile <- extract_ini_profile(content[i])
-      profiles[[current_profile]] <- c()
-      next
+  if (length(content) == 0) return(list())
+
+  # Get the profile name from an ini file
+  found <- grep("^\\[.*\\]", content)
+  rm_els <- grep("(^;)|(^#)", content)
+
+  profile_nms <- gsub("\\[|\\]", "", content[found])
+  profiles <- vector("list", length = length(profile_nms))
+  names(profiles) <- profile_nms
+
+  start <- (found + 1)
+  end <- c(found[-1]-1,  length(content))
+  split_content <- strsplit(sub("=", "\n", content, fixed = T), "\n", fixed = T)
+  for (i in seq_along(profiles)) {
+    els <- seq.int(start[i], end[i])
+    sub_content <- split_content[els[!(els %in% rm_els)]]
+    found_nested_content <- lengths(sub_content) == 1
+
+    if (any(found_nested_content)) {
+      profiles[[i]] <- nested_ini_content(sub_content, found_nested_content)
+    } else {
+      profiles[[i]] <- unlist(lapply(
+        sub_content, extract_ini_parameter
+      ), recursive = F
+      )
     }
-    parameter <- extract_ini_parameter(content[i])
-    profiles[[current_profile]] <- c(profiles[[current_profile]], parameter)
+  }
+  return(profiles)
+}
+
+nested_ini_content <- function(sub_content, found_nested_content) {
+  position <- which(found_nested_content)
+  start <- (position + 1)
+  end <- c(position[-1]-1,  length(sub_content))
+
+  profile_nms <- trimws(unlist(sub_content[position]))
+
+  sub_grp <- which(!vapply(sub_content, function(x) grepl("^[ ]+", x[1]), logical(1)))
+  non_nest <- sub_grp[!sub_grp%in% position]
+
+  profiles <- unlist(lapply(
+    sub_content[non_nest], extract_ini_parameter
+  ), recursive = F
+  )
+  for (i in seq_along(position)) {
+    els <- seq.int(start[i], end[i])
+    nest_content <- sub_content[els[!(els %in% sub_grp)]]
+    profiles[[profile_nms[i]]] <- unlist(lapply(
+      nest_content, extract_ini_parameter
+    ), recursive = F
+    )
   }
   return(profiles)
 }

--- a/paws.common/tests/testthat/data_ini
+++ b/paws.common/tests/testthat/data_ini
@@ -26,6 +26,9 @@ arg2=value2
 arg1 = value1
 arg2 = value2
 
+[profile sts]
+sts_regional_endpoint = legacy
+
 [nested]
 nested1 =
   arg1 = value1

--- a/paws.common/tests/testthat/data_ini
+++ b/paws.common/tests/testthat/data_ini
@@ -26,6 +26,10 @@ arg2=value2
 arg1 = value1
 arg2 = value2
 
-
-[profile sts]
-sts_regional_endpoint = legacy
+[nested]
+nested1 =
+  arg1 = value1
+  arg2 = value2
+arg3 = value3
+nested2 =
+  arg4 = value4

--- a/paws.common/tests/testthat/test_iniutil.R
+++ b/paws.common/tests/testthat/test_iniutil.R
@@ -38,3 +38,11 @@ test_that("Reads in values with spaces around the equal sign", {
   expect_equal(content[[profile]][["arg1"]], "value1")
   expect_equal(content[[profile]][["arg2"]], "value2")
 })
+
+test_that("Reads in values with nested content", {
+  content <- read_ini("data_ini")
+  profile <- "nested"
+  expect_equal(content[[profile]][["nested1"]], list(arg1 = "value1", arg2 = "value2"))
+  expect_equal(content[[profile]][["nested2"]], list(arg4 = "value4"))
+  expect_equal(content[[profile]][["arg3"]], "value3")
+})


### PR DESCRIPTION
This PR addresses the issue of being able to read nested content within an ini files.

For example AWS config file could have the following (this is prep work for #667):

```
[profile development]
s3 =
  max_concurrent_requests = 20
  max_queue_size = 10000
  multipart_threshold = 64MB
```

Previously paws would keep everything a as flattened list.
``` r
# paws.common 0.6.0
paws.common:::read_ini("data_ini")
#> $default
#> $default$arg1
#> [1] "value1"
#> 
#> $default$arg2
#> [1] "value2"
#> 
#> 
#> $foo
#> $foo$arg1
#> [1] "foo_value1"
#> 
#> $foo$arg2
#> [1] "foo_value2"
#> 
#> 
#> $`profile bar`
#> $`profile bar`$arg1
#> [1] "bar_value1"
#> 
#> $`profile bar`$arg2
#> [1] "bar_value2"
#> 
#> 
#> $equalsign
#> $equalsign$arg1
#> [1] "value1=="
#> 
#> $equalsign$arg2
#> [1] "value2"
#> 
#> 
#> $spaces
#> $spaces$arg1
#> [1] "value1"
#> 
#> $spaces$arg2
#> [1] "value2"
#> 
#> 
#> $`profile sts`
#> $`profile sts`$sts_regional_endpoint
#> [1] "legacy"
#> 
#> 
#> $nested
#> $nested$nested1
#> [1] ""
#> 
#> $nested$arg1
#> [1] "value1"
#> 
#> $nested$arg2
#> [1] "value2"
#> 
#> $nested$arg3
#> [1] "value3"
#> 
#> $nested$nested2
#> [1] ""
#> 
#> $nested$arg4
#> [1] "value4"
```

<sup>Created on 2023-09-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Now paws will include nested contents as a nest list.
``` r
# paws.common 0.6.0.9000
paws.common:::read_ini("data_ini")
#> $default
#> $default$arg1
#> [1] "value1"
#> 
#> $default$arg2
#> [1] "value2"
#> 
#> 
#> $foo
#> $foo$arg1
#> [1] "foo_value1"
#> 
#> $foo$arg2
#> [1] "foo_value2"
#> 
#> 
#> $`profile bar`
#> $`profile bar`$arg1
#> [1] "bar_value1"
#> 
#> $`profile bar`$arg2
#> [1] "bar_value2"
#> 
#> 
#> $equalsign
#> $equalsign$arg1
#> [1] "value1=="
#> 
#> $equalsign$arg2
#> [1] "value2"
#> 
#> 
#> $spaces
#> $spaces$arg1
#> [1] "value1"
#> 
#> $spaces$arg2
#> [1] "value2"
#> 
#> 
#> $`profile sts`
#> $`profile sts`$sts_regional_endpoint
#> [1] "legacy"
#> 
#> 
#> $nested
#> $nested$arg3
#> [1] "value3"
#> 
#> $nested$nested1
#> $nested$nested1$arg1
#> [1] "value1"
#> 
#> $nested$nested1$arg2
#> [1] "value2"
#> 
#> 
#> $nested$nested2
#> $nested$nested2$arg4
#> [1] "value4"
```

<sup>Created on 2023-09-14 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

The new method for `read_ini` does have some performance improvement however it is hardly noticeable 😛 (roughly ~0.5ms improvement)