### PR TITLE
Check for custom endpoint

### DIFF
--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -2,6 +2,7 @@
 * improve performance of `restxml_unmarshal` by x3
 * fix `rest_unmarshal_location_elements` only skip header if location is not found (#761)
 * support global `endpoint_url` in config file and environmental variables (#764), thanks to @James-G-Hill for raising issue
+* ensure custom endpoints aren't modified
 
 # paws.common 0.7.1
 * minor performance enhancements

--- a/paws.common/R/client.R
+++ b/paws.common/R/client.R
@@ -43,6 +43,7 @@ ClientConfig <- struct(
   config = Config(),
   handlers = Handlers(),
   endpoint = "",
+  custom_endpoint = FALSE,
   signing_region = "",
   signing_name = "",
   signing_name_derived = FALSE
@@ -54,6 +55,7 @@ ClientInfo <- struct(
   service_id = "",
   api_version = "",
   endpoint = "",
+  custom_endpoint = FALSE,
   signing_name = "",
   signing_region = "",
   json_version = "",
@@ -135,6 +137,7 @@ client_config <- function(service_name, endpoints, cfgs, service_id) {
   if (!is.null(cfgs)) {
     s$config <- cfgs
   }
+  custom_endpoint <- FALSE
   # If region not defined, set it
   if (nchar(s$config$region) == 0) {
     s$config$region <- get_region(cfgs[["credentials"]][["profile"]])
@@ -147,6 +150,7 @@ client_config <- function(service_name, endpoints, cfgs, service_id) {
     endpoint <- get_service_endpoint(cfgs[["credentials"]][["profile"]], service_id)
     if (!is.null(endpoint)) {
       signing_region <- region
+      custom_endpoint <- TRUE
     } else {
       sts_regional_endpoint <- s$config$sts_regional_endpoint
       e <- resolver_endpoint(service_name, region, endpoints, sts_regional_endpoint)
@@ -158,6 +162,7 @@ client_config <- function(service_name, endpoints, cfgs, service_id) {
     config = s$config,
     handlers = s$handlers,
     endpoint = endpoint,
+    custom_endpoint = custom_endpoint,
     signing_region = signing_region,
     signing_name = service_name
   )

--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -95,14 +95,6 @@ remove_bucket_from_url <- function(url) {
   return(url)
 }
 
-has_custom_endpoint <- function(endpoint, host_url) {
-  if (endpoint != "")
-    return(TRUE)
-  if (!grepl("^s3.*(amazonaws|c2s.ic|sc2s.sgov).*(com|cn|gov)$", host_url, perl=T))
-    return(TRUE)
-  return(FALSE)
-}
-
 update_endpoint_for_s3_config <- function(request) {
   if (is.null(bucket_name <- request$params[["Bucket"]])) {
     return(request)
@@ -124,8 +116,9 @@ update_endpoint_for_s3_config <- function(request) {
 
   use_virtual_host_style <- TRUE
   if (request$config$s3_force_path_style) use_virtual_host_style <- FALSE
-  if (has_custom_endpoint(request$config$endpoint, request$http_request$url$host))
+  if (request$client_info$custom_endpoint) {
     use_virtual_host_style <- FALSE
+  }
 
   if (use_virtual_host_style) {
     request$http_request$url <-

--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -31,27 +31,28 @@ convert_file_to_raw <- function(request) {
 }
 
 ################################################################################
-
-bucket_name_from_req_params <- function(request) {
-  request_params <- request$params
-  bucket <- request_params["Bucket"]
-
-  if (is.null(bucket)) {
-    return(NULL)
-  }
-
-  bucket_name <- bucket[[1]]
-
-  return(bucket_name)
-}
-
-host_compatible_bucket_name <- function(bucket) {
-  if (grepl(".", bucket, fixed = TRUE)) {
+# host_compatible_bucket_name returns true if the request should
+# put the bucket in the host. This is false if S3ForcePathStyle is
+# explicitly set or if the bucket is not DNS compatible.
+host_compatible_bucket_name <- function(url, bucket) {
+  # Bucket might be DNS compatible but dots in the hostname will fail
+  # certificate validation, so do not use host-style.
+  if (url$scheme == "https" && grepl(".", bucket, fixed = TRUE)) {
     return(FALSE)
   }
+  return(dns_compatible_bucket_name(bucket))
+}
+
+# dns_compatible_bucket_name returns true if the bucket name is DNS compatible.
+# Buckets created outside of the classic region MUST be DNS compatible.
+dns_compatible_bucket_name <- function(bucket) {
   domain <- "^[a-z0-9][a-z0-9\\.\\-]{1,61}[a-z0-9]$"
   ip_address <- "^(\\d+\\.){3}\\d+$"
-  return(grepl(domain, bucket) && !grepl(ip_address, bucket))
+  return(
+    grepl(domain, bucket) &&
+      !grepl(ip_address, bucket) &&
+      !grepl("..", bucket, fixed = T)
+  )
 }
 
 move_bucket_to_host <- function(url, bucket) {
@@ -94,10 +95,16 @@ remove_bucket_from_url <- function(url) {
   return(url)
 }
 
-update_endpoint_for_s3_config <- function(request) {
-  bucket_name <- bucket_name_from_req_params(request)
+has_custom_endpoint <- function(endpoint, host_url) {
+  if (endpoint != "")
+    return(TRUE)
+  if (!grepl("^s3.*(amazonaws|c2s.ic|sc2s.sgov).*(com|cn|gov)$", host_url, perl=T))
+    return(TRUE)
+  return(FALSE)
+}
 
-  if (is.null(bucket_name)) {
+update_endpoint_for_s3_config <- function(request) {
+  if (is.null(bucket_name <- request$params[["Bucket"]])) {
     return(request)
   }
 
@@ -107,7 +114,7 @@ update_endpoint_for_s3_config <- function(request) {
     return(request)
   }
 
-  if (!host_compatible_bucket_name(bucket_name)) {
+  if (!host_compatible_bucket_name(request$http_request$url, bucket_name)) {
     return(request)
   }
 
@@ -117,7 +124,8 @@ update_endpoint_for_s3_config <- function(request) {
 
   use_virtual_host_style <- TRUE
   if (request$config$s3_force_path_style) use_virtual_host_style <- FALSE
-  if (request$config$endpoint != "") use_virtual_host_style <- FALSE
+  if (has_custom_endpoint(request$config$endpoint, request$http_request$url$host))
+    use_virtual_host_style <- FALSE
 
   if (use_virtual_host_style) {
     request$http_request$url <-
@@ -354,7 +362,7 @@ s3_redirect_from_error <- function(request) {
   if (!can_be_redirected(request, error_code, error)) {
     return(request)
   }
-  bucket_name <- bucket_name_from_req_params(request)
+  bucket_name <- request$params[["Bucket"]]
   new_region <- s3_get_bucket_region(request$http_response, error)
   if (is.null(new_region)) {
     log_debug(

--- a/paws.common/R/service.R
+++ b/paws.common/R/service.R
@@ -123,6 +123,7 @@ new_service <- function(metadata, handlers, cfgs = NULL) {
 
   signing_name <- metadata$signing_name
   if (is.null(signing_name)) signing_name <- cfg$signing_name
+  custom_endpoint <- cfg$config$endpoint != "" || cfg$custom_endpoint
   client_info <- ClientInfo(
     service_name = metadata$service_name,
     service_id = metadata$service_id,
@@ -130,6 +131,7 @@ new_service <- function(metadata, handlers, cfgs = NULL) {
     signing_name = signing_name,
     signing_region = cfg$signing_region,
     endpoint = cfg$endpoint,
+    custom_endpoint = custom_endpoint,
     json_version = metadata$json_version,
     target_prefix = metadata$target_prefix
   )

--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -132,7 +132,7 @@ parse_query_string <- function(query) {
   query <- gsub("^\\?", "", query)
   params <- parse_in_half(strsplit(query, "&")[[1]], "=")
   if (length(params) == 0) {
-    return(NULL)
+    return(list())
   }
   out <- as.list(curl::curl_unescape(params[, 2]))
   names(out) <- curl::curl_unescape(params[, 1])

--- a/paws.common/tests/testthat/test_custom_s3.R
+++ b/paws.common/tests/testthat/test_custom_s3.R
@@ -37,12 +37,6 @@ test_that("update_endpoint_for_s3_config", {
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "s3.amazonaws.com")
 
-  # Use a path style URL if the config has a custom endpoint.
-  req <- build_request(bucket = "foo-bar", operation = "ListObjects")
-  req$config$endpoint <- "localhost:9000"
-  result <- update_endpoint_for_s3_config(req)
-  expect_equal(result$http_request$url$host, "s3.amazonaws.com")
-
   # Use a path style URL if the bucket name is not DNS compatible.
   req <- build_request(bucket = "foo.bar", operation = "ListObjects")
   result <- update_endpoint_for_s3_config(req)

--- a/paws.common/tests/testthat/test_custom_s3.R
+++ b/paws.common/tests/testthat/test_custom_s3.R
@@ -21,6 +21,12 @@ test_that("update_endpoint_for_s3_config", {
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "foo.s3.amazonaws.com")
 
+  # Don't modify URL when using custom host
+  req <- build_request(bucket = "foo-bar", operation = "ListObjects")
+  req$client_info$custom_endpoint <- TRUE
+  result <- update_endpoint_for_s3_config(req)
+  expect_equal(result$http_request$url$host, "s3.amazonaws.com")
+
   req <- build_request(bucket = "foo-bar", operation = "ListObjects")
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "foo-bar.s3.amazonaws.com")
@@ -46,12 +52,6 @@ test_that("update_endpoint_for_s3_config", {
   req <- build_request(bucket = "foo-bar", operation = "GetBucketLocation")
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "s3.amazonaws.com")
-
-  # Don't modify URL when using custom host
-  req <- build_request(bucket = "foo-bar", operation = "ListObjects")
-  req$http_request$url$host <- "127.0.0.1"
-  result <- update_endpoint_for_s3_config(req)
-  expect_equal(result$http_request$url$host, "127.0.0.1")
 })
 
 test_that("content_md5 works with an empty body", {

--- a/paws.common/tests/testthat/test_custom_s3.R
+++ b/paws.common/tests/testthat/test_custom_s3.R
@@ -46,6 +46,12 @@ test_that("update_endpoint_for_s3_config", {
   req <- build_request(bucket = "foo-bar", operation = "GetBucketLocation")
   result <- update_endpoint_for_s3_config(req)
   expect_equal(result$http_request$url$host, "s3.amazonaws.com")
+
+  # Don't modify URL when using custom host
+  req <- build_request(bucket = "foo-bar", operation = "ListObjects")
+  req$http_request$url$host <- "127.0.0.1"
+  result <- update_endpoint_for_s3_config(req)
+  expect_equal(result$http_request$url$host, "127.0.0.1")
 })
 
 test_that("content_md5 works with an empty body", {
@@ -284,7 +290,7 @@ test_that("ignore redirect when no http response is given", {
 test_that("ignore redirect when http status is successful", {
   for (status in c(200, 201, 202, 204, 206)) {
     req <- build_request(bucket = "foo", operation = "ListObjects")
-    req$http_response <- paws.common:::HttpResponse(
+    req$http_response <- HttpResponse(
       status_code = status,
       body = raw(0),
       header = list()
@@ -296,7 +302,7 @@ test_that("ignore redirect when http status is successful", {
 
 test_that("ignore redirect if already redirected", {
   req <- build_request(bucket = "foo", operation = "ListObjects")
-  req$http_response <- paws.common:::HttpResponse(
+  req$http_response <- HttpResponse(
     status_code = 301,
     body = charToRaw(paste0(
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>PermanentRedirect</Code>",
@@ -319,7 +325,7 @@ test_that("ignore redirect if unable to find S3 region", {
     "<Bucket>foo</Bucket></Error>"
   ))
   req <- build_request(bucket = "foo", operation = "ListObjects")
-  req$http_response <- paws.common:::HttpResponse(
+  req$http_response <- HttpResponse(
     status_code = 301,
     body = raw_error
   )
@@ -331,7 +337,7 @@ test_that("ignore redirect if unable to find S3 region", {
 
 test_that("redirect request from http response error", {
   req <- build_request(bucket = "foo", operation = "ListObjects")
-  req$http_response <- paws.common:::HttpResponse(
+  req$http_response <- HttpResponse(
     status_code = 301,
     body = charToRaw(paste0(
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>PermanentRedirect</Code>",
@@ -357,7 +363,7 @@ test_that("redirect request from http response error", {
 
 test_that("redirect error with region", {
   req <- build_request(bucket = "foo", operation = "ListObjects")
-  req$http_response <- paws.common:::HttpResponse(
+  req$http_response <- HttpResponse(
     status_code = 301,
     body = charToRaw(paste0(
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>PermanentRedirect</Code>",
@@ -380,7 +386,7 @@ test_that("redirect error with region", {
 
 test_that("redirect error without region", {
   req <- build_request(bucket = "foo", operation = "ListObjects")
-  req$http_response <- paws.common:::HttpResponse(
+  req$http_response <- HttpResponse(
     status_code = 301,
     body = charToRaw(paste0(
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>PermanentRedirect</Code>",

--- a/paws.common/tests/testthat/test_url.R
+++ b/paws.common/tests/testthat/test_url.R
@@ -25,6 +25,6 @@ test_that("missing query values become empty strings", {
 })
 
 test_that("empty queries become NULL", {
-  expect_equal(parse_query_string("?"), NULL)
-  expect_equal(parse_query_string(""), NULL)
+  expect_equal(parse_query_string("?"), list())
+  expect_equal(parse_query_string(""), list())
 })


### PR DESCRIPTION
Issue regarding custom endpoint not correctly being parse when provided from config file:

For example:

``` r
library(paws)
client <- s3(config(credentials(profile = "minio"), signature_version = "s3v4"))
client$generate_presigned_url("list_objects", params = list(Bucket = "demo"))
#> [1] "http://demo.127.0.0.1:9000/?X-Amz-Algorithm=..."
```

<sup>Created on 2024-04-02 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>

However it should be the following:

``` r
library(paws)
client <- s3(config(credentials(profile = "minio"), signature_version = "s3v4"))
client$generate_presigned_url("list_objects", params = list(Bucket = "demo"))
#> [1] "http://127.0.0.1:9000/demo?X-Amz-Algorithm=..."
```

<sup>Created on 2024-04-02 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>


