### PR TITLE
remove repeat processes

### DIFF
--- a/paws.common/R/iniutil.R
+++ b/paws.common/R/iniutil.R
@@ -1,17 +1,9 @@
 #' @include util.R
 
 # Get a parameter and its value
-extract_ini_parameter_list <- function(items) {
-  ii <- gsub("^[ \t\r\n]+|[ \t\r\n]+$", "", do.call(rbind, items), perl = T)
-  parameter <- as.list(ii[, 2])
-  names(parameter) <- ii[, 1]
-  return(parameter)
-}
-
-extract_ini_parameter_matrix <- function(items) {
-  ii <- gsub("^[ \t\r\n]+|[ \t\r\n]+$", "", items, perl = T)
-  parameter <- as.list(ii[, 2])
-  names(parameter) <- ii[, 1]
+extract_ini_parameter <- function(items) {
+  parameter <- as.list.default(items[, 2])
+  names(parameter) <- items[, 1]
   return(parameter)
 }
 
@@ -19,12 +11,7 @@ read_ini <- function(file_name) {
   if (!file.exists(file_name)) {
     stopf("Unable to find file: %s", file_name)
   }
-  content <- sub(
-    "[ \t\r\n]+$", "",
-    scan(file_name, what = "", sep = "\n", quiet = T),
-    perl = TRUE
-  )
-
+  content <- scan(file_name, what = "", sep = "\n", quiet = T)
   # Return empty list for empty files
   if (length(content) == 0) {
     return(list())
@@ -35,8 +22,11 @@ read_ini <- function(file_name) {
   if (length(rm_els) > 0) content <- content[-rm_els]
 
   found <- grep("^\\[.*\\]", content, perl = TRUE)
-
-  profile_nms <- gsub("\\[|\\]", "", content[found])
+  profile_nms <- gsub(
+    "^[ \t\r\n]+|[ \t\r\n]+$", "",
+    gsub("\\[|\\]", "", content[found]),
+    perl = T
+  )
   profiles <- vector("list", length = length(profile_nms))
   names(profiles) <- profile_nms
 
@@ -45,41 +35,37 @@ read_ini <- function(file_name) {
   split_content <- strsplit(sub("=", "\n", content, fixed = T), "\n", fixed = T)
   nested_contents <- lengths(split_content) == 1
 
+  split_content <- sub("[ \t\r\n]+$", "", do.call(rbind, split_content), perl = T)
+  sub_grps <- !grepl("^[ ]+", split_content[, 1])
+  split_content <- sub("^[ \t\r]+", "", split_content, perl = T)
   for (i in which(start <= end)) {
     items <- seq.int(start[i], end[i])
     found_nested_content <- nested_contents[items]
     if (any(found_nested_content)) {
-      profiles[[i]] <- nested_ini_content(split_content[items], found_nested_content)
+      profiles[[i]] <- nested_ini_content(
+        split_content[items,,drop = FALSE], found_nested_content, which(sub_grps[items])
+      )
     } else {
-      profiles[[i]] <- extract_ini_parameter_list(split_content[items])
+      profiles[[i]] <- extract_ini_parameter(split_content[items,,drop = FALSE])
     }
   }
   return(profiles)
 }
 
-nested_ini_content <- function(sub_content, found_nested_content) {
-  sub_content <- do.call(rbind, sub_content)
-  sub_grp <- grep("^[ ]+", sub_content[, 1], invert = T)
-  profile_nms <- gsub(
-    "^[ \t\r\n]+|[ \t\r\n]+$", "", sub_content[sub_grp],
-    perl = T
-  )
+nested_ini_content <- function(sub_content, found_nested_content, sub_grp) {
+  profile_nms <- sub_content[sub_grp]
   profiles <- vector("list", length(profile_nms))
   names(profiles) <- profile_nms
 
   position <- which(found_nested_content)
   non_nest <- !(sub_grp %in% position)
-  profiles[non_nest] <- gsub(
-    "^[ \t\r\n]+|[ \t\r\n]+$", "",
-    sub_content[sub_grp[non_nest], 2],
-    perl = T
-  )
+  profiles[non_nest] <- sub_content[sub_grp[non_nest], 2, drop = T]
 
   start <- (sub_grp + 1)
   end <- c(sub_grp[-1] - 1, nrow(sub_content))
   for (i in which(start <= end)) {
     items <- seq.int(start[i], end[i])
-    profiles[[profile_nms[i]]] <- extract_ini_parameter_matrix(sub_content[items,,drop = F])
+    profiles[[profile_nms[i]]] <- extract_ini_parameter(sub_content[items,,drop = F])
   }
   return(profiles)
 }


### PR DESCRIPTION
I believe this is the fastest I can get `read_ini` function without going full c++.

We have some decent performance now with roughly ~500us to read in the test data_ini compared to ~3ms. This should help with any extra calls to the config files we need to make.

![image](https://github.com/paws-r/paws/assets/23235152/0c593a2d-2902-4c0b-905d-1ce139662df8)



