### PR TITLE
Exit paginator when previous token matches current

### DIFF
--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -161,7 +161,7 @@ sse_md5_build <- function(request) {
 # encryption key. This handler does both if the MD5 has not been set by
 # the caller.
 sse_md5 <- function(params) {
-  return(.sse_md5(params, 'SSECustomer'))
+  return(.sse_md5(params, "SSECustomer"))
 }
 
 # S3 server-side encryption requires the encryption key to be sent to the
@@ -169,14 +169,15 @@ sse_md5 <- function(params) {
 # encryption key. This handler does both if the MD5 has not been set by
 # the caller specifically if the parameter is for the copy-source sse-c key.
 copy_source_sse_md5 <- function(params) {
-  return(.sse_md5(params, 'CopySourceSSECustomer'))
+  return(.sse_md5(params, "CopySourceSSECustomer"))
 }
 
-.sse_md5 <- function(params, sse_member_prefix='SSECustomer') {
-  if (!.needs_s3_sse_customization(params, sse_member_prefix))
+.sse_md5 <- function(params, sse_member_prefix = "SSECustomer") {
+  if (!.needs_s3_sse_customization(params, sse_member_prefix)) {
     return(params)
-  sse_key_member <- paste0(sse_member_prefix, 'Key')
-  sse_md5_member <- paste0(sse_member_prefix, 'KeyMD5')
+  }
+  sse_key_member <- paste0(sse_member_prefix, "Key")
+  sse_md5_member <- paste0(sse_member_prefix, "KeyMD5")
   key_md5_str <- base64enc::base64encode(
     digest::digest(params[[sse_key_member]], serialize = FALSE, raw = TRUE)
   )
@@ -186,9 +187,9 @@ copy_source_sse_md5 <- function(params) {
 }
 
 .needs_s3_sse_customization <- function(params, sse_member_prefix) {
-  return (
-    !is_empty(params[[paste0(sse_member_prefix, 'Key')]]) &
-    is_empty(params[[paste0(sse_member_prefix, 'KeyMD5')]])
+  return(
+    !is_empty(params[[paste0(sse_member_prefix, "Key")]]) &
+      is_empty(params[[paste0(sse_member_prefix, "KeyMD5")]])
   )
 }
 

--- a/paws.common/R/paginate.R
+++ b/paws.common/R/paginate.R
@@ -62,16 +62,22 @@ paginate <- function(Operation,
     for (i in seq_along(new_tokens)) {
       fn[[paginator$input_token[[i]]]] <- new_tokens[[i]]
     }
+
+    resp_len <- length(resp[[primary_result_key]])
+    if (resp_len == 0) {
+      break
+    }
+
     result[[length(result) + 1]] <- resp
 
     # exit if no more results
-    if (!is.null(paginator$more_results)) {
-      if (isFALSE(resp[[paginator$more_results]])) {
+    if (!is.null(paginator[["more_results"]])) {
+      if (isFALSE(resp[[paginator[["more_results"]]]])) {
         break
       }
     }
     if (!is.null(MaxItems)) {
-      no_items <- no_items + length(resp[[primary_result_key]])
+      no_items <- no_items + resp_len
       if (no_items >= MaxItems) {
         break
       }
@@ -244,16 +250,22 @@ paginate_xapply <- function(
     for (i in seq_along(new_tokens)) {
       fn[[paginator$input_token[[i]]]] <- new_tokens[[i]]
     }
+
+    resp_len <- length(resp[[primary_result_key]])
+    if (resp_len == 0) {
+      break
+    }
+
     result[[length(result) + 1]] <- FUN(resp, ...)
 
     # exit if no more results
-    if (!is.null(paginator$more_results)) {
-      if (isFALSE(resp[[paginator$more_results]])) {
+    if (!is.null(paginator[["more_results"]])) {
+      if (isFALSE(resp[[paginator[["more_results"]]]])) {
         break
       }
     }
     if (!is.null(MaxItems)) {
-      no_items <- no_items + length(resp[[primary_result_key]])
+      no_items <- no_items + resp_len
       if (no_items >= MaxItems) {
         break
       }

--- a/paws.common/R/paginate.R
+++ b/paws.common/R/paginate.R
@@ -63,7 +63,7 @@ paginate <- function(Operation,
     new_tokens <- get_tokens(resp, paginator$output_token)
 
     # Exit paginator if previous token matches current token
-    # https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.78.0
+    # https://github.com/smithy-lang/smithy-typescript/blob/main/packages/core/src/pagination/createPaginator.ts#L53
     if (isTRUE(StopOnSameToken)) {
       previous_token <- unlist(fn[[paginator$input_token]], use.names = F)
       if (identical(previous_token, unlist(new_tokens, use.names = F))) {
@@ -262,7 +262,7 @@ paginate_xapply <- function(
     new_tokens <- get_tokens(resp, paginator$output_token)
 
     # Exit paginator if previous token matches current token
-    # https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.78.0
+    # https://github.com/smithy-lang/smithy-typescript/blob/main/packages/core/src/pagination/createPaginator.ts#L53
     if (isTRUE(StopOnSameToken)) {
       previous_token <- unlist(fn[[paginator$input_token]], use.names = F)
       if (identical(previous_token, unlist(new_tokens, use.names = F))) {

--- a/paws.common/R/paginate.R
+++ b/paws.common/R/paginate.R
@@ -260,7 +260,6 @@ paginate_xapply <- function(
   while (!identical(fn[[paginator$input_token[[1]]]], character(0))) {
     resp <- eval(fn, envir = parent.frame(n = 2))
     new_tokens <- get_tokens(resp, paginator$output_token)
-    previous_token <- unlist(fn[[paginator$input_token]], use.names = F)
 
     # Exit paginator if previous token matches current token
     # https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.78.0

--- a/paws.common/man/paginate.Rd
+++ b/paws.common/man/paginate.Rd
@@ -6,7 +6,13 @@
 \alias{paginate_sapply}
 \title{Paginate over an operation.}
 \usage{
-paginate(Operation, PageSize = NULL, MaxItems = NULL, StartingToken = NULL)
+paginate(
+  Operation,
+  PageSize = NULL,
+  MaxItems = NULL,
+  StartingToken = NULL,
+  StopOnSameToken = FALSE
+)
 
 paginate_lapply(
   Operation,
@@ -14,7 +20,8 @@ paginate_lapply(
   ...,
   PageSize = NULL,
   MaxItems = NULL,
-  StartingToken = NULL
+  StartingToken = NULL,
+  StopOnSameToken = FALSE
 )
 
 paginate_sapply(
@@ -24,7 +31,8 @@ paginate_sapply(
   simplify = TRUE,
   PageSize = NULL,
   MaxItems = NULL,
-  StartingToken = NULL
+  StartingToken = NULL,
+  StopOnSameToken = FALSE
 )
 }
 \arguments{
@@ -36,6 +44,8 @@ paginate_sapply(
 
 \item{StartingToken}{Can be used to modify the starting marker or token of a paginator.
 This argument if useful for resuming pagination from a previous token or starting pagination at a known position.}
+
+\item{StopOnSameToken}{Exist paginator if previous token matches current token.}
 
 \item{FUN}{the function to be applied to each response element of \code{operation}.}
 


### PR DESCRIPTION
This addresses issue: https://github.com/paws-r/paws/issues/721

Developed from aws sdk js v3 solution: https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.78.0
