### PR TITLE
Js regex endpoints

### DIFF
--- a/paws.common/NEWS.md
+++ b/paws.common/NEWS.md
@@ -8,6 +8,7 @@
 * deprecated custom handler for `s3_unmarshal_select_object_content` in favour or new streamhandler
 * migrate `parse_url`, `parse_query_string` and `build_url` to `cpp` for performance improvement.
 * ensure `url` is set to lower case before signature
+* migrate vendor from `aws-sdk-js` to `aws-sdk-python` `boto3`.
 
 # paws.common 0.7.7
 * fix unix time expiration check

--- a/paws.common/R/client.R
+++ b/paws.common/R/client.R
@@ -84,14 +84,43 @@ HOST_PREFIX_RE <- "^[A-Za-z0-9\\.\\-]+$"
 
 # resolver_endpoint returns the endpoint for a given service.
 # e.g. "https://ec2.us-east-1.amazonaws.com"
-resolver_endpoint <- function(service, region, endpoints, sts_regional_endpoint = "", scheme = "https", host_prefix = "") {
-  switch(vendor_cache[["vendor"]],
-    "boto" = resolver_endpoint_boto(service, region, endpoints, sts_regional_endpoint, scheme, host_prefix),
-    "js" = resolver_endpoint_js(service, region, endpoints, sts_regional_endpoint, scheme, host_prefix)
+resolver_endpoint <- function(
+  service,
+  region,
+  endpoints,
+  sts_regional_endpoint = "",
+  scheme = "https",
+  host_prefix = ""
+) {
+  switch(
+    vendor_cache[["vendor"]],
+    "boto" = resolver_endpoint_boto(
+      service,
+      region,
+      endpoints,
+      sts_regional_endpoint,
+      scheme,
+      host_prefix
+    ),
+    "js" = resolver_endpoint_js(
+      service,
+      region,
+      endpoints,
+      sts_regional_endpoint,
+      scheme,
+      host_prefix
+    )
   )
 }
 
-resolver_endpoint_boto <- function(service, region, endpoints, sts_regional_endpoint, scheme, host_prefix) {
+resolver_endpoint_boto <- function(
+  service,
+  region,
+  endpoints,
+  sts_regional_endpoint,
+  scheme,
+  host_prefix
+) {
   # locate global endpoint
   global_found <- check_global(endpoints)
   global_region <- region == "aws-global"
@@ -99,12 +128,14 @@ resolver_endpoint_boto <- function(service, region, endpoints, sts_regional_endp
     stop("No region provided and no global region found.")
   }
   signing_region <- (
-    if (any(global_found) & global_region) names(global_found[global_found][1]) else region
+    if (any(global_found) & global_region)
+      names(global_found[global_found][1]) else region
   )
   e <- endpoints[[get_region_pattern(names(endpoints), signing_region)]]
   if (service == "sts" & nzchar(sts_regional_endpoint)) {
     e$endpoint <- set_sts_regional_endpoint(
-      sts_regional_endpoint, e
+      sts_regional_endpoint,
+      e
     )
     region <- set_sts_region(sts_regional_endpoint, region)
   }
@@ -115,14 +146,23 @@ resolver_endpoint_boto <- function(service, region, endpoints, sts_regional_endp
   }
   endpoint <- gsub("^(.+://)?", sprintf("%s://", scheme), endpoint)
 
-  return(list(
-    endpoint = endpoint,
-    signing_region = signing_region
-  ))
+  return(
+    list(
+      endpoint = endpoint,
+      signing_region = signing_region
+    )
+  )
 }
 
 # Support paws < 0.8.0
-resolver_endpoint_js <- function(service, region, endpoints, sts_regional_endpoint, scheme, host_prefix) {
+resolver_endpoint_js <- function(
+  service,
+  region,
+  endpoints,
+  sts_regional_endpoint,
+  scheme,
+  host_prefix
+) {
   # Set default region for s3:
   # https://github.com/boto/botocore/blob/develop/botocore/regions.py#L189-L220
   if (service == "s3" & (region == "aws-global")) {
@@ -135,7 +175,8 @@ resolver_endpoint_js <- function(service, region, endpoints, sts_regional_endpoi
     stop("No region provided and no global region found.")
   }
   search_region <- (
-    if (any(global_found) & global_region) names(global_found[global_found][1]) else region
+    if (any(global_found) & global_region)
+      names(global_found[global_found][1]) else region
   )
   e <- endpoints[[get_region_pattern_js(names(endpoints), search_region)]]
   if (is.character(e)) {
@@ -143,7 +184,8 @@ resolver_endpoint_js <- function(service, region, endpoints, sts_regional_endpoi
   }
   if (service == "sts" & nzchar(sts_regional_endpoint)) {
     e$endpoint <- set_sts_regional_endpoint(
-      sts_regional_endpoint, e
+      sts_regional_endpoint,
+      e
     )
     region <- set_sts_region(sts_regional_endpoint, region)
   }
@@ -154,14 +196,17 @@ resolver_endpoint_js <- function(service, region, endpoints, sts_regional_endpoi
   }
   endpoint <- gsub("^(.+://)?", sprintf("%s://", scheme), endpoint)
 
-  return(list(
-    endpoint = endpoint,
-    signing_region = signing_region
-  ))
+  return(
+    list(
+      endpoint = endpoint,
+      signing_region = signing_region
+    )
+  )
 }
 
 set_sts_regional_endpoint <- function(sts_regional_endpoint, endpoint) {
-  switch(sts_regional_endpoint,
+  switch(
+    sts_regional_endpoint,
     "legacy" = "sts.amazonaws.com",
     "regional" = "sts.{region}.amazonaws.com",
     endpoint
@@ -169,15 +214,18 @@ set_sts_regional_endpoint <- function(sts_regional_endpoint, endpoint) {
 }
 
 set_sts_region <- function(sts_regional_endpoint, region) {
-  switch(sts_regional_endpoint,
-    "legacy" = "us-east-1",
-    "regional" = region
-  )
+  switch(sts_regional_endpoint, "legacy" = "us-east-1", "regional" = region)
 }
 
 # client_config returns a ClientConfig configured for the service.
 # client_config returns a ClientConfig configured for the service.
-client_config <- function(service_name, endpoints, cfgs, service_id, operation = Operation()) {
+client_config <- function(
+  service_name,
+  endpoints,
+  cfgs,
+  service_id,
+  operation = Operation()
+) {
   sess <- new_session()
   if (!is.null(cfgs)) {
     sess$config <- cfgs
@@ -191,7 +239,10 @@ client_config <- function(service_name, endpoints, cfgs, service_id, operation =
   if (sess$config$endpoint != "") {
     endpoint <- sess$config$endpoint
   } else {
-    endpoint <- get_service_endpoint(sess$config[["credentials"]][["profile"]], service_id)
+    endpoint <- get_service_endpoint(
+      sess$config[["credentials"]][["profile"]],
+      service_id
+    )
     if (!is.null(endpoint)) {
       custom_endpoint <- TRUE
     } else {

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -102,8 +102,14 @@ set_config <- function(svc, cfgs = list()) {
 set_paws_vendor <- function() {
   where <- topenv(parent.frame(n = 2))
   pkg_name <- get0(".packageName", where, inherits = FALSE)
-  if (!is.null(pkg_name) && startsWith(pkg_name, "paws.")) {
-    vendor <- (if (packageVersion(pkg_name) >= numeric_version("0.8.0")) "boto" else "js")
+  if (
+    !is.null(pkg_name) &&
+      startsWith(pkg_name, "paws.") &&
+      pkg_name != "paws.common"
+  ) {
+    vendor <- (
+      if (packageVersion(pkg_name) >= numeric_version("0.8.0")) "boto" else "js"
+    )
     vendor_cache[["vendor"]] <- vendor
   }
 }
@@ -198,7 +204,9 @@ get_iam_role <- function() {
 get_instance_metadata <- function(query_path = "") {
   token_ttl <- "21600" # same approach as in boto3: https://github.com/boto/botocore/blob/master/botocore/utils.py#L376
   # Do not get metadata when the disabled setting is on.
-  if (trimws(tolower(get_env("AWS_EC2_METADATA_DISABLED"))) %in% c("true", "1")) {
+  if (
+    trimws(tolower(get_env("AWS_EC2_METADATA_DISABLED"))) %in% c("true", "1")
+  ) {
     return(NULL)
   }
   # Get token timeout for IMDSv2 tokens
@@ -221,7 +229,10 @@ get_instance_metadata <- function(query_path = "") {
       NULL
     }
   )
-  if (!is.null(metadata_token_response) && metadata_token_response$status_code == 200) {
+  if (
+    !is.null(metadata_token_response) &&
+      metadata_token_response$status_code == 200
+  ) {
     if (length(metadata_token_response[["body"]]) > 0) {
       token <- rawToChar(metadata_token_response[["body"]])
     }
@@ -353,7 +364,9 @@ check_config_file_endpoint <- function(profile = "", service_id = "") {
   if (is.null(service_name <- profile[["services"]])) {
     return(profile[["endpoint_url"]])
   }
-  profile_service <- config_values[[paste("services", service_name)]][[service_id]]
+  profile_service <- config_values[[paste("services", service_name)]][[
+    service_id
+  ]]
   if (is.null(profile_service)) {
     return(profile[["endpoint_url"]])
   }
@@ -402,7 +415,12 @@ get_web_identity_token_file <- function(web_identity_token_file = "") {
 
 # Get the Web Identity Token from reading the token file
 get_web_identity_token <- function(web_identity_token_file = "") {
-  return(readLines(get_web_identity_token_file(web_identity_token_file), warn = FALSE))
+  return(
+    readLines(
+      get_web_identity_token_file(web_identity_token_file),
+      warn = FALSE
+    )
+  )
 }
 
 # Check if sts_regional_endpoint is present in config file
@@ -460,7 +478,9 @@ build_config <- function(cfg) {
       for (credentails_name in credentails_names) {
         if (credentails_name == "creds") {
           for (cred_name in cred_names) {
-            creds[[cred_name]] <- cfg[[cfg_name]][[credentails_name]][[cred_name]]
+            creds[[cred_name]] <- cfg[[cfg_name]][[credentails_name]][[
+              cred_name
+            ]]
           }
           credentials[[credentails_name]] <- add_list(creds)
         } else {

--- a/paws.common/R/credential_sso.R
+++ b/paws.common/R/credential_sso.R
@@ -4,7 +4,7 @@
 
 .sso$metadata <- list(
   service_name = "sso",
-  endpoints = list("^(us|eu|ap|sa|ca|me|af|il|mx)\\-\\w+\\-\\d+$" = list(endpoint = "portal.sso.{region}.amazonaws.com", global = FALSE), "^cn\\-\\w+\\-\\d+$" = list(endpoint = "portal.sso.{region}.amazonaws.com.cn", global = FALSE), "^us\\-gov\\-\\w+\\-\\d+$" = list(endpoint = "portal.sso.{region}.amazonaws.com", global = FALSE), "^us\\-iso\\-\\w+\\-\\d+$" = list(endpoint = "portal.sso.{region}.c2s.ic.gov", global = FALSE), "^us\\-isob\\-\\w+\\-\\d+$" = list(endpoint = "portal.sso.{region}.sc2s.sgov.gov", global = FALSE), "^eu\\-isoe\\-\\w+\\-\\d+$" = list(endpoint = "portal.sso.{region}.cloud.adc-e.uk", global = FALSE), "^us\\-isof\\-\\w+\\-\\d+$" = list(endpoint = "portal.sso.{region}.csp.hci.ic.gov", global = FALSE)),
+  endpoints = list(),
   service_id = "SSO",
   api_version = "2019-06-10",
   signing_name = "awsssoportal",
@@ -12,20 +12,131 @@
   target_prefix = ""
 )
 
+.sso_endpoint <- function() {
+  switch(
+    vendor_cache[["vendor"]],
+    "boto" = list(
+      "^(us|eu|ap|sa|ca|me|af|il|mx)\\-\\w+\\-\\d+$" = list(
+        endpoint = "portal.sso.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "^cn\\-\\w+\\-\\d+$" = list(
+        endpoint = "portal.sso.{region}.amazonaws.com.cn",
+        global = FALSE
+      ),
+      "^us\\-gov\\-\\w+\\-\\d+$" = list(
+        endpoint = "portal.sso.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "^us\\-iso\\-\\w+\\-\\d+$" = list(
+        endpoint = "portal.sso.{region}.c2s.ic.gov",
+        global = FALSE
+      ),
+      "^us\\-isob\\-\\w+\\-\\d+$" = list(
+        endpoint = "portal.sso.{region}.sc2s.sgov.gov",
+        global = FALSE
+      ),
+      "^eu\\-isoe\\-\\w+\\-\\d+$" = list(
+        endpoint = "portal.sso.{region}.cloud.adc-e.uk",
+        global = FALSE
+      ),
+      "^us\\-isof\\-\\w+\\-\\d+$" = list(
+        endpoint = "portal.sso.{region}.csp.hci.ic.gov",
+        global = FALSE
+      )
+    ),
+    "js" = list(
+      "*" = list(
+        endpoint = "portal.sso.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "cn-*" = list(
+        endpoint = "portal.sso.{region}.amazonaws.com.cn",
+        global = FALSE
+      ),
+      "eu-isoe-*" = list(
+        endpoint = "portal.sso.{region}.cloud.adc-e.uk",
+        global = FALSE
+      ),
+      "us-iso-*" = list(
+        endpoint = "portal.sso.{region}.c2s.ic.gov",
+        global = FALSE
+      ),
+      "us-isob-*" = list(
+        endpoint = "portal.sso.{region}.sc2s.sgov.gov",
+        global = FALSE
+      ),
+      "us-isof-*" = list(
+        endpoint = "portal.sso.{region}.csp.hci.ic.gov",
+        global = FALSE
+      )
+    )
+  )
+}
+
 .sso$service <- function(config = list()) {
   handlers <- new_handlers("restjson", "v4")
+  .sso$metadata$endpoints <- .sso_endpoint()
   new_service(.sso$metadata, handlers, config)
 }
 
 .sso$get_role_credentials_input <- function(...) {
   args <- c(as.list(environment()), list(...))
-  shape <- structure(list(roleName = structure(logical(0), tags = list(location = "querystring", locationName = "role_name", type = "string")), accountId = structure(logical(0), tags = list(location = "querystring", locationName = "account_id", type = "string")), accessToken = structure(logical(0), tags = list(location = "header", locationName = "x-amz-sso_bearer_token", type = "string", sensitive = TRUE))), tags = list(type = "structure"))
+  shape <- structure(
+    list(
+      roleName = structure(
+        logical(0),
+        tags = list(
+          location = "querystring",
+          locationName = "role_name",
+          type = "string"
+        )
+      ),
+      accountId = structure(
+        logical(0),
+        tags = list(
+          location = "querystring",
+          locationName = "account_id",
+          type = "string"
+        )
+      ),
+      accessToken = structure(
+        logical(0),
+        tags = list(
+          location = "header",
+          locationName = "x-amz-sso_bearer_token",
+          type = "string",
+          sensitive = TRUE
+        )
+      )
+    ),
+    tags = list(type = "structure")
+  )
   return(populate(args, shape))
 }
 
 .sso$get_role_credentials_output <- function(...) {
   args <- c(as.list(environment()), list(...))
-  shape <- structure(list(roleCredentials = structure(list(accessKeyId = structure(logical(0), tags = list(type = "string")), secretAccessKey = structure(logical(0), tags = list(type = "string", sensitive = TRUE)), sessionToken = structure(logical(0), tags = list(type = "string", sensitive = TRUE)), expiration = structure(logical(0), tags = list(type = "long"))), tags = list(type = "structure"))), tags = list(type = "structure"))
+  shape <- structure(
+    list(
+      roleCredentials = structure(
+        list(
+          accessKeyId = structure(logical(0), tags = list(type = "string")),
+          secretAccessKey = structure(
+            logical(0),
+            tags = list(type = "string", sensitive = TRUE)
+          ),
+          sessionToken = structure(
+            logical(0),
+            tags = list(type = "string", sensitive = TRUE)
+          ),
+          expiration = structure(logical(0), tags = list(type = "long"))
+        ),
+        tags = list(type = "structure")
+      )
+    ),
+    tags = list(type = "structure")
+  )
   return(populate(args, shape))
 }
 
@@ -36,7 +147,11 @@ sso_get_role_credentials <- function(roleName, accountId, accessToken) {
     http_path = "/federation/credentials",
     paginator = list()
   )
-  input <- .sso$get_role_credentials_input(roleName = roleName, accountId = accountId, accessToken = accessToken)
+  input <- .sso$get_role_credentials_input(
+    roleName = roleName,
+    accountId = accountId,
+    accessToken = accessToken
+  )
   output <- .sso$get_role_credentials_output()
   config <- get_config()
   svc <- .sso$service(config)

--- a/paws.common/R/credential_sts.R
+++ b/paws.common/R/credential_sts.R
@@ -23,7 +23,7 @@ sts <- function(config = list()) {
 
 .sts$metadata <- list(
   service_name = "sts",
-  endpoints = list("aws-global" = list(endpoint = "sts.amazonaws.com", global = TRUE), "us-east-1" = list(endpoint = "sts.amazonaws.com", global = TRUE), "^(us|eu|ap|sa|ca|me|af|il|mx)\\-\\w+\\-\\d+$" = list(endpoint = "sts.{region}.amazonaws.com", global = FALSE), "^cn\\-\\w+\\-\\d+$" = list(endpoint = "sts.{region}.amazonaws.com.cn", global = FALSE), "^us\\-gov\\-\\w+\\-\\d+$" = list(endpoint = "sts.{region}.amazonaws.com", global = FALSE), "^us\\-iso\\-\\w+\\-\\d+$" = list(endpoint = "sts.{region}.c2s.ic.gov", global = FALSE), "^us\\-isob\\-\\w+\\-\\d+$" = list(endpoint = "sts.{region}.sc2s.sgov.gov", global = FALSE), "^eu\\-isoe\\-\\w+\\-\\d+$" = list(endpoint = "sts.{region}.cloud.adc-e.uk", global = FALSE), "^us\\-isof\\-\\w+\\-\\d+$" = list(endpoint = "sts.{region}.csp.hci.ic.gov", global = FALSE)),
+  endpoints = list(),
   service_id = "STS",
   api_version = "2011-06-15",
   signing_name = NULL,
@@ -31,8 +31,68 @@ sts <- function(config = list()) {
   target_prefix = ""
 )
 
+.sts_endpoint <- function() {
+  switch(
+    vendor_cache[["vendor"]],
+    "boto" = list(
+      "aws-global" = list(endpoint = "sts.amazonaws.com", global = TRUE),
+      "us-east-1" = list(endpoint = "sts.amazonaws.com", global = TRUE),
+      "^(us|eu|ap|sa|ca|me|af|il|mx)\\-\\w+\\-\\d+$" = list(
+        endpoint = "sts.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "^cn\\-\\w+\\-\\d+$" = list(
+        endpoint = "sts.{region}.amazonaws.com.cn",
+        global = FALSE
+      ),
+      "^us\\-gov\\-\\w+\\-\\d+$" = list(
+        endpoint = "sts.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "^us\\-iso\\-\\w+\\-\\d+$" = list(
+        endpoint = "sts.{region}.c2s.ic.gov",
+        global = FALSE
+      ),
+      "^us\\-isob\\-\\w+\\-\\d+$" = list(
+        endpoint = "sts.{region}.sc2s.sgov.gov",
+        global = FALSE
+      ),
+      "^eu\\-isoe\\-\\w+\\-\\d+$" = list(
+        endpoint = "sts.{region}.cloud.adc-e.uk",
+        global = FALSE
+      ),
+      "^us\\-isof\\-\\w+\\-\\d+$" = list(
+        endpoint = "sts.{region}.csp.hci.ic.gov",
+        global = FALSE
+      )
+    ),
+    "js" = list(
+      "*" = list(endpoint = "https://sts.amazonaws.com", global = TRUE),
+      "us-gov-*" = list(
+        endpoint = "sts.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "cn-*" = list(endpoint = "sts.{region}.amazonaws.com.cn", global = FALSE),
+      "eu-isoe-*" = list(
+        endpoint = "sts.{region}.cloud.adc-e.uk",
+        global = FALSE
+      ),
+      "us-iso-*" = list(endpoint = "sts.{region}.c2s.ic.gov", global = FALSE),
+      "us-isob-*" = list(
+        endpoint = "sts.{region}.sc2s.sgov.gov",
+        global = FALSE
+      ),
+      "us-isof-*" = list(
+        endpoint = "sts.{region}.csp.hci.ic.gov",
+        global = FALSE
+      )
+    )
+  )
+}
+
 .sts$service <- function(config = list()) {
   handlers <- new_handlers("query", "v4")
+  .sts$metadata$endpoints <- .sts_endpoint()
   new_service(.sts$metadata, handlers, config)
 }
 
@@ -40,13 +100,70 @@ sts <- function(config = list()) {
 # Docs: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
 .sts$assume_role_input <- function(...) {
   args <- c(as.list(environment()), list(...))
-  shape <- structure(list(RoleArn = structure(logical(0), tags = list(type = "string")), RoleSessionName = structure(logical(0), tags = list(type = "string")), PolicyArns = structure(list(structure(list(arn = structure(logical(0), tags = list(type = "string"))), tags = list(type = "structure"))), tags = list(type = "list")), Policy = structure(logical(0), tags = list(type = "string")), DurationSeconds = structure(logical(0), tags = list(type = "integer")), Tags = structure(list(structure(list(Key = structure(logical(0), tags = list(type = "string")), Value = structure(logical(0), tags = list(type = "string"))), tags = list(type = "structure"))), tags = list(type = "list")), TransitiveTagKeys = structure(list(structure(logical(0), tags = list(type = "string"))), tags = list(type = "list")), ExternalId = structure(logical(0), tags = list(type = "string")), SerialNumber = structure(logical(0), tags = list(type = "string")), TokenCode = structure(logical(0), tags = list(type = "string"))), tags = list(type = "structure"))
+  shape <- structure(
+    list(
+      RoleArn = structure(logical(0), tags = list(type = "string")),
+      RoleSessionName = structure(logical(0), tags = list(type = "string")),
+      PolicyArns = structure(
+        list(
+          structure(
+            list(arn = structure(logical(0), tags = list(type = "string"))),
+            tags = list(type = "structure")
+          )
+        ),
+        tags = list(type = "list")
+      ),
+      Policy = structure(logical(0), tags = list(type = "string")),
+      DurationSeconds = structure(logical(0), tags = list(type = "integer")),
+      Tags = structure(
+        list(
+          structure(
+            list(
+              Key = structure(logical(0), tags = list(type = "string")),
+              Value = structure(logical(0), tags = list(type = "string"))
+            ),
+            tags = list(type = "structure")
+          )
+        ),
+        tags = list(type = "list")
+      ),
+      TransitiveTagKeys = structure(
+        list(structure(logical(0), tags = list(type = "string"))),
+        tags = list(type = "list")
+      ),
+      ExternalId = structure(logical(0), tags = list(type = "string")),
+      SerialNumber = structure(logical(0), tags = list(type = "string")),
+      TokenCode = structure(logical(0), tags = list(type = "string"))
+    ),
+    tags = list(type = "structure")
+  )
   return(populate(args, shape))
 }
 
 .sts$assume_role_output <- function(...) {
   args <- c(as.list(environment()), list(...))
-  shape <- structure(list(Credentials = structure(list(AccessKeyId = structure(logical(0), tags = list(type = "string")), SecretAccessKey = structure(logical(0), tags = list(type = "string")), SessionToken = structure(logical(0), tags = list(type = "string")), Expiration = structure(logical(0), tags = list(type = "timestamp"))), tags = list(type = "structure")), AssumedRoleUser = structure(list(AssumedRoleId = structure(logical(0), tags = list(type = "string")), Arn = structure(logical(0), tags = list(type = "string"))), tags = list(type = "structure")), PackedPolicySize = structure(logical(0), tags = list(type = "integer"))), tags = list(type = "structure", resultWrapper = "AssumeRoleResult"))
+  shape <- structure(
+    list(
+      Credentials = structure(
+        list(
+          AccessKeyId = structure(logical(0), tags = list(type = "string")),
+          SecretAccessKey = structure(logical(0), tags = list(type = "string")),
+          SessionToken = structure(logical(0), tags = list(type = "string")),
+          Expiration = structure(logical(0), tags = list(type = "timestamp"))
+        ),
+        tags = list(type = "structure")
+      ),
+      AssumedRoleUser = structure(
+        list(
+          AssumedRoleId = structure(logical(0), tags = list(type = "string")),
+          Arn = structure(logical(0), tags = list(type = "string"))
+        ),
+        tags = list(type = "structure")
+      ),
+      PackedPolicySize = structure(logical(0), tags = list(type = "integer"))
+    ),
+    tags = list(type = "structure", resultWrapper = "AssumeRoleResult")
+  )
   return(populate(args, shape))
 }
 
@@ -55,14 +172,36 @@ sts <- function(config = list()) {
 # temporary credentials consist of an access key ID, a secret access key,
 # and a security token. Typically, you use `AssumeRole` within your
 # account or for cross-account access.
-sts_assume_role <- function(RoleArn, RoleSessionName, PolicyArns = NULL, Policy = NULL, DurationSeconds = NULL, Tags = NULL, TransitiveTagKeys = NULL, ExternalId = NULL, SerialNumber = NULL, TokenCode = NULL) {
+sts_assume_role <- function(
+  RoleArn,
+  RoleSessionName,
+  PolicyArns = NULL,
+  Policy = NULL,
+  DurationSeconds = NULL,
+  Tags = NULL,
+  TransitiveTagKeys = NULL,
+  ExternalId = NULL,
+  SerialNumber = NULL,
+  TokenCode = NULL
+) {
   op <- new_operation(
     name = "AssumeRole",
     http_method = "POST",
     http_path = "/",
     paginator = list()
   )
-  input <- .sts$assume_role_input(RoleArn = RoleArn, RoleSessionName = RoleSessionName, PolicyArns = PolicyArns, Policy = Policy, DurationSeconds = DurationSeconds, Tags = Tags, TransitiveTagKeys = TransitiveTagKeys, ExternalId = ExternalId, SerialNumber = SerialNumber, TokenCode = TokenCode)
+  input <- .sts$assume_role_input(
+    RoleArn = RoleArn,
+    RoleSessionName = RoleSessionName,
+    PolicyArns = PolicyArns,
+    Policy = Policy,
+    DurationSeconds = DurationSeconds,
+    Tags = Tags,
+    TransitiveTagKeys = TransitiveTagKeys,
+    ExternalId = ExternalId,
+    SerialNumber = SerialNumber,
+    TokenCode = TokenCode
+  )
   output <- .sts$assume_role_output()
   config <- get_config()
   svc <- .sts$service(config)
@@ -77,24 +216,90 @@ sts_assume_role <- function(RoleArn, RoleSessionName, PolicyArns = NULL, Policy 
 # Docs: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html
 .sts$assume_role_with_web_identity_input <- function(...) {
   args <- c(as.list(environment()), list(...))
-  shape <- structure(list(RoleArn = structure(logical(0), tags = list(type = "string")), RoleSessionName = structure(logical(0), tags = list(type = "string")), WebIdentityToken = structure(logical(0), tags = list(type = "string")), ProviderId = structure(logical(0), tags = list(type = "string")), PolicyArns = structure(list(structure(list(arn = structure(logical(0), tags = list(type = "string"))), tags = list(type = "structure"))), tags = list(type = "list")), Policy = structure(logical(0), tags = list(type = "string")), DurationSeconds = structure(logical(0), tags = list(type = "integer"))), tags = list(type = "structure"))
+  shape <- structure(
+    list(
+      RoleArn = structure(logical(0), tags = list(type = "string")),
+      RoleSessionName = structure(logical(0), tags = list(type = "string")),
+      WebIdentityToken = structure(logical(0), tags = list(type = "string")),
+      ProviderId = structure(logical(0), tags = list(type = "string")),
+      PolicyArns = structure(
+        list(
+          structure(
+            list(arn = structure(logical(0), tags = list(type = "string"))),
+            tags = list(type = "structure")
+          )
+        ),
+        tags = list(type = "list")
+      ),
+      Policy = structure(logical(0), tags = list(type = "string")),
+      DurationSeconds = structure(logical(0), tags = list(type = "integer"))
+    ),
+    tags = list(type = "structure")
+  )
   return(populate(args, shape))
 }
 
 .sts$assume_role_with_web_identity_output <- function(...) {
   args <- c(as.list(environment()), list(...))
-  shape <- structure(list(Credentials = structure(list(AccessKeyId = structure(logical(0), tags = list(type = "string")), SecretAccessKey = structure(logical(0), tags = list(type = "string")), SessionToken = structure(logical(0), tags = list(type = "string")), Expiration = structure(logical(0), tags = list(type = "timestamp"))), tags = list(type = "structure")), SubjectFromWebIdentityToken = structure(logical(0), tags = list(type = "string")), AssumedRoleUser = structure(list(AssumedRoleId = structure(logical(0), tags = list(type = "string")), Arn = structure(logical(0), tags = list(type = "string"))), tags = list(type = "structure")), PackedPolicySize = structure(logical(0), tags = list(type = "integer")), Provider = structure(logical(0), tags = list(type = "string")), Audience = structure(logical(0), tags = list(type = "string")), SourceIdentity = structure(logical(0), tags = list(type = "string"))), tags = list(type = "structure", resultWrapper = "AssumeRoleWithWebIdentityResult"))
+  shape <- structure(
+    list(
+      Credentials = structure(
+        list(
+          AccessKeyId = structure(logical(0), tags = list(type = "string")),
+          SecretAccessKey = structure(logical(0), tags = list(type = "string")),
+          SessionToken = structure(logical(0), tags = list(type = "string")),
+          Expiration = structure(logical(0), tags = list(type = "timestamp"))
+        ),
+        tags = list(type = "structure")
+      ),
+      SubjectFromWebIdentityToken = structure(
+        logical(0),
+        tags = list(type = "string")
+      ),
+      AssumedRoleUser = structure(
+        list(
+          AssumedRoleId = structure(logical(0), tags = list(type = "string")),
+          Arn = structure(logical(0), tags = list(type = "string"))
+        ),
+        tags = list(type = "structure")
+      ),
+      PackedPolicySize = structure(logical(0), tags = list(type = "integer")),
+      Provider = structure(logical(0), tags = list(type = "string")),
+      Audience = structure(logical(0), tags = list(type = "string")),
+      SourceIdentity = structure(logical(0), tags = list(type = "string"))
+    ),
+    tags = list(
+      type = "structure",
+      resultWrapper = "AssumeRoleWithWebIdentityResult"
+    )
+  )
   return(populate(args, shape))
 }
 
-sts_assume_role_with_web_identity <- function(RoleArn, RoleSessionName, WebIdentityToken, ProviderId = NULL, PolicyArns = NULL, Policy = NULL, DurationSeconds = NULL) {
+sts_assume_role_with_web_identity <- function(
+  RoleArn,
+  RoleSessionName,
+  WebIdentityToken,
+  ProviderId = NULL,
+  PolicyArns = NULL,
+  Policy = NULL,
+  DurationSeconds = NULL
+) {
   op <- new_operation(
     name = "AssumeRoleWithWebIdentity",
     http_method = "POST",
     http_path = "/",
     paginator = list()
   )
-  input <- .sts$assume_role_with_web_identity_input(RoleArn = RoleArn, RoleSessionName = RoleSessionName, WebIdentityToken = WebIdentityToken, ProviderId = ProviderId, PolicyArns = PolicyArns, Policy = Policy, DurationSeconds = DurationSeconds)
+  input <- .sts$assume_role_with_web_identity_input(
+    RoleArn = RoleArn,
+    RoleSessionName = RoleSessionName,
+    WebIdentityToken = WebIdentityToken,
+    ProviderId = ProviderId,
+    PolicyArns = PolicyArns,
+    Policy = Policy,
+    DurationSeconds = DurationSeconds
+  )
   output <- .sts$assume_role_with_web_identity_output()
   config <- get_config()
   svc <- .sts$service(config)

--- a/paws.common/R/head_bucket.R
+++ b/paws.common/R/head_bucket.R
@@ -1,22 +1,10 @@
-s3_endpoints <- list(
-  "aws-global" = list(endpoint = "s3.amazonaws.com", global = TRUE),
-  "us-east-1" = list(endpoint = "s3.amazonaws.com", global = TRUE),
-  "^(us|eu|ap|sa|ca|me|af|il|mx)\\-\\w+\\-\\d+$" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
-  "^cn\\-\\w+\\-\\d+$" = list(endpoint = "s3.{region}.amazonaws.com.cn", global = FALSE),
-  "^us\\-gov\\-\\w+\\-\\d+$" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
-  "^us\\-iso\\-\\w+\\-\\d+$" = list(endpoint = "s3.{region}.c2s.ic.gov", global = FALSE),
-  "^us\\-isob\\-\\w+\\-\\d+$" = list(endpoint = "s3.{region}.sc2s.sgov.gov", global = FALSE),
-  "^eu\\-isoe\\-\\w+\\-\\d+$" = list(endpoint = "s3.{region}.cloud.adc-e.uk", global = FALSE),
-  "^us\\-isof\\-\\w+\\-\\d+$" = list(endpoint = "s3.{region}.csp.hci.ic.gov", global = FALSE)
-)
-
 .s3 <- list()
 
 .s3$operations <- list()
 
 .s3$metadata <- list(
   service_name = "s3",
-  endpoints = s3_endpoints,
+  endpoints = list(),
   service_id = "S3",
   api_version = "2006-03-01",
   signing_name = "s3",
@@ -24,20 +12,162 @@ s3_endpoints <- list(
   target_prefix = ""
 )
 
+.s3_endpoint <- function() {
+  switch(
+    vendor_cache[["vendor"]],
+    "boto" = list(
+      "aws-global" = list(endpoint = "s3.amazonaws.com", global = TRUE),
+      "us-east-1" = list(endpoint = "s3.amazonaws.com", global = TRUE),
+      "^(us|eu|ap|sa|ca|me|af|il|mx)\\-\\w+\\-\\d+$" = list(
+        endpoint = "s3.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "^cn\\-\\w+\\-\\d+$" = list(
+        endpoint = "s3.{region}.amazonaws.com.cn",
+        global = FALSE
+      ),
+      "^us\\-gov\\-\\w+\\-\\d+$" = list(
+        endpoint = "s3.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "^us\\-iso\\-\\w+\\-\\d+$" = list(
+        endpoint = "s3.{region}.c2s.ic.gov",
+        global = FALSE
+      ),
+      "^us\\-isob\\-\\w+\\-\\d+$" = list(
+        endpoint = "s3.{region}.sc2s.sgov.gov",
+        global = FALSE
+      ),
+      "^eu\\-isoe\\-\\w+\\-\\d+$" = list(
+        endpoint = "s3.{region}.cloud.adc-e.uk",
+        global = FALSE
+      ),
+      "^us\\-isof\\-\\w+\\-\\d+$" = list(
+        endpoint = "s3.{region}.csp.hci.ic.gov",
+        global = FALSE
+      )
+    ),
+    "js" = list(
+      "us-gov-west-1" = list(
+        endpoint = "s3.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "us-west-1" = list(
+        endpoint = "s3.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "us-west-2" = list(
+        endpoint = "s3.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "eu-west-1" = list(
+        endpoint = "s3.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "ap-southeast-1" = list(
+        endpoint = "s3.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "ap-southeast-2" = list(
+        endpoint = "s3.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "ap-northeast-1" = list(
+        endpoint = "s3.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "sa-east-1" = list(
+        endpoint = "s3.{region}.amazonaws.com",
+        global = FALSE
+      ),
+      "us-east-1" = list(endpoint = "s3.amazonaws.com", global = FALSE),
+      "*" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+      "cn-*" = list(endpoint = "s3.{region}.amazonaws.com.cn", global = FALSE),
+      "eu-isoe-*" = list(
+        endpoint = "s3.{region}.cloud.adc-e.uk",
+        global = FALSE
+      ),
+      "us-iso-*" = list(endpoint = "s3.{region}.c2s.ic.gov", global = FALSE),
+      "us-isob-*" = list(
+        endpoint = "s3.{region}.sc2s.sgov.gov",
+        global = FALSE
+      ),
+      "us-isof-*" = list(
+        endpoint = "s3.{region}.csp.hci.ic.gov",
+        global = FALSE
+      )
+    )
+  )
+}
+
 .s3$service <- function(config = list()) {
   handlers <- new_handlers("restxml", "s3")
+  .s3$metadata$endpoints <- .s3_endpoint()
   new_service(.s3$metadata, handlers, config)
 }
 
 .s3$head_bucket_input <- function(...) {
   args <- c(as.list(environment()), list(...))
-  shape <- structure(list(Bucket = structure(logical(0), tags = list(location = "uri", locationName = "Bucket", type = "string")), ExpectedBucketOwner = structure(logical(0), tags = list(location = "header", locationName = "x-amz-expected-bucket-owner", type = "string"))), tags = list(type = "structure"))
+  shape <- structure(
+    list(
+      Bucket = structure(
+        logical(0),
+        tags = list(location = "uri", locationName = "Bucket", type = "string")
+      ),
+      ExpectedBucketOwner = structure(
+        logical(0),
+        tags = list(
+          location = "header",
+          locationName = "x-amz-expected-bucket-owner",
+          type = "string"
+        )
+      )
+    ),
+    tags = list(type = "structure")
+  )
   return(populate(args, shape))
 }
 
 .s3$head_bucket_output <- function(...) {
   args <- c(as.list(environment()), list(...))
-  shape <- structure(list(BucketLocationType = structure(logical(0), tags = list(location = "header", locationName = "x-amz-bucket-location-type", type = "string")), BucketLocationName = structure(logical(0), tags = list(location = "header", locationName = "x-amz-bucket-location-name", type = "string")), BucketRegion = structure(logical(0), tags = list(location = "header", locationName = "x-amz-bucket-region", type = "string")), AccessPointAlias = structure(logical(0), tags = list(location = "header", locationName = "x-amz-access-point-alias", type = "boolean", box = TRUE))), tags = list(type = "structure"))
+  shape <- structure(
+    list(
+      BucketLocationType = structure(
+        logical(0),
+        tags = list(
+          location = "header",
+          locationName = "x-amz-bucket-location-type",
+          type = "string"
+        )
+      ),
+      BucketLocationName = structure(
+        logical(0),
+        tags = list(
+          location = "header",
+          locationName = "x-amz-bucket-location-name",
+          type = "string"
+        )
+      ),
+      BucketRegion = structure(
+        logical(0),
+        tags = list(
+          location = "header",
+          locationName = "x-amz-bucket-region",
+          type = "string"
+        )
+      ),
+      AccessPointAlias = structure(
+        logical(0),
+        tags = list(
+          location = "header",
+          locationName = "x-amz-access-point-alias",
+          type = "boolean",
+          box = TRUE
+        )
+      )
+    ),
+    tags = list(type = "structure")
+  )
   return(populate(args, shape))
 }
 
@@ -48,7 +178,10 @@ s3_head_bucket <- function(Bucket, ExpectedBucketOwner = NULL) {
     http_path = "/{Bucket}",
     paginator = list()
   )
-  input <- .s3$head_bucket_input(Bucket = Bucket, ExpectedBucketOwner = ExpectedBucketOwner)
+  input <- .s3$head_bucket_input(
+    Bucket = Bucket,
+    ExpectedBucketOwner = ExpectedBucketOwner
+  )
   output <- .s3$head_bucket_output()
   config <- get_config()
   svc <- .s3$service(config)


### PR DESCRIPTION
To make the release of 0.8.0 goes smoothly, paws will support both js and boto regex endpoints in the short term before completely migrating over to just boto regex endpoints.

Note: this is to prevent any breaking change. 