### PR TITLE
Improve performance of restxml_unmarshal

### DIFF
--- a/paws.common/DESCRIPTION
+++ b/paws.common/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: paws.common
 Type: Package
 Title: Paws Low-Level Amazon Web Services API
-Version: 0.7.1
+Version: 0.7.1.9000
 Authors@R: c(
         person("David", "Kretch", email = "david.kretch@gmail.com", role = "aut"),
         person("Adam", "Banker", email = "adam.banker39@gmail.com", role = "aut"),

--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -1,3 +1,6 @@
+# paws.common 0.7.1.9000
+* improve performance of `restxml_unmarshal` by x3
+
 # paws.common 0.7.1
 * minor performance enhancements
 * fix MIME type for AWS BedrockRuntime Client (#749), thanks to @alex23lemm for raising issue.

--- a/paws.common/R/xmlutil.R
+++ b/paws.common/R/xmlutil.R
@@ -289,7 +289,9 @@ xml_parse_structure <- function(xml_elts, interface_i, tags_i, tag_type = NULL, 
   # the `is.list()` check is necessary because e.g. `CheckSumAlgorithm` has
   # a list interface though it isn't a list?!
   if (isTRUE(flattened)) {
-    result <- transpose(result)
+    if (is.list(result)) {
+      result <- .mapply(list, result, NULL)
+    }
   } else {
     result <- as.list(result)
   }
@@ -358,7 +360,9 @@ xml_parse_list <- function(xml_elts, interface_i, tags_i, tag_type = NULL, flatt
   # the `is.list()` check is necessary because e.g. `CheckSumAlgorithm` has
   # a list interface though it isn't a list?!
   if (isTRUE(flattened)) {
-    result <- transpose(result)
+    if (is.list(result)) {
+      result <- .mapply(list, result, NULL)
+    }
   }
 
   return(result)
@@ -459,37 +463,4 @@ default_parse_scalar <- function(interface_i, tag_type = NULL) {
     xml_scalar_default(interface_i, character())
   )
   return(result)
-}
-
-transpose <- function(x) {
-  if (!is.list(x)) {
-    return(x)
-  }
-  n_col <- length(x)
-  if (n_col == 0) {
-    return(list())
-  }
-  n_row <- length(x[[1]])
-  if (n_row == 0) {
-    return(list())
-  }
-  out <- vector("list", length = n_row)
-  col_seq <- seq.int(n_col, 1)
-
-  vals <- vector("list", length = n_col)
-  names(vals) <- names(x)
-
-  for (row in seq.int(1, n_row)) {
-    for (col in col_seq) {
-      vals[col] <- (
-        if (length(x[[col]]) < n_row) {
-          list(rep_len(x[[col]], n_row)[[row]])
-        } else {
-          list(x[[col]][[row]])
-        })
-    }
-    out[[row]] <- vals
-  }
-  names(out) <- names(x[[1]])
-  return(out)
 }

--- a/paws.common/R/xmlutil.R
+++ b/paws.common/R/xmlutil.R
@@ -288,10 +288,8 @@ xml_parse_structure <- function(xml_elts, interface_i, tags_i, tag_type = NULL, 
 
   # the `is.list()` check is necessary because e.g. `CheckSumAlgorithm` has
   # a list interface though it isn't a list?!
-  if (isTRUE(flattened)) {
-    if (is.list(result)) {
-      result <- .mapply(list, result, NULL)
-    }
+  if (isTRUE(flattened) && is.list(result)) {
+    result <- .mapply(list, result, NULL)
   } else {
     result <- as.list(result)
   }
@@ -359,10 +357,8 @@ xml_parse_list <- function(xml_elts, interface_i, tags_i, tag_type = NULL, flatt
 
   # the `is.list()` check is necessary because e.g. `CheckSumAlgorithm` has
   # a list interface though it isn't a list?!
-  if (isTRUE(flattened)) {
-    if (is.list(result)) {
-      result <- .mapply(list, result, NULL)
-    }
+  if (isTRUE(flattened) && is.list(result)) {
+    result <- .mapply(list, result, NULL)
   }
 
   return(result)


### PR DESCRIPTION
This PR has some significant performance enhancements for `xml_unmarshal`. This ultimately makes working with AWS S3 faster.


```r
# Mock response output to avoid any discrepancy from internet connections
httr_env <- asNamespace("httr")
unlockBinding("VERB", httr_env)
unlockBinding("GET", httr_env)

# NOTE: `resp.RDS` is the response from AWS S3. 
# Currently stored locally to avoid internet connection discrepancies
httr_env$VERB <- function(...) {
  resp <- readRDS("resp.RDS")
  return(resp)
}
httr_env$GET <- function(...) {
  resp <- readRDS("resp.RDS")
  return(resp)
}

library(paws)
# set region to us-east-2 to avoid PermanentRedirect
client <- s3(config(credentials(anonymous = T), region = "us-east-2"))

bm <- bench::mark(
   aws_s3 = aws.s3::get_bucket(bucket, region = "us-east-2"),
   paws.common_v0.7.1 = client$list_objects_v2(bucket),
   # paws.common_v0.7.1.9000 = client$list_objects_v2(bucket),
   check = F,
   iterations = 100
)


# A tibble: 3 × 13
  expression                   min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result memory                 time             gc                
  <bch:expr>              <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list> <list>                 <list>           <list>            
1 paws.common_v0.7.1.9000   20.5ms   22.2ms     42.3     1.42MB     16.4    72    28       1.7s <NULL> <Rprofmem [572 × 3]>   <bench_tm [100]> <tibble [100 × 3]>
2 aws_s3                   130.8ms  155.9ms      6.35    3.32MB     23.0   100   362     15.75s <NULL> <Rprofmem [6,190 × 3]> <bench_tm [100]> <tibble [100 × 3]>
3 paws.common_v0.7.1        38.4ms   51.8ms     18.4    23.82MB     13.3   100    72      5.43s <NULL> <Rprofmem [4,895 × 3]> <bench_tm [100]> <tibble [100 × 3]>
```

![image](https://github.com/paws-r/paws/assets/23235152/12e84516-9589-460e-8a00-4556d38c2122)

