### PR TITLE
Add air r formatter

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -58,8 +58,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: r-lib/actions/setup-r@v2
-
       - name: Install dependencies
         run: |
           curl -LsSf https://github.com/posit-dev/air/releases/latest/download/air-installer.sh | sh
@@ -112,12 +110,9 @@ jobs:
               lines <- readLines(desc)
               found <- grepl("Version: [0-9\\.]+", lines, perl = T)
               lines[found] <- gsub("[0-9\\.]+", version, lines[found])
-              found <- grepl("paws\\..*[0-9]+\\.[0-9]+\\.[0-9]+", lines,
-                             perl = T)
-              found[found] <- !grepl("paws\\.common.*[0-9]+\\.[0-9]+\\.[0-9]+",
-                                     lines[found], perl = T)
-              lines[found] <- gsub("[0-9]+\\.[0-9]+\\.[0-9]+", version,
-                                   lines[found])
+              found <- grepl("paws\\..*[0-9]+\\.[0-9]+\\.[0-9]+", lines, perl = T)
+              found[found] <- !grepl("paws\\.common.*[0-9]+\\.[0-9]+\\.[0-9]+", lines[found], perl = T)
+              lines[found] <- gsub("[0-9]+\\.[0-9]+\\.[0-9]+", version, lines[found])
               writeLines(lines, desc)
             }
           }

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -61,21 +61,20 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
 
       - name: Install dependencies
-        run: install.packages("styler")
-        shell: Rscript {0}
-
-      - name: Style
         run: |
-          styler::style_pkg(pkg = 'paws.common', exclude_files = c("R/RcppExports\\.R", "R/cpp11\\.R", "R/import-standalone.*\\.R", "R/service_parameter_helper\\.R"))
-          styler::style_pkg(pkg = 'make.paws')
-        shell: Rscript {0}
+          curl -LsSf https://github.com/posit-dev/air/releases/latest/download/air-installer.sh | sh
+
+      - name: Format
+        run: |
+          air format paws.common/R paws.common/tests
+          air format make.paws/R make.paws/tests
 
       - name: commit
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git add \*.R
-          git commit -m 'Style'
+          git commit -m 'Air R formatting'
 
       - uses: r-lib/actions/pr-push@v2
         with:
@@ -113,11 +112,11 @@ jobs:
               lines <- readLines(desc)
               found <- grepl("Version: [0-9\\.]+", lines, perl = T)
               lines[found] <- gsub("[0-9\\.]+", version, lines[found])
-              found <- grepl("paws\\..*[0-9]+\\.[0-9]+\\.[0-9]+", lines, 
+              found <- grepl("paws\\..*[0-9]+\\.[0-9]+\\.[0-9]+", lines,
                              perl = T)
-              found[found] <- !grepl("paws\\.common.*[0-9]+\\.[0-9]+\\.[0-9]+", 
+              found[found] <- !grepl("paws\\.common.*[0-9]+\\.[0-9]+\\.[0-9]+",
                                      lines[found], perl = T)
-              lines[found] <- gsub("[0-9]+\\.[0-9]+\\.[0-9]+", version, 
+              lines[found] <- gsub("[0-9]+\\.[0-9]+\\.[0-9]+", version,
                                    lines[found])
               writeLines(lines, desc)
             }

--- a/make.paws/.Rbuildignore
+++ b/make.paws/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^LICENSE\.md$
+^air\.toml$

--- a/make.paws/air.toml
+++ b/make.paws/air.toml
@@ -1,0 +1,8 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = false
+exclude = ["RcppExports.R", "service_parameter_helper.R"]
+default-exclude = true

--- a/paws.common/.Rbuildignore
+++ b/paws.common/.Rbuildignore
@@ -2,3 +2,4 @@
 ^\.Rproj\.user$
 ^cran-comments.md$
 ^revdep$
+^air\.toml$

--- a/paws.common/air.toml
+++ b/paws.common/air.toml
@@ -1,0 +1,8 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = false
+exclude = ["RcppExports.R", "service_parameter_helper.R"]
+default-exclude = true


### PR DESCRIPTION
Adding [Air R formatter](https://github.com/posit-dev/air) to allow of IDE formatting in vscode/rstudio/positron etc... Plus a consistent formatting across paws.