### PR TITLE
only add body if verb is not head

### DIFF
--- a/paws.common/R/net.R
+++ b/paws.common/R/net.R
@@ -138,7 +138,7 @@ request_aws <- function(url, http_request) {
   req$method <- http_request$method
   req$headers <- http_request$header
   req$policies$error_is_error <- function(resp) FALSE
-  if (!is.null(http_request$body)) {
+  if (!is.null(http_request$body) && http_request$method != "HEAD") {
     req$body <- list(data = http_request$body, type = "raw", content_type = "", params = list())
   }
   req <- req_options(

--- a/paws.common/R/net.R
+++ b/paws.common/R/net.R
@@ -138,7 +138,7 @@ request_aws <- function(url, http_request) {
   req$method <- http_request$method
   req$headers <- http_request$header
   req$policies$error_is_error <- function(resp) FALSE
-  if (!is.null(http_request$body) && http_request$method != "HEAD") {
+  if (http_request$method != "HEAD") {
     req$body <- list(data = http_request$body, type = "raw", content_type = "", params = list())
   }
   req <- req_options(


### PR DESCRIPTION
Ensure head has empty body. This ensure head isn't turn off by post.

curl options:
- post: [httr2:::req_body_apply_raw](https://github.com/r-lib/httr2/blob/e6f425ee480b9b464a6ab552b6bf7360a1c2181c/R/req-body.R#L286-L295) which adds [CURLOPT_POST](https://curl.se/libcurl/c/CURLOPT_POST.html#:~:text=When%20setting%20CURLOPT_POST%20to%201,CURLOPT_NOBODY%20or%20CURLOPT_HTTPGET%20or%20similar.): 
>When setting [CURLOPT_POST](https://curl.se/libcurl/c/CURLOPT_POST.html) to 1, libcurl automatically sets [CURLOPT_NOBODY](https://curl.se/libcurl/c/CURLOPT_NOBODY.html) and [CURLOPT_HTTPGET](https://curl.se/libcurl/c/CURLOPT_HTTPGET.html) to 0
- nobody: [httr2:::req_method_apply](https://github.com/r-lib/httr2/blob/e6f425ee480b9b464a6ab552b6bf7360a1c2181c/R/req-method.R#L24-L33) which adds [CURLOPT_NOBODY](https://curl.se/libcurl/c/CURLOPT_NOBODY.html): 
> A long parameter set to 1 tells libcurl to not include the body-part in the output when doing what would otherwise be a download. For HTTP(S), this makes libcurl do a HEAD request


Fixes: #868