### PR TITLE
Github action: version

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -83,7 +83,7 @@ jobs:
 
   version:
     if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/version') }}
-    name: style
+    name: version
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -122,7 +122,7 @@ jobs:
             }
           }
           
-          paws_update_version("cran", version = version)
+          paws_update_version("cran")
         shell: Rscript {0}
 
       - name: commit

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -108,6 +108,7 @@ jobs:
             cat("pkg_version=", version, "\n", sep="", file = Sys.getenv("GITHUB_OUTPUT"))
             packages <- list.files(dir, full.names = T)
             descriptions <- file.path(packages, "DESCRIPTION")
+            if (length(version) == 0) return()
             for (desc in descriptions) {
               lines <- readLines(desc)
               found <- grepl("Version: [0-9\\.]+", lines, perl = T)

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -80,3 +80,59 @@ jobs:
       - uses: r-lib/actions/pr-push@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  version:
+    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/version') }}
+    name: style
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ github.event.comment.body }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/pr-fetch@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: r-lib/actions/setup-r@v2
+      
+      - name: Version
+        id: version
+        run: |
+          # extract make.paws::paws_update_version to reduce the need to install make.paws
+          paws_update_version <- function(dir) {
+            var <- Sys.getenv("VERSION")
+            m <- regexpr("[0-9\\.]+", var)
+            version <- gsub('[[:punct:] ]$',"", regmatches(var, m, invert = FALSE))
+            cat("pkg_version=", version, "\n", sep="", file = Sys.getenv("GITHUB_OUTPUT"))
+            packages <- list.files(dir, full.names = T)
+            descriptions <- file.path(packages, "DESCRIPTION")
+            for (desc in descriptions) {
+              lines <- readLines(desc)
+              found <- grepl("Version: [0-9\\.]+", lines, perl = T)
+              lines[found] <- gsub("[0-9\\.]+", version, lines[found])
+              found <- grepl("paws\\..*[0-9]+\\.[0-9]+\\.[0-9]+", lines, 
+                             perl = T)
+              found[found] <- !grepl("paws\\.common.*[0-9]+\\.[0-9]+\\.[0-9]+", 
+                                     lines[found], perl = T)
+              lines[found] <- gsub("[0-9]+\\.[0-9]+\\.[0-9]+", version, 
+                                   lines[found])
+              writeLines(lines, desc)
+            }
+          }
+          
+          paws_update_version("cran", version = version)
+        shell: Rscript {0}
+
+      - name: commit
+        if: ${{ steps.version.outputs.pkg_version != '' }}
+        run: |
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add cran/*
+          git commit -m 'Update Cran Version: ${{ steps.version.outputs.pkg_version }}'
+
+      - uses: r-lib/actions/pr-push@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/make.paws/R/paws_helper_fun.R
+++ b/make.paws/R/paws_helper_fun.R
@@ -68,7 +68,7 @@ paws_service_param_fn <- function(dir = "../paws.common") {
 paws_new_services <- function(in_dir = "../vendor/aws-sdk-js") {
   existing_apis <- yaml::read_yaml(system.file("extdata/packages.yml", package = "make.paws"))
   existing_apis <- unlist(lapply(existing_apis, \(x) x$services))
-  
+
   new_apis <- list_apis(file.path(in_dir, "apis"))
   return(setdiff(new_apis, existing_apis))
 }


### PR DESCRIPTION
This lets maintainers update paws cran packages version through a PR comment:

Github action will update all cran packages to 0.5.0
```
/version 0.5.0
```

Github action will update all cran packages to 0.5.0
```
/version 0.5.0 oh yeah
```

The github action will skip editing cran package Descriptions
```
/version
```

Use case for this is to quickly update Package versions after paws regen github action has taken place.

Testing has been done on PR: https://github.com/DyfanJones/paws/pull/16
