### PR TITLE
Add support for web token based IAM in config files

### DIFF
--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -32,6 +32,7 @@ Suggests:
     covr,
     crayon,
     mockery,
+    withr,
     rstudioapi,
     testthat
 SystemRequirements: pandoc (>= 1.12.3) - http://pandoc.org

--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -2,6 +2,7 @@
 * minor performance improvement for `read_ini`
 * cache `read_ini` for improved performance
 * cache unix os environment variables to improve performance on unix systems.
+* support `web_identity_token_file` in AWS config file thanks to @liuquinlin for implementation.
 
 # paws.common 0.6.2
 * fix how `read_ini` reads empty profiles from ini files

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -393,6 +393,11 @@ get_web_identity_token_file <- function(web_identity_token_file = "") {
   return(web_identity_token_file)
 }
 
+# Get the Web Identity Token from reading the token file
+get_web_identity_token <- function(web_identity_token_file = "") {
+  return(readLines(get_web_identity_token_file(web_identity_token_file), warn = FALSE))
+}
+
 # Check if sts_regional_endpoint is present in config file
 check_config_file_sts_regional_endpoint <- function(profile = "") {
   config_path <- get_config_file_path()

--- a/paws.common/R/credential_providers.R
+++ b/paws.common/R/credential_providers.R
@@ -142,7 +142,9 @@ config_file_provider <- function(profile = "") {
       return(creds)
     }
   }
-  if ("role_arn" %in% names(profile)) {
+  profile_nms <- names(profile)
+
+  if ("role_arn" %in% profile_nms) {
     role_arn <- profile$role_arn
     role_session_name <- profile$role_session_name
     if (is.null(role_session_name)) {
@@ -151,21 +153,24 @@ config_file_provider <- function(profile = "") {
     }
     mfa_serial <- profile$mfa_serial
 
-    if ("credential_source" %in% names(profile)) {
+    if ("credential_source" %in% profile_nms) {
       credential_source <- profile$credential_source
       creds <- config_file_credential_source(role_arn, role_session_name, mfa_serial, credential_source)
       if (!is.null(creds)) {
         return(creds)
       }
     }
-    if ("source_profile" %in% names(profile)) {
+    if ("source_profile" %in% profile_nms) {
       source_profile <- profile$source_profile
       creds <- config_file_source_profile(role_arn, role_session_name, mfa_serial, source_profile)
       if (!is.null(creds)) {
         return(creds)
       }
     }
-    if ("web_identity_token_file" %in% names(profile)) {
+
+    # Get web_identity_token
+    # https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html#cli-configure-role-oidc
+    if ("web_identity_token_file" %in% profile_nms) {
       web_identity_token_file <- profile$web_identity_token_file
       web_identity_token <- get_web_identity_token(web_identity_token_file)
       creds <- get_assume_role_with_web_identity_creds(role_arn, role_session_name, web_identity_token)

--- a/paws.common/R/credential_providers.R
+++ b/paws.common/R/credential_providers.R
@@ -165,6 +165,14 @@ config_file_provider <- function(profile = "") {
         return(creds)
       }
     }
+    if ("web_identity_token_file" %in% names(profile)) {
+      web_identity_token_file <- profile$web_identity_token_file
+      web_identity_token <- get_web_identity_token(web_identity_token_file)
+      creds <- get_assume_role_with_web_identity_creds(role_arn, role_session_name, web_identity_token)
+      if (!is.null(creds)) {
+        return(creds)
+      }
+    }
   }
   log_info("Unable to get credentials from config file.")
   return(NULL)
@@ -440,7 +448,7 @@ get_container_credentials_eks <- function() {
   credentials_list <- get_assume_role_with_web_identity_creds(
     role_arn = get_role_arn(),
     role_session_name = get_role_session_name(),
-    web_identity_token = readLines(get_web_identity_token_file(), warn = FALSE)
+    web_identity_token = get_web_identity_token()
   )
 
   return(credentials_list)

--- a/paws.common/tests/testthat/test_config.R
+++ b/paws.common/tests/testthat/test_config.R
@@ -67,37 +67,51 @@ test_that("set_config", {
 })
 
 test_that("get_profile_name", {
-  Sys.setenv(AWS_PROFILE = "bar")
-  expect_equal(get_profile_name(), "bar")
-  expect_equal(get_profile_name(NULL), "bar")
-  expect_equal(get_profile_name("foo"), "foo")
+  withr::with_envvar(list(AWS_PROFILE="bar"), {
+    expect_equal(get_profile_name(), "bar")
+    expect_equal(get_profile_name(NULL), "bar")
+    expect_equal(get_profile_name("foo"), "foo")
+  })
 })
 
 test_that("get_region", {
-  Sys.setenv(AWS_REGION = "foo")
-  expect_equal(get_region(), "foo")
-  expect_equal(get_region(NULL), "foo")
+  withr::with_envvar(list(AWS_REGION = "foo"), {
+    expect_equal(get_region(), "foo")
+    expect_equal(get_region(NULL), "foo")
+  })
 })
 
 test_that("get_role_arn", {
-  Sys.setenv(AWS_ROLE_ARN = "bar")
-  expect_equal(get_role_arn(), "bar")
-  expect_equal(get_role_arn(NULL), "bar")
-  expect_equal(get_role_arn("foo"), "foo")
+  withr::with_envvar(list(AWS_ROLE_ARN = "bar"), {
+    expect_equal(get_role_arn(), "bar")
+    expect_equal(get_role_arn(NULL), "bar")
+    expect_equal(get_role_arn("foo"), "foo")
+  })
 })
 
 test_that("get_role_session_name", {
-  Sys.setenv(AWS_ROLE_SESSION_NAME = "bar")
-  expect_equal(get_role_session_name(), "bar")
-  expect_equal(get_role_session_name(NULL), "bar")
-  expect_equal(get_role_session_name("foo"), "foo")
+  withr::with_envvar(list(AWS_ROLE_SESSION_NAME = "bar"), {
+    expect_equal(get_role_session_name(), "bar")
+    expect_equal(get_role_session_name(NULL), "bar")
+    expect_equal(get_role_session_name("foo"), "foo")
+  })
 })
 
 test_that("get_web_identity_token_file", {
-  Sys.setenv(AWS_WEB_IDENTITY_TOKEN_FILE = "bar")
-  expect_equal(get_web_identity_token_file(), "bar")
-  expect_equal(get_web_identity_token_file(NULL), "bar")
-  expect_equal(get_web_identity_token_file("foo"), "foo")
+  expect_error(get_web_identity_token_file(), "No WebIdentityToken file available")
+
+  withr::with_envvar(list(AWS_WEB_IDENTITY_TOKEN_FILE = "bar"), {
+    expect_equal(get_web_identity_token_file(), "bar")
+    expect_equal(get_web_identity_token_file(NULL), "bar")
+    expect_equal(get_web_identity_token_file("foo"), "foo")
+  })
+})
+
+test_that("get_web_identity_token", {
+  withr::with_tempfile("tmp", {
+    write("token", tmp)
+    expect_equal(get_web_identity_token(tmp), "token")
+  })
 })
 
 test_that("get_instance_metadata_imdsv1", {
@@ -466,10 +480,10 @@ test_that("check for invalid token, missing expiresAt", {
 })
 
 test_that("check sts regional from environment", {
-  Sys.setenv("AWS_STS_REGIONAL_ENDPOINTS" = "regional")
-  actual <- get_sts_regional_endpoint()
-  expect_equal(actual, "regional")
-  Sys.unsetenv("AWS_STS_REGIONAL_ENDPOINTS")
+  withr::with_envvar(list(AWS_STS_REGIONAL_ENDPOINTS = "regional"), {
+    actual <- get_sts_regional_endpoint()
+    expect_equal(actual, "regional")
+  })
 })
 
 test_that("check sts regional from config file", {

--- a/paws.common/tests/testthat/test_config_ini
+++ b/paws.common/tests/testthat/test_config_ini
@@ -1,0 +1,17 @@
+[default]
+credential_process = echo '{"Version":[1],"AccessKeyId":["defaultId"],"SecretAccessKey":["defaultSecret"]}'
+
+[profile p1]
+role_arn = arn:aws:iam::p1_role
+role_session_name = p1_role_session
+credential_source = Environment
+
+[profile p2]
+role_arn = arn:aws:iam::p2_role
+role_session_name = p2_role_session
+web_identity_token_file = test_config_webtoken
+
+[profile p3]
+role_arn = arn:aws:iam::p3_role
+role_session_name = p3_role_session
+source_profile = p2

--- a/paws.common/tests/testthat/test_config_webtoken
+++ b/paws.common/tests/testthat/test_config_webtoken
@@ -1,0 +1,1 @@
+webtoken_for_p2

--- a/paws.common/tests/testthat/test_credential_providers.R
+++ b/paws.common/tests/testthat/test_credential_providers.R
@@ -55,3 +55,68 @@ test_that("get_creds_from_sts_resp()", {
   expect_equal(test_creds$session_token, test_session_token)
   expect_equal(test_creds$expiration, test_expiration)
 })
+
+test_that("config_file_provider", {
+  # Setup the expected creds for each profile
+  profiles <- c("default", "env", "p1", "p2", "p3")
+  creds <- lapply(profiles, function(profile) {
+    return(Creds(
+      access_key_id = paste0(profile, "Id"),
+      secret_access_key = paste0(profile, "Secret")
+    ))
+  })
+  names(creds) <- profiles
+
+  envvars <- list(
+    "AWS_CONFIG_FILE" = "test_config_ini",
+    "AWS_ACCESS_KEY_ID" = creds$env$access_key_id,
+    "AWS_SECRET_ACCESS_KEY" = creds$env$secret_access_key
+  )
+  withr::with_envvar(envvars, {
+    # Test missing profile
+    expect_null(config_file_provider("invalidProfile"))
+    
+    # Test default profile using credential_process
+    expect_equal(config_file_provider(), creds$default)
+    
+    # Test profile using environment credential_source
+    mock_get_assumed_role_creds <- mock2(creds$p1)
+    local_mocked_bindings(
+      get_assumed_role_creds = mock_get_assumed_role_creds,
+    )
+    expect_equal(config_file_provider("p1"), creds$p1)
+    expect_equal(mock_arg(mock_get_assumed_role_creds)[1:3], list(
+      "arn:aws:iam::p1_role", "p1_role_session", NULL
+    ))
+    expect_equal(mock_arg(mock_get_assumed_role_creds)[[4]]$access_key_id,
+                 creds$env$access_key_id)
+    expect_equal(mock_arg(mock_get_assumed_role_creds)[[4]]$secret_access_key,
+                 creds$env$secret_access_key)
+    
+    # Test profile using web_identity_token
+    mock_web_identity_creds <- mock2(creds$p2)
+    local_mocked_bindings(
+      get_assume_role_with_web_identity_creds = mock_web_identity_creds,
+    )
+    # mockery::stub(config_file_provider, "get_assume_role_with_web_identity_creds", mock_web_identity_creds)
+    expect_equal(config_file_provider("p2"), creds$p2)
+    expect_equal(mock_arg(mock_web_identity_creds), list(
+      "arn:aws:iam::p2_role", "p2_role_session", "webtoken_for_p2"
+    ))
+
+    # Test profile using source_profile
+    mock_get_web_identity_creds <- mock2(profile_creds$p2)
+    mock_get_assumed_role_creds <- mock2(profile_creds$p3)
+    local_mocked_bindings(
+      get_assume_role_with_web_identity_creds = mock_get_web_identity_creds,
+      get_assumed_role_creds = mock_get_assumed_role_creds
+    )
+    expect_equal(config_file_provider("p3"), profile_creds$p3)
+    expect_equal(mock_arg(mock_get_web_identity_creds), list(
+      "arn:aws:iam::p2_role", "p2_role_session", "webtoken_for_p2"
+    ))
+    expect_equal(mock_arg(mock_get_assumed_role_creds), list(
+      "arn:aws:iam::p3_role", "p3_role_session", NULL, profile_creds$p2
+    ))
+  })
+})

--- a/paws.common/tests/testthat/test_credential_providers.R
+++ b/paws.common/tests/testthat/test_credential_providers.R
@@ -75,10 +75,10 @@ test_that("config_file_provider", {
   withr::with_envvar(envvars, {
     # Test missing profile
     expect_null(config_file_provider("invalidProfile"))
-    
+
     # Test default profile using credential_process
     expect_equal(config_file_provider(), creds$default)
-    
+
     # Test profile using environment credential_source
     mock_get_assumed_role_creds <- mock2(creds$p1)
     local_mocked_bindings(
@@ -92,7 +92,7 @@ test_that("config_file_provider", {
                  creds$env$access_key_id)
     expect_equal(mock_arg(mock_get_assumed_role_creds)[[4]]$secret_access_key,
                  creds$env$secret_access_key)
-    
+
     # Test profile using web_identity_token
     mock_web_identity_creds <- mock2(creds$p2)
     local_mocked_bindings(
@@ -105,18 +105,18 @@ test_that("config_file_provider", {
     ))
 
     # Test profile using source_profile
-    mock_get_web_identity_creds <- mock2(profile_creds$p2)
-    mock_get_assumed_role_creds <- mock2(profile_creds$p3)
+    mock_get_web_identity_creds <- mock2(creds$p2)
+    mock_get_assumed_role_creds <- mock2(creds$p3)
     local_mocked_bindings(
       get_assume_role_with_web_identity_creds = mock_get_web_identity_creds,
       get_assumed_role_creds = mock_get_assumed_role_creds
     )
-    expect_equal(config_file_provider("p3"), profile_creds$p3)
+    expect_equal(config_file_provider("p3"), creds$p3)
     expect_equal(mock_arg(mock_get_web_identity_creds), list(
       "arn:aws:iam::p2_role", "p2_role_session", "webtoken_for_p2"
     ))
     expect_equal(mock_arg(mock_get_assumed_role_creds), list(
-      "arn:aws:iam::p3_role", "p3_role_session", NULL, profile_creds$p2
+      "arn:aws:iam::p3_role", "p3_role_session", NULL, creds$p2
     ))
   })
 })


### PR DESCRIPTION
Adding support for web_identity_token_file in the AWS config file (see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html#cli-configure-role-oidc) - also opportunistically adding some unit testing in that area.

I need this functionality for a project I'm working on that uses this auth method, let me know if there's anything else I need to do to enable this change (I've successfully tested this for my use case by modifying the source via `trace`).