### PR TITLE
fix `NULL` method `as.POSIXct.default` for older versions of R

### DIFF
--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -3,6 +3,7 @@
 * cache `read_ini` for improved performance
 * cache unix os environment variables to improve performance on unix systems.
 * support `web_identity_token_file` in AWS config file thanks to @liuquinlin for implementation.
+* fix `NULL` method `as.POSIXct.default` for older versions of R
 
 # paws.common 0.6.2
 * fix how `read_ini` reads empty profiles from ini files

--- a/paws.common/R/xmlutil.R
+++ b/paws.common/R/xmlutil.R
@@ -455,7 +455,7 @@ default_parse_scalar <- function(interface_i, tag_type = NULL) {
     double = xml_scalar_default(interface_i, numeric()),
     long = xml_scalar_default(interface_i, numeric()),
     float = xml_scalar_default(interface_i, numeric()),
-    timestamp = xml_scalar_default(interface_i, as.POSIXct(NULL)),
+    timestamp = xml_scalar_default(interface_i, .POSIXct(numeric())),
     boolean = xml_scalar_default(interface_i, logical()),
     xml_scalar_default(interface_i, character())
   )


### PR DESCRIPTION
Address Ticket (#698)