### PR TITLE
Minor performance

### DIFF
--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: paws.common
 Type: Package
 Title: Paws Low-Level Amazon Web Services API
-Version: 0.7.0
+Version: 0.7.0.9000
 Authors@R: c(
         person("David", "Kretch", email = "david.kretch@gmail.com", role = "aut"),
         person("Adam", "Banker", email = "adam.banker39@gmail.com", role = "aut"),

--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -1,3 +1,6 @@
+# paws.common 0.7.0.9000
+* minor performance enhancements
+
 # paws.common 0.7.0
 * support sse md5 (#718). Thanks to @odysseu for raising issue.
 * add pagination StopOnSameToken option (#721) aligns with aws-sdk-js-v3 implementation (https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.78.0). Thanks to @wlandau for raising error in `paginate`.

--- a/paws.common/R/RcppExports.R
+++ b/paws.common/R/RcppExports.R
@@ -7,3 +7,9 @@ paws_url_encoder <- function(urls, safe = "") {
     .Call('_paws_common_paws_url_encoder', PACKAGE = 'paws.common', urls, safe)
 }
 
+#' @useDynLib paws.common _paws_common_char_sort
+#' @importFrom Rcpp evalCpp
+char_sort <- function(str) {
+    .Call('_paws_common_char_sort', PACKAGE = 'paws.common', str)
+}
+

--- a/paws.common/R/client.R
+++ b/paws.common/R/client.R
@@ -80,7 +80,9 @@ new_session <- function() {
 resolver_endpoint <- function(service, region, endpoints, sts_regional_endpoint = "", scheme = "https") {
   get_region_pattern <- function(region, endpoints) {
     patterns <- names(endpoints)
-    matches <- patterns[sapply(patterns, function(pattern) grepl(pattern, region))]
+    matches <- patterns[
+      vapply(patterns, function(pattern) grepl(pattern, region), FUN.VALUE = logical(1))
+    ]
     match <- matches[order(nchar(matches), decreasing = TRUE)][1]
     return(match)
   }

--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -453,8 +453,8 @@ s3_get_bucket_region <- function(response, error) {
 set_request_url <- function(original_endpoint,
                             new_endpoint,
                             use_new_scheme = TRUE) {
-  new_endpoint_components <- httr::parse_url(new_endpoint)
-  original_endpoint_components <- httr::parse_url(original_endpoint)
+  new_endpoint_components <- paws_url_parse(new_endpoint)
+  original_endpoint_components <- paws_url_parse(original_endpoint)
   scheme <- original_endpoint_components$scheme
   if (use_new_scheme) {
     scheme <- new_endpoint_components$scheme

--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -459,7 +459,7 @@ set_request_url <- function(original_endpoint,
   if (use_new_scheme) {
     scheme <- new_endpoint_components$scheme
   }
-  final_endpoint_components <- structure(list(
+  final_endpoint_components <- list(
     scheme = scheme,
     hostname = new_endpoint_components$hostname %||% "",
     path = original_endpoint_components$path %||% "",
@@ -467,7 +467,7 @@ set_request_url <- function(original_endpoint,
     fragment = "",
     raw_path = "",
     raw_query = ""
-  ), class = "url")
+  )
   final_endpoint <- build_url(final_endpoint_components)
   return(final_endpoint)
 }

--- a/paws.common/R/dateutil.R
+++ b/paws.common/R/dateutil.R
@@ -7,7 +7,7 @@ as_timestamp <- function(x, format, tz = "GMT") {
     return(result)
   }
   if (length(x) == 1 && nchar(x) == 0) {
-    result <- NA_character_
+    result <- NA_integer_
     class(result) <- c("POSIXct", "POSIXt")
     attr(result, "tzone") <- tz
     return(result)

--- a/paws.common/R/dateutil.R
+++ b/paws.common/R/dateutil.R
@@ -1,8 +1,16 @@
 # Return a POSIXct timestamp given a string and a format.
-# TODO: Allow setting time zone.
 as_timestamp <- function(x, format, tz = "GMT") {
   if (length(x) == 0) {
-    return(structure(numeric(0), class = c("POSIXct", "POSIXt")))
+    result <- numeric(0)
+    class(result) <- c("POSIXct", "POSIXt")
+    attr(result, "tzone") <- tz
+    return(result)
+  }
+  if (length(x) == 1 && nchar(x) == 0) {
+    result <- NA_character_
+    class(result) <- c("POSIXct", "POSIXt")
+    attr(result, "tzone") <- tz
+    return(result)
   }
   lookup <- c(
     "iso8601" = "%Y-%m-%dT%H:%M:%S",

--- a/paws.common/R/handlers_rest.R
+++ b/paws.common/R/handlers_rest.R
@@ -80,7 +80,7 @@ rest_build_query_string <- function(query, field, name) {
   if (t == "list") {
     query[[name]] <- field
   } else if (t == "map") {
-    for (key in sort(names(field))) {
+    for (key in char_sort(names(field))) {
       query[[key]] <- field[[key]]
     }
   } else {

--- a/paws.common/R/idempotency.R
+++ b/paws.common/R/idempotency.R
@@ -1,5 +1,5 @@
 IDEMPOTENCY_TOKEN_FILL_TAG <- "idempotencyToken"
-IDEMPOTENCY_RAND_FN <- function() sample(0:(2^8 - 1), 1)
+IDEMPOTENCY_RAND_FN <- function(len) sample(0:(2^8 - 1), len, replace = TRUE)
 
 # Return whether the idempotency token can be automatically set.
 can_set_idempotency_token <- function(value) {
@@ -9,8 +9,7 @@ can_set_idempotency_token <- function(value) {
 # Return a randomly-generated idempotency token.
 get_idempotency_token <- function() {
   rand <- getOption("idempotency_rand_fn", default = IDEMPOTENCY_RAND_FN)
-  b <- sapply(1:16, function(x) rand())
-  return(uuid(b))
+  return(uuid(rand(16)))
 }
 
 # Return a UUID version 4 based on the given `bytes`.

--- a/paws.common/R/iniutil.R
+++ b/paws.common/R/iniutil.R
@@ -43,11 +43,11 @@ read_ini <- function(file_name) {
 
   start <- (found + 1)
   end <- c(found[-1] - 1, length(content))
-  split_content <- strsplit(sub("=", "\n", content, fixed = T), "\n", fixed = T)
-  nested_contents <- lengths(split_content) == 1
+  split_content <- parse_in_half(content)
+  nested_contents <- split_content[,2] == ""
 
-  split_content <- sub("[ \t\r\n]+$", "", do.call(rbind, split_content), perl = TRUE)
   sub_grps <- !grepl("^[ ]+", split_content[, 1])
+  split_content <- sub("[ \t\r\n]+$", "", split_content, perl = TRUE)
   split_content <- sub("^[ \t\r]+", "", split_content, perl = TRUE)
   for (i in which(start <= end)) {
     items <- seq.int(start[i], end[i])

--- a/paws.common/R/iniutil.R
+++ b/paws.common/R/iniutil.R
@@ -44,7 +44,7 @@ read_ini <- function(file_name) {
   start <- (found + 1)
   end <- c(found[-1] - 1, length(content))
   split_content <- parse_in_half(content)
-  nested_contents <- split_content[,2] == ""
+  nested_contents <- split_content[, 2] == ""
 
   sub_grps <- !grepl("^[ ]+", split_content[, 1])
   split_content <- sub("[ \t\r\n]+$", "", split_content, perl = TRUE)

--- a/paws.common/R/jsonutil.R
+++ b/paws.common/R/jsonutil.R
@@ -100,14 +100,10 @@ json_build_list <- function(values) {
 }
 
 json_build_map <- function(values) {
-  v <- list()
-  for (key in char_sort(names(values))) {
-    value <- values[[key]]
-    buf <- sprintf('"%s":%s', key, json_build_any(value))
-    v[[length(v) + 1]] <- buf
-  }
-  v <- sprintf("{%s}", paste(v, collapse = ","))
-  return(v)
+  v <- lapply(char_sort(names(values)), function(key) {
+    sprintf('"%s":%s', key, json_build_any(values[[key]]))
+  })
+  return(sprintf("{%s}", paste(v, collapse = ",")))
 }
 
 json_build_scalar <- function(values) {

--- a/paws.common/R/jsonutil.R
+++ b/paws.common/R/jsonutil.R
@@ -101,7 +101,7 @@ json_build_list <- function(values) {
 
 json_build_map <- function(values) {
   v <- list()
-  for (key in sort(names(values))) {
+  for (key in char_sort(names(values))) {
     value <- values[[key]]
     buf <- sprintf('"%s":%s', key, json_build_any(value))
     v[[length(v) + 1]] <- buf

--- a/paws.common/R/paginate.R
+++ b/paws.common/R/paginate.R
@@ -59,11 +59,11 @@ paginate <- function(Operation,
   paginator <- fn_update$paginator
   primary_result_key <- paginator$result_key[[1]]
   no_items <- 0
+  jmes_path_token <- NULL
   result <- list()
   while (!identical(fn[[paginator$input_token[[1]]]], character(0))) {
     resp <- eval(fn, envir = parent.frame())
-    new_tokens <- get_tokens(resp, paginator$output_token)
-
+    new_tokens <- get_tokens(resp, paginator$output_token, environment())
     # Exit paginator if previous token matches current token
     # https://github.com/smithy-lang/smithy-typescript/blob/main/packages/core/src/pagination/createPaginator.ts#L53
     if (isTRUE(StopOnSameToken)) {
@@ -258,10 +258,11 @@ paginate_xapply <- function(
     StopOnSameToken = FALSE) {
   primary_result_key <- paginator$result_key[[1]]
   no_items <- 0
+  jmes_path_token <- NULL
   result <- list()
   while (!identical(fn[[paginator$input_token[[1]]]], character(0))) {
     resp <- eval(fn, envir = parent.frame(n = 2))
-    new_tokens <- get_tokens(resp, paginator$output_token)
+    new_tokens <- get_tokens(resp, paginator$output_token, environment())
 
     # Exit paginator if previous token matches current token
     # https://github.com/smithy-lang/smithy-typescript/blob/main/packages/core/src/pagination/createPaginator.ts#L53
@@ -297,20 +298,22 @@ paginate_xapply <- function(
 
 token_error_msg <- "attempt to select less than one element in integerOneIndex"
 # Get all output tokens
-get_tokens <- function(resp, token) {
+get_tokens <- function(resp, token, caller_env) {
   last <- function(x) x[[length(x)]]
   tokens <- list()
   for (tkn in token) {
-    tokens[[tkn]] <- tryCatch(
-      eval(parse(text = jmespath_index(tkn)), envir = environment()),
-      error = function(err) {
-        # Return default character(0) for empty lists
-        if (grepl(token_error_msg, err[["message"]], perl = T)) {
-          character(0)
-        } else {
-          stop(err)
-        }
+    tokens[[tkn]] <- tryCatch({
+      jmes_path <- caller_env[["jmes_path_token"]][[tkn]] %||% jmespath_index(tkn, caller_env)
+      eval(parse(text = jmes_path, keep.source = FALSE), envir = environment())
+    },
+    error = function(err) {
+      # Return default character(0) for empty lists
+      if (grepl(token_error_msg, err[["message"]], perl = T)) {
+        character(0)
+      } else {
+        stop(err)
       }
+    }
     )
   }
   return(tokens)
@@ -325,7 +328,7 @@ split_token <- function(token) {
 # This is a simple implementation of jmespath for R list: i.e.
 # Path.To[-1].Token -> last(resp[["Path"]][["To"]])[["Token"]]
 # Path.To.Token -> resp[["Path"]][["To"]][["Token"]]
-jmespath_index <- function(token) {
+jmespath_index <- function(token, caller_env) {
   token_prts <- split_token(token)
   pattern <- "[[:alpha:]]+"
 
@@ -355,5 +358,6 @@ jmespath_index <- function(token) {
     # Path.To.Token
     final_token <- sprintf("resp[[%s]]", paste0(token_prts, collapse = "]][["))
   }
+  caller_env[["jmes_path_token"]][[token]] <- final_token
   return(final_token)
 }

--- a/paws.common/R/paginate.R
+++ b/paws.common/R/paginate.R
@@ -302,18 +302,19 @@ get_tokens <- function(resp, token, caller_env) {
   last <- function(x) x[[length(x)]]
   tokens <- list()
   for (tkn in token) {
-    tokens[[tkn]] <- tryCatch({
-      jmes_path <- caller_env[["jmes_path_token"]][[tkn]] %||% jmespath_index(tkn, caller_env)
-      eval(parse(text = jmes_path, keep.source = FALSE), envir = environment())
-    },
-    error = function(err) {
-      # Return default character(0) for empty lists
-      if (grepl(token_error_msg, err[["message"]], perl = T)) {
-        character(0)
-      } else {
-        stop(err)
+    jmes_path <- caller_env[["jmes_path_token"]][[tkn]] %||% jmespath_index(tkn, caller_env)
+    tokens[[tkn]] <- tryCatch(
+      {
+        eval(parse(text = jmes_path, keep.source = FALSE), envir = environment())
+      },
+      error = function(err) {
+        # Return default character(0) for empty lists
+        if (grepl(token_error_msg, err[["message"]], perl = T)) {
+          character(0)
+        } else {
+          stop(err)
+        }
       }
-    }
     )
   }
   return(tokens)

--- a/paws.common/R/populate.R
+++ b/paws.common/R/populate.R
@@ -2,7 +2,7 @@
 
 # Sometimes the locationName is different from the interface name
 check_location_name <- function(name, interface) {
-  location_names <- sapply(interface, function(x) tag_get(x, "locationName"))
+  location_names <- vapply(interface, function(x) tag_get(x, "locationName"), FUN.VALUE = character(1))
 
   in_location_names <- name %in% location_names
   if (!in_location_names) {

--- a/paws.common/R/populate.R
+++ b/paws.common/R/populate.R
@@ -2,15 +2,15 @@
 
 # Sometimes the locationName is different from the interface name
 check_location_name <- function(name, interface) {
-  location_names <- vapply(interface, function(x) tag_get(x, "locationName"), FUN.VALUE = character(1))
-
+  location_names <- vapply(
+    interface, function(x) tag_get(x, "locationName"),
+    FUN.VALUE = character(1)
+  )
   in_location_names <- name %in% location_names
   if (!in_location_names) {
     return(in_location_names)
   }
-
   location_index <- which(name == location_names)
-
   return(location_index)
 }
 
@@ -29,7 +29,6 @@ populate_structure <- function(input, interface) {
       if (!check_location) {
         stopf("invalid name: %s", name)
       }
-
       interface[[check_location]] <- populate(
         input[[name]],
         interface[[check_location]]

--- a/paws.common/R/request.R
+++ b/paws.common/R/request.R
@@ -37,7 +37,7 @@ Operation <- struct(
 #' @export
 new_operation <- function(name, http_method, http_path, paginator, before_presign_fn = NULL) {
   args <- as.list(environment())
-  args[sapply(args, is.null)] <- NULL
+  args[vapply(args, is.null, FUN.VALUE = logical(1))] <- NULL
   return(do.call(Operation, args))
 }
 

--- a/paws.common/R/request.R
+++ b/paws.common/R/request.R
@@ -37,7 +37,7 @@ Operation <- struct(
 #' @export
 new_operation <- function(name, http_method, http_path, paginator, before_presign_fn = NULL) {
   args <- as.list(environment())
-  args[vapply(args, is.null, FUN.VALUE = logical(1))] <- NULL
+  args[lengths(args) == 0] <- NULL
   return(do.call(Operation, args))
 }
 

--- a/paws.common/R/signer_v4.R
+++ b/paws.common/R/signer_v4.R
@@ -368,7 +368,7 @@ build_canonical_headers <- function(ctx, header, ignored_headers) {
     ctx$signed_header_vals[[lower_case_key]] <- header[[key]]
     headers[length(headers) + 1] <- lower_case_key
   }
-  headers <- sort(headers)
+  headers <- char_sort(headers)
   ctx$signed_headers <- paste(headers, collapse = ";")
 
   if (ctx$is_presigned) {

--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -85,18 +85,6 @@ paws_parse_match <- function(x, pattern) {
   return(pieces)
 }
 
-paws_parse_delim <- function(x, delim, quote = "\"", ...) {
-  scan(
-    text = x,
-    what = character(),
-    sep = delim,
-    quote = quote,
-    quiet = TRUE,
-    strip.white = TRUE,
-    ...
-  )
-}
-
 # Build a URL from a Url object.
 # <scheme>://<net_loc>/<path>;<params>?<query>#<fragment>
 build_url <- function(url) {
@@ -152,7 +140,7 @@ build_query_string <- function(params) {
 # e.g. `parse_query_string("bar=baz&foo=qux")` -> `list(bar = "baz", foo = "qux")`
 parse_query_string <- function(query) {
   query <- gsub("^\\?", "", query)
-  params <- parse_in_half(paws_parse_delim(query, "&"), "=")
+  params <- parse_in_half(strsplit(query,"&")[[1]], "=")
   if (length(params) == 0) {
     return(NULL)
   }

--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -140,7 +140,7 @@ build_query_string <- function(params) {
 # e.g. `parse_query_string("bar=baz&foo=qux")` -> `list(bar = "baz", foo = "qux")`
 parse_query_string <- function(query) {
   query <- gsub("^\\?", "", query)
-  params <- parse_in_half(strsplit(query,"&")[[1]], "=")
+  params <- parse_in_half(strsplit(query, "&")[[1]], "=")
   if (length(params) == 0) {
     return(NULL)
   }
@@ -221,15 +221,4 @@ escaped_path <- function(url) {
 # TODO: Implement.
 valid_encoded_path <- function(path) {
   return(TRUE)
-}
-
-# Convert a value to be used in a query string.
-query_convert <- function(value) {
-  # find elements that are logical
-  found <- as.logical(unlist(lapply(value, is.logical)))
-  # convert logical elements
-  value[which(found)] <- tolower(value[which(found)])
-  # convert non-logical elements
-  value[which(!found)] <- as.character(value[which(!found)])
-  return(value)
 }

--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -100,8 +100,8 @@ paws_parse_delim <- function(x, delim, quote = "\"", ...) {
 # Build a URL from a Url object.
 # <scheme>://<net_loc>/<path>;<params>?<query>#<fragment>
 build_url <- function(url) {
-  if (nzchar(url$scheme) && nzchar(url$hostname)) {
-    l <- paste0(url$scheme, "://", url$hostname)
+  if (nzchar(url$scheme) && nzchar(url$host)) {
+    l <- paste0(url$scheme, "://", url$host)
   } else {
     return("")
   }
@@ -151,7 +151,7 @@ build_query_string <- function(params) {
 # Decode a query string into a list.
 # e.g. `parse_query_string("bar=baz&foo=qux")` -> `list(bar = "baz", foo = "qux")`
 parse_query_string <- function(query) {
-  x <- gsub("^\\?", "", query)
+  query <- gsub("^\\?", "", query)
   params <- parse_in_half(paws_parse_delim(query, "&"), "=")
   if (length(params) == 0) {
     return(NULL)
@@ -171,11 +171,6 @@ update_query_string <- function(query_string, params) {
     result[[key]] <- params[[key]]
   }
   return(build_query_string(result))
-}
-
-# Escape strings so they can be safely included in a URL query.
-query_escape <- function(string) {
-  return(escape(string, "encodeQueryComponent"))
 }
 
 # Escape strings so they can be safely included in a URL.
@@ -221,14 +216,6 @@ unescape <- function(string) {
   return(curl_unescape(string))
 }
 
-# The inverse of query_escape: convert the encoded string back to the original,
-# e.g. "%20" -> " ".
-# TODO: Complete.
-query_unescape <- function(string) {
-  return(unescape(string))
-}
-
-#
 escaped_path <- function(url) {
   if (url$raw_path != "" && valid_encoded_path(url$raw_path)) {
     if (unescape(url$raw_path) == url$path) {

--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -155,9 +155,7 @@ parse_query_string <- function(query) {
 # e.g. `update_query_string("a=1&b=2", list(b = 3, c = 4))` -> "a=1&b=3&c=4"
 update_query_string <- function(query_string, params) {
   result <- parse_query_string(query_string)
-  for (key in names(params)) {
-    result[[key]] <- params[[key]]
-  }
+  result[names(params)] <- params
   return(build_query_string(result))
 }
 

--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -108,7 +108,6 @@ query_empty <- function(params) {
   (is.null(params) || length(params) == 0)
 }
 
-
 # Encode a list into a query string.
 # e.g. `list(bar = "baz", foo = "qux")` -> "bar=baz&foo=qux".
 build_query_string <- function(params) {

--- a/paws.common/R/util.R
+++ b/paws.common/R/util.R
@@ -121,7 +121,7 @@ sort_list <- function(x) {
   if (length(x) == 0) {
     return(x)
   }
-  x[sort(names(x))]
+  x[char_sort(names(x))]
 }
 
 str_match <- function(str, pattern) {
@@ -224,4 +224,23 @@ stopf <- function(fmt, ...) {
 # https://stat.ethz.ch/pipermail/r-devel/2023-September/082892.html
 is_atomic <- function(x) {
   return(is.atomic(x) || is.null(x))
+}
+
+parse_in_half <- function(x, char = "=") {
+  match_loc <- regexpr(char, x, fixed = TRUE)
+  match_len <- attr(match_loc, "match.length")
+
+  left_end <- match_loc - 1
+  right_start <- match_loc + match_len
+  right_end <- nchar(x)
+
+  no_match <- match_loc == -1
+  left_end[no_match] <- right_end[no_match]
+  right_start[no_match] <- 0
+  right_end[no_match] <- 0
+
+  cbind(
+    substr(x, 1, left_end),
+    substr(x, right_start, right_end)
+  )
 }

--- a/paws.common/R/util.R
+++ b/paws.common/R/util.R
@@ -226,6 +226,8 @@ is_atomic <- function(x) {
   return(is.atomic(x) || is.null(x))
 }
 
+# fast method to parse strings in half
+# https://gist.github.com/hadley/2fd32cdc053099d62d56f5f28898ec95
 parse_in_half <- function(x, char = "=") {
   match_loc <- regexpr(char, x, fixed = TRUE)
   match_len <- attr(match_loc, "match.length")

--- a/paws.common/src/RcppExports.cpp
+++ b/paws.common/src/RcppExports.cpp
@@ -22,9 +22,21 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// char_sort
+CharacterVector char_sort(CharacterVector str);
+RcppExport SEXP _paws_common_char_sort(SEXP strSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< CharacterVector >::type str(strSEXP);
+    rcpp_result_gen = Rcpp::wrap(char_sort(str));
+    return rcpp_result_gen;
+END_RCPP
+}
 
 static const R_CallMethodDef CallEntries[] = {
     {"_paws_common_paws_url_encoder", (DL_FUNC) &_paws_common_paws_url_encoder, 2},
+    {"_paws_common_char_sort", (DL_FUNC) &_paws_common_char_sort, 1},
     {NULL, NULL, 0}
 };
 

--- a/paws.common/src/encoding.cpp
+++ b/paws.common/src/encoding.cpp
@@ -95,3 +95,15 @@ CharacterVector paws_url_encoder(CharacterVector urls, CharacterVector safe = ""
   //Return
   return output;
 }
+
+// Sort character vector
+// param str A character vector to be sorted
+//' @useDynLib paws.common _paws_common_char_sort
+//' @importFrom Rcpp evalCpp
+// [[Rcpp::export]]
+CharacterVector char_sort(CharacterVector str) {
+  IntegerVector idx = seq_along(str) - 1;
+  std::sort(idx.begin(), idx.end(), [&](int i, int j){return str[i] < str[j];});
+  return str[idx];
+}
+

--- a/paws.common/tests/testthat/test_dateutil.R
+++ b/paws.common/tests/testthat/test_dateutil.R
@@ -10,8 +10,14 @@ test_that("as_timestamp ISO8601", {
   expect_equal(out, exp)
 })
 
-test_that("as_timestamp empty input", {
+test_that("as_timestamp NULL input", {
   out <- as_timestamp(NULL, format = "foo")
-  exp <- structure(numeric(0), class = c("POSIXct", "POSIXt"))
+  exp <- structure(numeric(0), class = c("POSIXct", "POSIXt"), tzone = "GMT")
+  expect_equal(out, exp)
+})
+
+test_that("as_timestamp empty input", {
+  out <- as_timestamp("", format = "foo", tz = "GMT")
+  exp <- as.POSIXct("", tz = "GMT", format = "foo")
   expect_equal(out, exp)
 })

--- a/paws.common/tests/testthat/test_handlers_ec2query.R
+++ b/paws.common/tests/testthat/test_handlers_ec2query.R
@@ -6,8 +6,8 @@ op <- Operation(name = "OperationName")
 svc <- Client()
 svc$client_info$api_version <- "2014-01-01"
 svc$handlers$build <- HandlerList(ec2query_build)
-options(idempotency_rand_fn = function() {
-  0
+options(idempotency_rand_fn = function(len) {
+  rep(0, len)
 })
 
 op_input1 <- function(Foo = NULL, Bar = NULL, Yuck = NULL) {

--- a/paws.common/tests/testthat/test_handlers_jsonrpc.R
+++ b/paws.common/tests/testthat/test_handlers_jsonrpc.R
@@ -10,8 +10,8 @@ svc <- Client(
   )
 )
 svc$handlers$build <- HandlerList(jsonrpc_build)
-options(idempotency_rand_fn = function() {
-  0
+options(idempotency_rand_fn = function(len) {
+  rep(0, len)
 })
 
 op_input1 <- function(Name) {

--- a/paws.common/tests/testthat/test_handlers_restjson.R
+++ b/paws.common/tests/testthat/test_handlers_restjson.R
@@ -8,8 +8,8 @@ svc <- Client(
   )
 )
 svc$handlers$build <- HandlerList(restjson_build)
-options(idempotency_rand_fn = function() {
-  0
+options(idempotency_rand_fn = function(len) {
+  rep(0, len)
 })
 
 test_that("no parameters", {

--- a/paws.common/tests/testthat/test_paginate.R
+++ b/paws.common/tests/testthat/test_paginate.R
@@ -3,6 +3,7 @@
 ########################################################################
 
 test_that("check token is correctly retrieved", {
+  jmes_path_token <- NULL
   output_tokens <- list(
     "NextToken",
     "Contents.Keys[-1].Id",
@@ -14,11 +15,12 @@ test_that("check token is correctly retrieved", {
     Mark = list(NextToken = "token3")
   )
   expected <- setNames(list("token1", "token2", "token3"), output_tokens)
-  actual <- get_tokens(resp, output_tokens)
+  actual <- get_tokens(resp, output_tokens, environment())
   expect_equal(actual, expected)
 })
 
 test_that("check empty token is returned", {
+  jmes_path_token <- NULL
   output_tokens <- list(
     "NextToken",
     "Contents[-1].Id"
@@ -28,7 +30,7 @@ test_that("check empty token is returned", {
     Contents = list()
   )
   expected <- setNames(list(character(0), character(0)), output_tokens)
-  actual <- get_tokens(resp, output_tokens)
+  actual <- get_tokens(resp, output_tokens, environment())
   expect_equal(actual, expected)
 })
 

--- a/paws.common/tests/testthat/test_url.R
+++ b/paws.common/tests/testthat/test_url.R
@@ -17,3 +17,14 @@ test_that("parse and build query strings", {
   expected <- input
   expect_equal(actual, expected)
 })
+
+test_that("missing query values become empty strings", {
+  expect_equal(parse_query_string("?q="), list(q = ""))
+  expect_equal(parse_query_string("?q"), list(q = ""))
+  expect_equal(parse_query_string("?a&q"), list(a = "", q = ""))
+})
+
+test_that("empty queries become NULL", {
+  expect_equal(parse_query_string("?"), NULL)
+  expect_equal(parse_query_string(""), NULL)
+})


### PR DESCRIPTION
This a minor performance enhancement. 

Focusing on:
- removal of `sapply` in favour of `vapply` or `lapply`
- improved get_token handler within paginate functions (only need to create path to token once).
- enhanced url_parse developed from `httr2` (long term `httr2` will slowly replace `httr` dependency)
- enhanced `build_query_string` function
- new `parse_in_half` method thanks to @hadley for discussion around performance https://github.com/r-lib/httr2/pull/430 (utilised in `read_ini` and `paws_url_parse`).
- simplified `get_idempotency_token` function to improve performance