### PR TITLE
Enrich SSO error message

### DIFF
--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -1,5 +1,6 @@
 # paws.common 0.7.7.9000
 * migrate backend from httr to httr2
+* enrich sso message (#844). Thanks to @hadley for raising issue.
 
 # paws.common 0.7.7
 * fix unix time expiration check

--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -1,6 +1,8 @@
 # paws.common 0.7.7.9000
 * migrate backend from httr to httr2
 * enrich sso message (#844). Thanks to @hadley for raising issue.
+* attempt to automatically set/refresh `sso` credentials by calling `aws cli` (#844)
+* moved api log level to `debug` and `trace`. This is to prevent `info` level being saturated by api calls.
 
 # paws.common 0.7.7
 * fix unix time expiration check

--- a/paws.common/R/credential_providers.R
+++ b/paws.common/R/credential_providers.R
@@ -237,7 +237,7 @@ aws_sso_cmd <- function(profile_name, msg) {
   cmd <- sprintf("aws sso login --profile %s", profile_name)
   log_warn(msg, cmd)
   log_info(
-    "Please set `options(paws.aws_sso_creds = FALSE)` to turn off sso credentials automation"
+    "Set `options(paws.aws_sso_creds = FALSE)` to turn off sso credentials automation"
   )
   system(cmd, intern = T)
 }

--- a/paws.common/R/logging.R
+++ b/paws.common/R/logging.R
@@ -3,7 +3,7 @@
 
 # basic paws logging system
 # Error messages only shown
-# Levels: 4 = DEBUG, 3 = INFO/MSG, 2 = WARNING, 1 = ERROR
+# Levels: 5 = TRACE, 4 = DEBUG, 3 = INFO/MSG, 2 = WARNING, 1 = ERROR
 
 #' @importFrom utils modifyList flush.console
 
@@ -17,6 +17,7 @@
 #' * `paws.log_timestamp_fmt` (character): see [format.POSIXct()]
 #'
 #' @param level (integer) to determine the level logging threshold.
+#' * `5L`: TRACE
 #' * `4L`: DEBUG
 #' * `3L`: INFO
 #' * `2L`: WARNING
@@ -69,6 +70,12 @@ parse_msg <- function(...) {
   if (length(list(...)) == 1) paste(...) else sprintf(...)
 }
 
+log_trace <- function(...) {
+  if (isTRUE(getOption("paws.log_level") >= 5L)) {
+    log_msg("TRACE", parse_msg(...))
+  }
+}
+
 log_debug <- function(...) {
   if (isTRUE(getOption("paws.log_level") >= 4L)) {
     log_msg("DEBUG", parse_msg(...))
@@ -106,6 +113,7 @@ log_msg <- function(lvl, msg) {
 
 log_color <- function(lvl) {
   color <- switch(lvl,
+    TRACE = style_trace,
     DEBUG = style_debug,
     INFO = style_info,
     WARN = style_warn,
@@ -119,17 +127,10 @@ log_color <- function(lvl) {
 # https://github.com/r-lib/httr2/blob/8e9f8588e66378f1f419158cd1810a82a4dad022/R/req-options.R#L167-L187
 paws_debug <- function(type, msg) {
   switch(type + 1,
-         text = prefix_debug("*  ", msg),
-         headerIn = prefix_info("<- ", msg),
-         headerOut = prefix_info("-> ", msg)
+         text = prefix_trace("*  ", msg),
+         headerIn = prefix_debug("<- ", msg),
+         headerOut = prefix_debug("-> ", msg)
   )
-}
-
-prefix_info <- function(prefix, x) {
-  x <- readBin(x, character())
-  lines <- unlist(strsplit(x, "\r?\n", useBytes = TRUE))
-  out <- paste0(prefix, lines, collapse = "\n")
-  log_info(out)
 }
 
 prefix_debug <- function(prefix, x) {
@@ -137,6 +138,13 @@ prefix_debug <- function(prefix, x) {
   lines <- unlist(strsplit(x, "\r?\n", useBytes = TRUE))
   out <- paste0(prefix, lines, collapse = "\n")
   log_debug(out)
+}
+
+prefix_trace <- function(prefix, x) {
+  x <- readBin(x, character())
+  lines <- unlist(strsplit(x, "\r?\n", useBytes = TRUE))
+  out <- paste0(prefix, lines, collapse = "\n")
+  log_trace(out)
 }
 
 init_log_config <- function() {
@@ -173,11 +181,13 @@ init_log_styles <- function() {
     style_warn <- crayon::make_style("#EEBB50", colors = 256)
     style_info <- function(...) paste(...)
     style_debug <- crayon::make_style("#808080", grey = TRUE)
+    style_trace <- style_debug
   } else {
     style_error <- function(...) paste(...)
     style_warn <- style_error
     style_info <- style_error
     style_debug <- style_error
+    style_trace <- style_error
   }
 
   # make color functions available inside the package
@@ -185,4 +195,5 @@ init_log_styles <- function() {
   assign("style_warn", style_warn, envir = parent.env(environment()))
   assign("style_info", style_info, envir = parent.env(environment()))
   assign("style_debug", style_debug, envir = parent.env(environment()))
+  assign("style_trace", style_trace, envir = parent.env(environment()))
 }

--- a/paws.common/R/net.R
+++ b/paws.common/R/net.R
@@ -1,4 +1,4 @@
-#' @importFrom httr2 request req_body_raw req_options req_perform
+#' @importFrom httr2 request req_options req_perform
 
 #' @include struct.R
 #' @include url.R
@@ -137,7 +137,7 @@ request_aws <- function(url, http_request) {
   req$method <- http_request$method
   req$headers <- http_request$header
   req$policies$error_is_error <- function(resp) FALSE
-  req <- req_body_raw(req, http_request$body)
+  req$body <- list(data = http_request$body, type = "raw", content_type = "", params = list())
   req <- req_options(
     .req = req,
     timeout_ms = http_request$timeout * 1000,

--- a/paws.common/R/onLoad.R
+++ b/paws.common/R/onLoad.R
@@ -2,6 +2,7 @@
 #' @include logging.R
 
 .onLoad <- function(libname, pkgname) {
+  set_paws_options()
   init_log_config()
   init_log_styles()
   set_user_agent(pkgname)

--- a/paws.common/R/util.R
+++ b/paws.common/R/util.R
@@ -251,3 +251,10 @@ set_user_agent <- function(pkgname) {
   )
   assign("PAWS_USER_AGENT", user_agent, envir = getNamespace(pkgname))
 }
+
+set_paws_options <- function() {
+  paws_options <- list(
+    paws.aws_sso_creds = TRUE
+  )
+  do.call(options, paws_options)
+}

--- a/paws.common/R/util.R
+++ b/paws.common/R/util.R
@@ -256,5 +256,14 @@ set_paws_options <- function() {
   paws_options <- list(
     paws.aws_sso_creds = TRUE
   )
+  paws_options_names <- names(paws_options)
+
+  # check R options for log settings
+  r_options <- lapply(paws_options_names, getOption)
+  names(r_options) <- paws_options_names
+  paws_options <- modifyList(
+    paws_options, Filter(Negate(is.null), r_options)
+  )
+
   do.call(options, paws_options)
 }


### PR DESCRIPTION
- attempt to automatically set/refresh `sso` credentials by calling `aws cli`
- enrich sso error message
- move api log level to `debug` and `trace`. This is to prevent `info` level being saturated by api calls.

addresses ticket: #844 