### PR TITLE
set line length to 90

### DIFF
--- a/make.paws/R/aws_services.R
+++ b/make.paws/R/aws_services.R
@@ -38,12 +38,7 @@ category_service_ops_count <- function(in_dir = "../vendor/botocore") {
     data.frame(name = rep(x$name, length(x$services)), services = x$services)
   })
   paws_cat <- rbindlist(paws_cat, fill = T)
-  paws_cat_service_ops <- merge(
-    paws_cat,
-    aws_service_ops,
-    by = "services",
-    all.y = T
-  )
+  paws_cat_service_ops <- merge(paws_cat, aws_service_ops, by = "services", all.y = T)
   setcolorder(paws_cat_service_ops, "name")
   names(paws_cat_service_ops) <- c("category", "services", "operations")
   paws_cat_service_ops_count <- paws_cat_service_ops[,

--- a/make.paws/R/cache.R
+++ b/make.paws/R/cache.R
@@ -127,14 +127,7 @@ maybe_spot_check <- function(cache_result, value_expr, key_label) {
           collapse = "\n",
           "  ",
           utils::capture.output(
-            print(
-              waldo::compare(
-                cache_result,
-                value,
-                x_arg = "cached",
-                y_arg = "live"
-              )
-            )
+            print(waldo::compare(cache_result, value, x_arg = "cached", y_arg = "live"))
           )
         )
       )

--- a/make.paws/R/cran_category.R
+++ b/make.paws/R/cran_category.R
@@ -29,14 +29,7 @@ make_category <- function(category, service_names, sdk_dir, out_dir) {
 
   package_dir <- file.path(out_dir, name)
   write_skeleton_category(package_dir)
-  write_description_category(
-    package_dir,
-    name,
-    title,
-    description,
-    version,
-    imports
-  )
+  write_description_category(package_dir, name, title, description, version, imports)
   for (service in services) {
     copy_files(service_names[[service]], from = sdk_dir, to = package_dir)
   }
@@ -54,10 +47,7 @@ get_package_name <- function(suffix) {
 
 # Get the stored AWS service categories and which services they include.
 get_categories <- function() {
-  path <- system_file(
-    "extdata/packages.yml",
-    package = methods::getPackageName()
-  )
+  path <- system_file("extdata/packages.yml", package = methods::getPackageName())
   yaml::read_yaml(path)
 }
 

--- a/make.paws/R/cran_collection.R
+++ b/make.paws/R/cran_collection.R
@@ -64,10 +64,7 @@ write_source_collection <- function(
     }
   }
   write_list(clients, file.path(out_dir, "R", "paws.R"))
-  write_list(
-    make_reexports(),
-    file.path(out_dir, "R", "reexports_paws.common.R")
-  )
+  write_list(make_reexports(), file.path(out_dir, "R", "reexports_paws.common.R"))
 }
 
 # Add the category packages to the DESCRIPTION file's Imports.

--- a/make.paws/R/cran_sub_category.R
+++ b/make.paws/R/cran_sub_category.R
@@ -38,11 +38,7 @@ make_category_collection <- function(
     expand_doc_links = TRUE
   )
   write_documentation(package_dir)
-  write_imports_collection(
-    package_dir,
-    version,
-    get_category_packages(categories)
-  )
+  write_imports_collection(package_dir, version, get_category_packages(categories))
 }
 
 # Identify sub-categories

--- a/make.paws/R/custom/rds.R
+++ b/make.paws/R/custom/rds.R
@@ -57,10 +57,7 @@ NULL
 #' @keywords internal
 #' @seealso \link[paws.database:rds_build_auth_token_v2]{rds_build_auth_token_v2}
 #' @rdname rds_build_auth_token
-rds_build_auth_token <- utils::getFromNamespace(
-  "rds_build_auth_token",
-  "paws.common"
-)
+rds_build_auth_token <- utils::getFromNamespace("rds_build_auth_token", "paws.common")
 .rds$operations$build_auth_token <- rds_build_auth_token
 
 #' Generates an auth token used to connect to a db with IAM credentials.

--- a/make.paws/R/custom/s3.R
+++ b/make.paws/R/custom/s3.R
@@ -241,10 +241,7 @@ s3_generate_presigned_url <- function(
       )
     },
     error = function(err) {
-      stop(
-        sprintf("Client does not have method: %s", client_method),
-        call. = FALSE
-      )
+      stop(sprintf("Client does not have method: %s", client_method), call. = FALSE)
     }
   )
   operation_body <- body(operation_fun)
@@ -270,9 +267,7 @@ s3_generate_presigned_url <- function(
   # create: input from client_method
   kwargs <- as.list(modifyList(original_params, params))
   input <- do.call(
-    get(.pkg_api, envir = getNamespace(pkg_name))[[
-      sprintf("%s_input", client_method)
-    ]],
+    get(.pkg_api, envir = getNamespace(pkg_name))[[sprintf("%s_input", client_method)]],
     kwargs
   )
 

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -38,14 +38,7 @@ make_docs_short <- function(operation, api) {
   params <- make_doc_params(operation, api)
   rdname <- make_doc_rdname(operation, api)
   docs <- glue::glue_collapse(
-    c(
-      title,
-      description,
-      link_to_web_docs,
-      params,
-      "#' @keywords internal",
-      rdname
-    ),
+    c(title, description, link_to_web_docs, params, "#' @keywords internal", rdname),
     sep = "\n#'\n"
   )
   return(as.character(docs))
@@ -60,11 +53,7 @@ make_doc_title <- function(operation) {
 
 # Make the description documentation.
 make_doc_desc <- function(operation, api) {
-  docs <- convert(
-    operation$documentation,
-    package_name(api),
-    links = get_links(api)
-  )
+  docs <- convert(operation$documentation, package_name(api), links = get_links(api))
   if (length(docs) == 1 && docs == "") docs <- get_operation_title(operation)
   description <- glue::glue("#' {docs}")
   description <- glue::glue_collapse(description, sep = "\n")
@@ -74,11 +63,7 @@ make_doc_desc <- function(operation, api) {
 
 # Make a short description of the operation with only the first paragraph.
 make_doc_desc_short <- function(operation, api) {
-  docs <- convert(
-    operation$documentation,
-    package_name(api),
-    links = get_links(api)
-  )
+  docs <- convert(operation$documentation, package_name(api), links = get_links(api))
   if (length(docs) == 1 && docs == "") {
     docs <- get_operation_title(operation)
   } else {
@@ -278,11 +263,7 @@ make_doc_alias <- function(operation, api) {
 # Get the first paragraph from a block of text.
 first_paragraph <- function(x) {
   blank_line <- which(x == "")
-  first_paragraph <- ifelse(
-    length(blank_line) >= 1,
-    blank_line[1] - 1,
-    length(x)
-  )
+  first_paragraph <- ifelse(length(blank_line) >= 1, blank_line[1] - 1, length(x))
   paragraph <- paste(x[1:first_paragraph], collapse = " ")
   paragraph <- gsub(" +", " ", paragraph)
   return(paragraph)
@@ -556,8 +537,7 @@ escape_unmatched_chars <- function(x, chars) {
 
 escape_unmatched_pairs <- function(x, pairs) {
   result <- x
-  count <- function(string, char)
-    stringr::str_count(string, stringr::fixed(char))
+  count <- function(string, char) stringr::str_count(string, stringr::fixed(char))
   for (i in seq_along(pairs)) {
     a <- names(pairs)[i]
     b <- pairs[i]
@@ -758,13 +738,8 @@ clean_example <- function(s) {
     } else if (current_character == ",") {
       # Add new line after every comma
 
-      indents <- paste0(
-        rep(tab_string, max(length(open_perens) - 1, 0)),
-        collapse = ""
-      )
-      space_number <- (
-        if (substr(s, i + 1, i + 1) == " ") num_spaces - 1 else num_spaces
-      )
+      indents <- paste0(rep(tab_string, max(length(open_perens) - 1, 0)), collapse = "")
+      space_number <- (if (substr(s, i + 1, i + 1) == " ") num_spaces - 1 else num_spaces)
       final_tab <- paste0(rep(" ", space_number), collapse = "")
       cleaned[[i]] <- paste0(",\n", indents, final_tab)
     } else {

--- a/make.paws/R/interfaces.R
+++ b/make.paws/R/interfaces.R
@@ -15,10 +15,7 @@ interface_file_template <- template(
 
 # Return a list of interfaces for an API.
 make_interfaces <- function(api) {
-  interfaces <- lapply(
-    api$operations,
-    function(op) make_interface_pair(op, api)
-  )
+  interfaces <- lapply(api$operations, function(op) make_interface_pair(op, api))
   render(
     interface_file_template,
     service = package_name(api),
@@ -50,11 +47,7 @@ make_interface <- function(name, shape_data, api) {
     if (key == "shape") next
     shape <- tag_add(shape, stats::setNames(shape_data[[key]], key))
   }
-  interface <- render(
-    interface_template,
-    name = name,
-    shape = get_structure(shape)
-  )
+  interface <- render(interface_template, name = name, shape = get_structure(shape))
   return(interface)
 }
 
@@ -71,9 +64,7 @@ make_interface_pair <- function(operation, api) {
 }
 
 # Declare variables to avoid R CMD check notes about templates.
-utils::globalVariables(
-  "\n    ${name} <- function(...) {\n      list()\n    }\n    "
-)
+utils::globalVariables("\n    ${name} <- function(...) {\n      list()\n    }\n    ")
 
 make_empty_interface <- function(name) {
   interface_template <- template(

--- a/make.paws/R/make_sdk.R
+++ b/make.paws/R/make_sdk.R
@@ -27,9 +27,7 @@ make_sdk <- function(
   # The SDK is separated into categories to fit in CRAN's package size limit.
   categories <- get_categories()
   if (only_cran) {
-    cran <- row.names(
-      utils::available.packages(repos = "https://cran.rstudio.com")
-    )
+    cran <- row.names(utils::available.packages(repos = "https://cran.rstudio.com"))
     package <- sapply(categories, function(x) get_package_name(x$name))
     parent_package <- sapply(categories, function(x) get_package_name(x$parent))
     categories <- categories[package %in% cran | parent_package %in% cran]
@@ -70,13 +68,7 @@ make_sdk <- function(
 
     # Build categories from sub-categories
     for (cat in names(grp_sub_cats)) {
-      make_category_collection(
-        temp_dir,
-        out_sdk_dir,
-        grp_sub_cats[[cat]],
-        cat,
-        api_names
-      )
+      make_category_collection(temp_dir, out_sdk_dir, grp_sub_cats[[cat]], cat, api_names)
     }
   }
 

--- a/make.paws/R/operations.R
+++ b/make.paws/R/operations.R
@@ -15,12 +15,7 @@ operation_file_template <- template(
 
 # Make all API operations.
 make_operations <- function(api, doc_maker) {
-  operations <- lapply(
-    api$operations,
-    make_operation,
-    api = api,
-    doc_maker = doc_maker
-  )
+  operations <- lapply(api$operations, make_operation, api = api, doc_maker = doc_maker)
   render(
     operation_file_template,
     service = package_name(api),

--- a/make.paws/R/package.R
+++ b/make.paws/R/package.R
@@ -68,9 +68,7 @@ get_description <- function(path) {
 cache_env <- new.env(parent = emptyenv())
 get_version <- function(major = 0, minor = 0, patch = 0) {
   if (is.null(cache_env$version)) {
-    df <- as.data.frame(
-      utils::available.packages(repos = "https://cran.rstudio.com")
-    )
+    df <- as.data.frame(utils::available.packages(repos = "https://cran.rstudio.com"))
     cache_env$version <- package_version(df[df$Package == "paws", "Version"])
     cache_env$version[[c(1, 1)]] <- cache_env$version$major + major
     cache_env$version[[c(1, 2)]] <- cache_env$version$minor + minor
@@ -83,12 +81,7 @@ get_version <- function(major = 0, minor = 0, patch = 0) {
 clear_files <- function(path, keep) {
   if (dir.exists(path)) {
     files <- list.files(path, full.names = TRUE)
-    delete <- grep(
-      paste(keep, collapse = "|"),
-      files,
-      invert = TRUE,
-      value = TRUE
-    )
+    delete <- grep(paste(keep, collapse = "|"), files, invert = TRUE, value = TRUE)
     unlink(delete, recursive = TRUE)
   }
 }

--- a/make.paws/R/read_api.R
+++ b/make.paws/R/read_api.R
@@ -73,11 +73,7 @@ get_latest_api_version_v2 <- function(api_name, path) {
 
 # Returns a list of API files for a given API version.
 get_api_files <- function(version, path) {
-  files <- list.files(
-    path,
-    pattern = sprintf("^%s", version),
-    full.names = TRUE
-  )
+  files <- list.files(path, pattern = sprintf("^%s", version), full.names = TRUE)
   types <- gsub("^.+\\.(.+)\\..+", "\\1", basename(files))
   files <- as.list(files)
   names(files) <- types
@@ -178,12 +174,7 @@ merge_region_config <- function(api, region_config) {
       rule <- region_config$patterns[[rule]]
     }
     rules[[region]] <- list(
-      endpoint = gsub(
-        "{service}",
-        endpoint_prefix,
-        rule$endpoint,
-        fixed = TRUE
-      ),
+      endpoint = gsub("{service}", endpoint_prefix, rule$endpoint, fixed = TRUE),
       global = isTRUE(rule$globalEndpoint)
     )
   }
@@ -201,11 +192,7 @@ merge_region_config_v2 <- function(api, region_config) {
     hostname <- partition$defaults$hostname
     region_regex <- gsub("\\", "\\\\", partition$regionRegex, fixed = T)
     if (
-      !is.null(
-        global <- partition$services[[endpoint_prefix]]$endpoints[[
-          "aws-global"
-        ]]
-      )
+      !is.null(global <- partition$services[[endpoint_prefix]]$endpoints[["aws-global"]])
     ) {
       endpoint <- build_endpoint(endpoint_prefix, global$hostname, dnsSuffix)
       endpoint <- list(endpoint = endpoint, global = TRUE)

--- a/make.paws/R/sdk_helper.R
+++ b/make.paws/R/sdk_helper.R
@@ -141,9 +141,7 @@ paws_rhub_action_check <- function(
   platforms = c("linux", "macos", "macos-arm64", "windows")
 ) {
   url <- "https://api.github.com/repos/paws-r/paws-rhub/actions/workflows/rhub.yaml/dispatches"
-  pat <- gitcreds::gitcreds_get(
-    url = "https://github.com/paws-r/paws-rhub"
-  )$password
+  pat <- gitcreds::gitcreds_get(url = "https://github.com/paws-r/paws-rhub")$password
   config <- list(platforms = platforms)
   name <- paste(platforms, collapse = ", ")
   to_json <- \(x) jsonlite::toJSON(x, auto_unbox = T)
@@ -151,10 +149,7 @@ paws_rhub_action_check <- function(
     id <- sprintf(
       "%s-%s",
       pkg,
-      paste0(
-        sample(c(letters, LETTERS, 0:9), 10, replace = TRUE),
-        collapse = ""
-      )
+      paste0(sample(c(letters, LETTERS, 0:9), 10, replace = TRUE), collapse = "")
     )
     data <- list(
       ref = "main",
@@ -176,19 +171,13 @@ paws_rhub_action_check <- function(
       stop(sprintf("Failed to start rhub action for package: %s", pkg))
     }
   }
-  writeLines(
-    "Please check results: https://github.com/paws-r/paws-rhub/actions"
-  )
+  writeLines("Please check results: https://github.com/paws-r/paws-rhub/actions")
   invisible(NULL)
 }
 
 #' @rdname paws_check_rhub
 #' @export
-paws_check_win_devel <- function(
-  in_dir = "../cran",
-  pkg_list = list(),
-  email = NULL
-) {
+paws_check_win_devel <- function(in_dir = "../cran", pkg_list = list(), email = NULL) {
   paws_check_win_devel_sub_cat(in_dir, pkg_list, email)
   paws_check_win_devel_cat(in_dir, pkg_list, email)
   pkg <- file.path(in_dir, "paws")
@@ -358,10 +347,7 @@ paws_build_cran_comments <- function(
 ) {
   log_info <- utils::getFromNamespace("log_info", "paws.common")
   all_cats <- basename(list_paws_pkgs(in_dir))
-  log_info(
-    "Running local checks for: ['%s']",
-    paste(all_cats, collapse = "', '")
-  )
+  log_info("Running local checks for: ['%s']", paste(all_cats, collapse = "', '"))
   dir_info <- paws_check_pkg_size(in_dir, pkg_list = all_cats)
   if (is.null(cache_path)) {
     results_local <- paws_check_local(
@@ -380,11 +366,7 @@ paws_build_cran_comments <- function(
 
   dir_info[
     result_dt,
-    `:=`(
-      "errors" = get("errors"),
-      "warnings" = get("warnings"),
-      "notes" = get("notes")
-    ),
+    `:=`("errors" = get("errors"), "warnings" = get("warnings"), "notes" = get("notes")),
     on = "package"
   ]
 
@@ -497,10 +479,7 @@ paws_pkg_doc_build <- function(in_dir = "../cran", pkg_list = list()) {
   log_info("Rebuild paws documentation.")
   for (pkg in pkgs[basename(pkgs) != "paws"]) {
     roxygen2::roxygenise(package.dir = pkg)
-    log_info(
-      "Successfully update r documentation for package: %s",
-      basename(pkg)
-    )
+    log_info("Successfully update r documentation for package: %s", basename(pkg))
   }
 }
 
@@ -511,14 +490,9 @@ paws_rd_links <- function(in_dir = "../cran") {
   pkgs <- basename(list_cat_pkgs(list_paws_pkgs(in_dir)))
   pkg_service <- c()
   for (pkg in pkgs) {
-    services <- unique(
-      gsub("_.*", "", list.files(sprintf("%s/%s/R", in_dir, pkg)))
-    )
+    services <- unique(gsub("_.*", "", list.files(sprintf("%s/%s/R", in_dir, pkg))))
     services <- services[services != "reexports"]
-    pkg_service <- c(
-      pkg_service,
-      setNames(services, rep(pkg, length(services)))
-    )
+    pkg_service <- c(pkg_service, setNames(services, rep(pkg, length(services))))
   }
 
   path <- sprintf("%s/paws/man", in_dir)

--- a/make.paws/R/tests_config.R
+++ b/make.paws/R/tests_config.R
@@ -11,9 +11,7 @@ tests_config <- list(
   ),
   appstream = list(skip = list("describe_user_stack_associations")),
   batch = list(skip = list("list_jobs")),
-  cloudformation = list(
-    skip = list("describe_stack_events", "describe_stack_resources")
-  ),
+  cloudformation = list(skip = list("describe_stack_events", "describe_stack_resources")),
   cloudhsm = list(skip = list("*")),
   codedeploy = list(skip = list("list_deployment_targets")),
   costandusagereportservice = list(
@@ -39,14 +37,9 @@ tests_config <- list(
       "describe_spot_datafeed_subscription"
     )
   ),
-  ecs = list(
-    skip = list("list_container_instances", "list_services", "list_tasks")
-  ),
+  ecs = list(skip = list("list_container_instances", "list_services", "list_tasks")),
   elasticache = list(
-    skip = list(
-      "describe_cache_security_groups",
-      "list_allowed_node_type_modifications"
-    )
+    skip = list("describe_cache_security_groups", "list_allowed_node_type_modifications")
   ),
   elasticbeanstalk = list(
     skip = list(
@@ -144,10 +137,7 @@ tests_config <- list(
   ),
   pinpointsmsvoice = list(skip = list("*")),
   redshift = list(
-    skip = list(
-      "describe_cluster_security_groups",
-      "describe_table_restore_status"
-    )
+    skip = list("describe_cluster_security_groups", "describe_table_restore_status")
   ),
   servicecatalog = list(skip = list("list_tag_options")),
   shield = list(
@@ -169,16 +159,10 @@ tests_config <- list(
   ),
   support = list(skip = list("*")),
   waf = list(
-    skip = list(
-      "list_activated_rules_in_rule_group",
-      "list_logging_configurations"
-    )
+    skip = list("list_activated_rules_in_rule_group", "list_logging_configurations")
   ),
   wafregional = list(
-    skip = list(
-      "list_activated_rules_in_rule_group",
-      "list_logging_configurations"
-    )
+    skip = list("list_activated_rules_in_rule_group", "list_logging_configurations")
   ),
   workdocs = list(skip = list("describe_activities", "describe_users")),
   workspaces = list(skip = list("*"))

--- a/make.paws/R/text.R
+++ b/make.paws/R/text.R
@@ -21,12 +21,7 @@ html_to <- function(html, to) {
     temp_in <- tempfile()
     write_utf8(html, temp_in)
     temp_out <- tempfile()
-    rmarkdown::pandoc_convert(
-      temp_in,
-      output = temp_out,
-      from = "html",
-      to = to
-    )
+    rmarkdown::pandoc_convert(temp_in, output = temp_out, from = "html", to = to)
     result <- read_utf8(temp_out)
     # Pandoc inappropriately escapes "%" and "*"; undo this escaping.
     result <- gsub("\\\\(\\%|\\*)", "\\1", result)
@@ -80,10 +75,7 @@ unmask <- function(object, masks) {
 tabular <- function(cols) {
   stopifnot(is.data.frame(cols))
   col_align <- paste(rep("l", ncol(cols)), collapse = "")
-  contents <- do.call(
-    "paste",
-    c(cols, list(sep = " \\tab ", collapse = "\\cr\n  "))
-  )
+  contents <- do.call("paste", c(cols, list(sep = " \\tab ", collapse = "\\cr\n  ")))
   paste("\\tabular{", col_align, "}{\n  ", contents, "\n}\n", sep = "")
 }
 

--- a/make.paws/R/utils.R
+++ b/make.paws/R/utils.R
@@ -108,10 +108,7 @@ get_url <- function(url, tries = 3) {
   cached_expr(list("get_url", url = url), function() {
     try <- 0
     while (try < tries) {
-      resp <- tryCatch(
-        httr::HEAD(url, httr::timeout(1)),
-        error = function(e) NULL
-      )
+      resp <- tryCatch(httr::HEAD(url, httr::timeout(1)), error = function(e) NULL)
       if (!is.null(resp)) {
         if (resp$status_code >= 400) {
           return(NULL)

--- a/make.paws/air.toml
+++ b/make.paws/air.toml
@@ -1,5 +1,5 @@
 [format]
-line-width = 80
+line-width = 90
 indent-width = 2
 indent-style = "space"
 line-ending = "auto"

--- a/make.paws/tests/testthat/helper.R
+++ b/make.paws/tests/testthat/helper.R
@@ -18,12 +18,7 @@
 #
 # $z
 # [1] "bye"
-mock2 <- function(
-  ...,
-  cycle = FALSE,
-  side_effect = NULL,
-  envir = parent.frame()
-) {
+mock2 <- function(..., cycle = FALSE, side_effect = NULL, envir = parent.frame()) {
   return_values <- eval(substitute(alist(...)))
   return_values_env <- envir
   call_no <- 0
@@ -35,10 +30,7 @@ mock2 <- function(
     args[[call_no]] <<- list(...)
     if (length(return_values)) {
       if (call_no > length(return_values) && !cycle) {
-        stop(
-          "too many calls to mock object and cycle set to FALSE",
-          call. = FALSE
-        )
+        stop("too many calls to mock object and cycle set to FALSE", call. = FALSE)
       }
       value <- return_values[[(call_no - 1) %% length(return_values) + 1]]
       return(eval(value, envir = return_values_env))

--- a/make.paws/tests/testthat/test_docs.R
+++ b/make.paws/tests/testthat/test_docs.R
@@ -7,15 +7,11 @@ test_that("make_doc_title", {
   expected <- "#' Foo"
   expect_equal(make_doc_title(operation), expected)
 
-  operation <- list(
-    documentation = "<body><p>Foo <a href='baz'>bar</a>.</p></body>"
-  )
+  operation <- list(documentation = "<body><p>Foo <a href='baz'>bar</a>.</p></body>")
   expected <- "#' Foo bar"
   expect_equal(make_doc_title(operation), expected)
 
-  operation <- list(
-    documentation = "<body><p>[In brackets] Outside brackets.</p></body>"
-  )
+  operation <- list(documentation = "<body><p>[In brackets] Outside brackets.</p></body>")
   expected <- "#' &#91;In brackets&#93; Outside brackets"
   expect_equal(make_doc_title(operation), expected)
 
@@ -63,10 +59,7 @@ test_that("make_doc_request", {
     shapes = list(
       OperationShape = list(
         type = "structure",
-        members = list(
-          Foo = list(shape = "FooShape"),
-          Bar = list(shape = "BarShape")
-        )
+        members = list(Foo = list(shape = "FooShape"), Bar = list(shape = "BarShape"))
       ),
       FooShape = list(type = "string"),
       BarShape = list(
@@ -111,10 +104,7 @@ test_that("make_doc_value", {
     shapes = list(
       OperationShape = list(
         type = "structure",
-        members = list(
-          Foo = list(shape = "FooShape"),
-          Bar = list(shape = "BarShape")
-        )
+        members = list(Foo = list(shape = "FooShape"), Bar = list(shape = "BarShape"))
       ),
       FooShape = list(type = "string"),
       BarShape = list(

--- a/make.paws/tests/testthat/test_interfaces.R
+++ b/make.paws/tests/testthat/test_interfaces.R
@@ -5,9 +5,7 @@ test_that("make_interfaces", {
       Foo = list(name = "Foo", input = list(shape = "FooShape")),
       Bar = list(name = "Bar")
     ),
-    shapes = list(
-      FooShape = list(type = "string", enum = list("value1", "value2"))
-    )
+    shapes = list(FooShape = list(type = "string", enum = list("value1", "value2")))
   )
   actual <- make_interfaces(api)
   expected <- gsub(
@@ -48,9 +46,7 @@ test_that("make_interface with root-level metadata", {
         input = list(shape = "FooShape", locationName = "FooShapeInput")
       )
     ),
-    shapes = list(
-      FooShape = list(type = "string", enum = list("value1", "value2"))
-    )
+    shapes = list(FooShape = list(type = "string", enum = list("value1", "value2")))
   )
   actual <- make_interface(".api$foo_input", api$operations$Foo$input, api)
   expected <- gsub(
@@ -67,9 +63,7 @@ test_that("make_interface with root-level metadata", {
 
 test_that("scalar", {
   api <- list(
-    shapes = list(
-      FooShape = list(type = "string", enum = list("value1", "value2"))
-    )
+    shapes = list(FooShape = list(type = "string", enum = list("value1", "value2")))
   )
   out <- make_shape(list(shape = "FooShape"), api = api)
   expect_length(out, 0)
@@ -128,14 +122,8 @@ test_that("nested structure", {
         type = "structure",
         members = list(Foo = list(shape = "FooShape"))
       ),
-      FooShape = list(
-        type = "structure",
-        members = list(Bar = list(shape = "BarShape"))
-      ),
-      BarShape = list(
-        type = "structure",
-        members = list(Baz = list(shape = "BazShape"))
-      ),
+      FooShape = list(type = "structure", members = list(Bar = list(shape = "BarShape"))),
+      BarShape = list(type = "structure", members = list(Baz = list(shape = "BazShape"))),
       BazShape = list(type = "double")
     )
   )

--- a/make.paws/tests/testthat/test_make_sdk.R
+++ b/make.paws/tests/testthat/test_make_sdk.R
@@ -41,14 +41,7 @@ api <- list(
   documentation = "AWS Foo is an example AWS API."
 )
 
-api_path <- file.path(
-  path_in,
-  "botocore",
-  "data",
-  "foo",
-  "2018-11-01",
-  "service-2.json"
-)
+api_path <- file.path(path_in, "botocore", "data", "foo", "2018-11-01", "service-2.json")
 dir.create(dirname(api_path), recursive = TRUE, showWarnings = FALSE)
 jsonlite::write_json(api, api_path, auto_unbox = TRUE)
 

--- a/make.paws/tests/testthat/test_read_api.R
+++ b/make.paws/tests/testthat/test_read_api.R
@@ -13,10 +13,7 @@ test_that("read_api", {
   fs::dir_create(api_dir, "2018-11-01")
   fs::dir_create(api_dir, "2017-11-01")
 
-  write_json(
-    list(foo = "examples"),
-    file.path(api_dir, "2018-11-01", "examples-1.json")
-  )
+  write_json(list(foo = "examples"), file.path(api_dir, "2018-11-01", "examples-1.json"))
 
   write_json(
     list(
@@ -35,18 +32,9 @@ test_that("read_api", {
     file.path(api_dir, "2018-11-01", "paginators-1.json")
   )
 
-  write_json(
-    list(foo = "wrong1"),
-    file.path(api_dir, "2017-11-01", "examples-1.json")
-  )
-  write_json(
-    list(foo = "wrong3"),
-    file.path(api_dir, "2017-11-01", "service-2.json")
-  )
-  write_json(
-    list(foo = "wrong4"),
-    file.path(api_dir, "2017-11-01", "paginators-1.json")
-  )
+  write_json(list(foo = "wrong1"), file.path(api_dir, "2017-11-01", "examples-1.json"))
+  write_json(list(foo = "wrong3"), file.path(api_dir, "2017-11-01", "service-2.json"))
+  write_json(list(foo = "wrong4"), file.path(api_dir, "2017-11-01", "paginators-1.json"))
 
   write_json(
     list(
@@ -102,17 +90,9 @@ test_that("merge_examples", {
 })
 
 test_that("merge_paginators", {
-  api <- list(
-    operations = list(DescribeDestinations = list(), GetLogEvents = list())
-  )
+  api <- list(operations = list(DescribeDestinations = list(), GetLogEvents = list()))
   paginator <- list("DescribeDestinations" = list("input_token" = "nextToken"))
   ret <- make.paws:::merge_paginators(api, "logs", paginator)
-  expect_equal(
-    ret$operations$DescribeDestinations$paginators$input_token,
-    "nextToken"
-  )
-  expect_equal(
-    ret$operations$DescribeDestinations$paginators$input_token,
-    "nextToken"
-  )
+  expect_equal(ret$operations$DescribeDestinations$paginators$input_token, "nextToken")
+  expect_equal(ret$operations$DescribeDestinations$paginators$input_token, "nextToken")
 })

--- a/make.paws/tests/testthat/test_sdk_helper.R
+++ b/make.paws/tests/testthat/test_sdk_helper.R
@@ -6,19 +6,13 @@ test_that("check list paws packages", {
 })
 
 test_that("check list paws packages restrict package", {
-  expect_equal(
-    basename(list_paws_pkgs("./dummy/pkg3", "paws.cat1")),
-    c("paws.cat1")
-  )
+  expect_equal(basename(list_paws_pkgs("./dummy/pkg3", "paws.cat1")), c("paws.cat1"))
 })
 
 test_that("check list paws sub category packages", {
   pkgs_list <- list_paws_pkgs("./dummy/pkg4")
 
-  expect_equal(
-    basename(pkgs_list),
-    c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat2")
-  )
+  expect_equal(basename(pkgs_list), c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat2"))
 })
 
 test_that("check list paws only category packages", {
@@ -104,9 +98,7 @@ test_that("check paws_check_local_cat", {
     )
   )
 
-  mock_check_pkgs <- mock2(
-    list(paws.cat1 = list(errors = "foo", warnings = "bar"))
-  )
+  mock_check_pkgs <- mock2(list(paws.cat1 = list(errors = "foo", warnings = "bar")))
   mockery::stub(paws_check_local_cat, "check_pkgs", mock_check_pkgs)
   mockery::stub(paws_check_local_cat, "list_paws_pkgs", mock_list_paws_pkgs)
 
@@ -130,11 +122,7 @@ test_that("check paws_check_local", {
     "paws_check_local_sub_cat",
     mock_paws_check_local_sub_cat
   )
-  mockery::stub(
-    paws_check_local,
-    "paws_check_local_cat",
-    mock_paws_check_local_cat
-  )
+  mockery::stub(paws_check_local, "paws_check_local_cat", mock_paws_check_local_cat)
   mockery::stub(paws_check_local, "check_pkgs", mock_check_pkgs)
 
   check <- paws_check_local()
@@ -143,9 +131,7 @@ test_that("check paws_check_local", {
 })
 
 test_that("check paws_check_url", {
-  mock_list_paws_pkgs <- mock2(
-    file.path("dummy", c("paws", "paws.cat1", "paws.cat2"))
-  )
+  mock_list_paws_pkgs <- mock2(file.path("dummy", c("paws", "paws.cat1", "paws.cat2")))
   mock_url_check <- mock2("foo", "bar", "cho", cycle = T)
   mockery::stub(paws_check_url, "urlchecker::url_check", mock_url_check)
   mockery::stub(paws_check_url, "list_paws_pkgs", mock_list_paws_pkgs)
@@ -158,29 +144,18 @@ test_that("check paws_check_url", {
 })
 
 test_that("check paws_check_rhub_sub_cat", {
-  mock_list_paws_pkgs <- mock2(
-    c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat1.p2")
-  )
+  mock_list_paws_pkgs <- mock2(c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat1.p2"))
   mock_check_rhub <- mock2()
-  mockery::stub(
-    paws_check_rhub_sub_cat,
-    "paws_rhub_action_check",
-    mock_check_rhub
-  )
+  mockery::stub(paws_check_rhub_sub_cat, "paws_rhub_action_check", mock_check_rhub)
   mockery::stub(paws_check_rhub_sub_cat, "list_paws_pkgs", mock_list_paws_pkgs)
 
   check <- paws_check_rhub_sub_cat()
 
-  expect_equal(
-    mock_arg(mock_check_rhub)[[1]],
-    c("paws.cat1.p1", "paws.cat1.p2")
-  )
+  expect_equal(mock_arg(mock_check_rhub)[[1]], c("paws.cat1.p1", "paws.cat1.p2"))
 })
 
 test_that("check paws_check_rhub_cat", {
-  mock_list_paws_pkgs <- mock2(
-    c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat1.p2")
-  )
+  mock_list_paws_pkgs <- mock2(c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat1.p2"))
   mock_check_rhub <- mock2()
   mockery::stub(paws_check_rhub_cat, "paws_rhub_action_check", mock_check_rhub)
   mockery::stub(paws_check_rhub_cat, "list_paws_pkgs", mock_list_paws_pkgs)
@@ -194,9 +169,7 @@ test_that("check paws_check_rhub_cat", {
 })
 
 test_that("check paws_check_win_devel_sub_cat", {
-  mock_list_paws_pkgs <- mock2(
-    c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat1.p2")
-  )
+  mock_list_paws_pkgs <- mock2(c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat1.p2"))
 
   mock_check_rhub <- mock2()
   mockery::stub(
@@ -204,11 +177,7 @@ test_that("check paws_check_win_devel_sub_cat", {
     "devtools::check_win_devel",
     mock_check_rhub
   )
-  mockery::stub(
-    paws_check_win_devel_sub_cat,
-    "list_paws_pkgs",
-    mock_list_paws_pkgs
-  )
+  mockery::stub(paws_check_win_devel_sub_cat, "list_paws_pkgs", mock_list_paws_pkgs)
 
   check <- paws_check_win_devel_sub_cat()
 
@@ -219,16 +188,10 @@ test_that("check paws_check_win_devel_sub_cat", {
 })
 
 test_that("check paws_check_win_devel_cat", {
-  mock_list_paws_pkgs <- mock2(
-    c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat1.p2")
-  )
+  mock_list_paws_pkgs <- mock2(c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat1.p2"))
 
   mock_check_rhub <- mock2()
-  mockery::stub(
-    paws_check_win_devel_cat,
-    "devtools::check_win_devel",
-    mock_check_rhub
-  )
+  mockery::stub(paws_check_win_devel_cat, "devtools::check_win_devel", mock_check_rhub)
   mockery::stub(paws_check_win_devel_cat, "list_paws_pkgs", mock_list_paws_pkgs)
 
   check <- paws_check_win_devel_cat()
@@ -240,9 +203,7 @@ test_that("check paws_check_win_devel_cat", {
 })
 
 test_that("check paws_release_sub_cat", {
-  mock_list_paws_pkgs <- mock2(
-    c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat1.p2")
-  )
+  mock_list_paws_pkgs <- mock2(c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat1.p2"))
 
   mock_release <- mock2()
   mockery::stub(paws_release_sub_cat, "devtools::submit_cran", mock_release)
@@ -257,9 +218,7 @@ test_that("check paws_release_sub_cat", {
 })
 
 test_that("check paws_release_cat", {
-  mock_list_paws_pkgs <- mock2(
-    c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat1.p2")
-  )
+  mock_list_paws_pkgs <- mock2(c("paws", "paws.cat1", "paws.cat1.p1", "paws.cat1.p2"))
 
   mock_release <- mock2()
   mockery::stub(paws_release_cat, "devtools::submit_cran", mock_release)
@@ -280,16 +239,8 @@ test_that("check paws_install", {
   mock_install_local <- mock2()
   mock_install_local_pkg_list <- mock2()
   mockery::stub(paws_install, "devtools::install_local", mock_install_local)
-  mockery::stub(
-    paws_install,
-    "install_local_pkg_list",
-    mock_install_local_pkg_list
-  )
-  mockery::stub(
-    paws_install,
-    "install_local_pkg_list",
-    mock_install_local_pkg_list
-  )
+  mockery::stub(paws_install, "install_local_pkg_list", mock_install_local_pkg_list)
+  mockery::stub(paws_install, "install_local_pkg_list", mock_install_local_pkg_list)
   mockery::stub(paws_install, "list_paws_pkgs", mock_list_paws_pkgs)
 
   check <- paws_install("dummy")
@@ -309,9 +260,7 @@ test_that("check paws_install", {
 })
 
 test_that("check paws_uninstall", {
-  mock_installed_packages <- mock2(
-    list(Package = c("paws", "paws.cat1", "paws.cat2"))
-  )
+  mock_installed_packages <- mock2(list(Package = c("paws", "paws.cat1", "paws.cat2")))
   mock_remove_packages <- mock2()
   mockery::stub(paws_uninstall, "installed.packages", mock_installed_packages)
   mockery::stub(paws_uninstall, "remove.packages", mock_remove_packages)
@@ -352,10 +301,7 @@ test_that("check paws_check_pkg_size", {
 
 test_that("check paws_build_cran_comments", {
   mock_desc_get_deps <- mock2(
-    data.frame(
-      "type" = rep("Imports", 2),
-      "package" = c("paws.cat1", "paws.cat2")
-    )
+    data.frame("type" = rep("Imports", 2), "package" = c("paws.cat1", "paws.cat2"))
   )
   mock_list_paws_pkgs <- mock2(c("paws.cat1", "paws.cat2"))
   mock_paws_check_pkg_size <- mock2(
@@ -369,30 +315,14 @@ test_that("check paws_build_cran_comments", {
   mock_paws_check_local <- mock2(
     list(
       paws = list(errors = NULL, warnings = NULL, notes = NULL),
-      paws.cat1 = list(
-        errors = NULL,
-        warnings = "this is a dummy warning",
-        notes = NULL
-      ),
-      paws.cat2 = list(
-        errors = NULL,
-        warnings = NULL,
-        notes = "this is a dummy note"
-      )
+      paws.cat1 = list(errors = NULL, warnings = "this is a dummy warning", notes = NULL),
+      paws.cat2 = list(errors = NULL, warnings = NULL, notes = "this is a dummy note")
     )
   )
   mock_write_line <- mock2()
   mockery::stub(paws_build_cran_comments, "list_paws_pkgs", mock_list_paws_pkgs)
-  mockery::stub(
-    paws_build_cran_comments,
-    "paws_check_pkg_size",
-    mock_paws_check_pkg_size
-  )
-  mockery::stub(
-    paws_build_cran_comments,
-    "paws_check_local",
-    mock_paws_check_local
-  )
+  mockery::stub(paws_build_cran_comments, "paws_check_pkg_size", mock_paws_check_pkg_size)
+  mockery::stub(paws_build_cran_comments, "paws_check_local", mock_paws_check_local)
   mockery::stub(paws_build_cran_comments, "writeLines", mock_write_line)
 
   paws_build_cran_comments(in_dir = "made_up")
@@ -403,11 +333,7 @@ test_that("check paws_build_cran_comments", {
   )
   expect_equal(
     mock_arg(mock_paws_check_local),
-    list(
-      in_dir = "made_up",
-      pkg_list = c("paws.cat1", "paws.cat2"),
-      keep_notes = TRUE
-    )
+    list(in_dir = "made_up", pkg_list = c("paws.cat1", "paws.cat2"), keep_notes = TRUE)
   )
   expect_equal(
     mockery::mock_args(mock_write_line),
@@ -434,10 +360,7 @@ test_that("check paws_build_cran_comments", {
 
 test_that("check paws_build_cran_comments from cache", {
   mock_desc_get_deps <- mock2(
-    data.frame(
-      "type" = rep("Imports", 2),
-      "package" = c("paws.cat1", "paws.cat2")
-    )
+    data.frame("type" = rep("Imports", 2), "package" = c("paws.cat1", "paws.cat2"))
   )
   mock_list_paws_pkgs <- mock2(c("paws.cat1", "paws.cat2"))
   mock_paws_check_pkg_size <- mock2(
@@ -449,23 +372,12 @@ test_that("check paws_build_cran_comments from cache", {
     )
   )
   mock_write_line <- mock2()
-  mockery::stub(
-    paws_build_cran_comments,
-    "desc::desc_get_deps",
-    mock_desc_get_deps
-  )
+  mockery::stub(paws_build_cran_comments, "desc::desc_get_deps", mock_desc_get_deps)
   mockery::stub(paws_build_cran_comments, "list_paws_pkgs", mock_list_paws_pkgs)
-  mockery::stub(
-    paws_build_cran_comments,
-    "paws_check_pkg_size",
-    mock_paws_check_pkg_size
-  )
+  mockery::stub(paws_build_cran_comments, "paws_check_pkg_size", mock_paws_check_pkg_size)
   mockery::stub(paws_build_cran_comments, "writeLines", mock_write_line)
 
-  paws_build_cran_comments(
-    in_dir = "made_up",
-    cache_path = "local_check_results.yml"
-  )
+  paws_build_cran_comments(in_dir = "made_up", cache_path = "local_check_results.yml")
 
   expect_equal(
     mock_arg(mock_paws_check_pkg_size),

--- a/make.paws/tests/testthat/test_tests.R
+++ b/make.paws/tests/testthat/test_tests.R
@@ -36,18 +36,12 @@ test_that("make_tests", {
     metadata = list(serviceAbbreviation = "api"),
     operations = list(
       CreateFoo = list(name = "CreateFoo"),
-      DescribeFoo = list(
-        name = "DescribeFoo",
-        input = list(shape = "DescribeFooShape")
-      ),
+      DescribeFoo = list(name = "DescribeFoo", input = list(shape = "DescribeFooShape")),
       ListBar = list(name = "ListBar"),
       ListBaz = list(name = "ListBaz", input = list(shape = "ListBazShape"))
     ),
     shapes = list(
-      DescribeFooShape = list(
-        members = list(MaxResults = list()),
-        required = list()
-      ),
+      DescribeFooShape = list(members = list(MaxResults = list()), required = list()),
       ListBazShape = list(members = list(Qux = list()), required = list("Qux"))
     )
   )

--- a/paws.common/R/client.R
+++ b/paws.common/R/client.R
@@ -125,8 +125,8 @@ resolver_endpoint_boto <- function(
     stop("No region provided and no global region found.")
   }
   signing_region <- (
-    if (any(global_found) & global_region)
-      names(global_found[global_found][1]) else region
+    if (any(global_found) & global_region) names(global_found[global_found][1]) else
+      region
   )
   e <- endpoints[[get_region_pattern(names(endpoints), signing_region)]]
   if (service == "sts" & nzchar(sts_regional_endpoint)) {
@@ -164,8 +164,8 @@ resolver_endpoint_js <- function(
     stop("No region provided and no global region found.")
   }
   search_region <- (
-    if (any(global_found) & global_region)
-      names(global_found[global_found][1]) else region
+    if (any(global_found) & global_region) names(global_found[global_found][1]) else
+      region
   )
   e <- endpoints[[get_region_pattern_js(names(endpoints), search_region)]]
   if (is.character(e)) {

--- a/paws.common/R/config.R
+++ b/paws.common/R/config.R
@@ -102,14 +102,8 @@ set_config <- function(svc, cfgs = list()) {
 set_paws_vendor <- function() {
   where <- topenv(parent.frame(n = 2))
   pkg_name <- get0(".packageName", where, inherits = FALSE)
-  if (
-    !is.null(pkg_name) &&
-      startsWith(pkg_name, "paws.") &&
-      pkg_name != "paws.common"
-  ) {
-    vendor <- (
-      if (packageVersion(pkg_name) >= numeric_version("0.8.0")) "boto" else "js"
-    )
+  if (!is.null(pkg_name) && startsWith(pkg_name, "paws.") && pkg_name != "paws.common") {
+    vendor <- (if (packageVersion(pkg_name) >= numeric_version("0.8.0")) "boto" else "js")
     vendor_cache[["vendor"]] <- vendor
   }
 }
@@ -204,9 +198,7 @@ get_iam_role <- function() {
 get_instance_metadata <- function(query_path = "") {
   token_ttl <- "21600" # same approach as in boto3: https://github.com/boto/botocore/blob/master/botocore/utils.py#L376
   # Do not get metadata when the disabled setting is on.
-  if (
-    trimws(tolower(get_env("AWS_EC2_METADATA_DISABLED"))) %in% c("true", "1")
-  ) {
+  if (trimws(tolower(get_env("AWS_EC2_METADATA_DISABLED"))) %in% c("true", "1")) {
     return(NULL)
   }
   # Get token timeout for IMDSv2 tokens
@@ -227,18 +219,12 @@ get_instance_metadata <- function(query_path = "") {
       NULL
     }
   )
-  if (
-    !is.null(metadata_token_response) &&
-      metadata_token_response$status_code == 200
-  ) {
+  if (!is.null(metadata_token_response) && metadata_token_response$status_code == 200) {
     if (length(metadata_token_response[["body"]]) > 0) {
       token <- rawToChar(metadata_token_response[["body"]])
     }
   }
-  metadata_url <- file.path(
-    "http://169.254.169.254/latest/meta-data",
-    query_path
-  )
+  metadata_url <- file.path("http://169.254.169.254/latest/meta-data", query_path)
   if (token != "") {
     metadata_request <- new_http_request(
       "GET",
@@ -358,9 +344,7 @@ check_config_file_endpoint <- function(profile = "", service_id = "") {
   if (is.null(service_name <- profile[["services"]])) {
     return(profile[["endpoint_url"]])
   }
-  profile_service <- config_values[[paste("services", service_name)]][[
-    service_id
-  ]]
+  profile_service <- config_values[[paste("services", service_name)]][[service_id]]
   if (is.null(profile_service)) {
     return(profile[["endpoint_url"]])
   }
@@ -409,12 +393,7 @@ get_web_identity_token_file <- function(web_identity_token_file = "") {
 
 # Get the Web Identity Token from reading the token file
 get_web_identity_token <- function(web_identity_token_file = "") {
-  return(
-    readLines(
-      get_web_identity_token_file(web_identity_token_file),
-      warn = FALSE
-    )
-  )
+  return(readLines(get_web_identity_token_file(web_identity_token_file), warn = FALSE))
 }
 
 # Check if sts_regional_endpoint is present in config file
@@ -450,9 +429,7 @@ get_sts_regional_endpoint <- function(profile = "") {
   return(sts_regional_endpoint %||% "")
 }
 
-.optional_config_parameter <- list(
-  "sts_regional_endpoint" = get_sts_regional_endpoint
-)
+.optional_config_parameter <- list("sts_regional_endpoint" = get_sts_regional_endpoint)
 
 # Ensures config is built correctly from service parameters
 build_config <- function(cfg) {
@@ -472,9 +449,7 @@ build_config <- function(cfg) {
       for (credentails_name in credentails_names) {
         if (credentails_name == "creds") {
           for (cred_name in cred_names) {
-            creds[[cred_name]] <- cfg[[cfg_name]][[credentails_name]][[
-              cred_name
-            ]]
+            creds[[cred_name]] <- cfg[[cfg_name]][[credentails_name]][[cred_name]]
           }
           credentials[[credentails_name]] <- add_list(creds)
         } else {

--- a/paws.common/R/credential_sso.R
+++ b/paws.common/R/credential_sso.R
@@ -46,30 +46,12 @@
       )
     ),
     "js" = list(
-      "*" = list(
-        endpoint = "portal.sso.{region}.amazonaws.com",
-        global = FALSE
-      ),
-      "cn-*" = list(
-        endpoint = "portal.sso.{region}.amazonaws.com.cn",
-        global = FALSE
-      ),
-      "eu-isoe-*" = list(
-        endpoint = "portal.sso.{region}.cloud.adc-e.uk",
-        global = FALSE
-      ),
-      "us-iso-*" = list(
-        endpoint = "portal.sso.{region}.c2s.ic.gov",
-        global = FALSE
-      ),
-      "us-isob-*" = list(
-        endpoint = "portal.sso.{region}.sc2s.sgov.gov",
-        global = FALSE
-      ),
-      "us-isof-*" = list(
-        endpoint = "portal.sso.{region}.csp.hci.ic.gov",
-        global = FALSE
-      )
+      "*" = list(endpoint = "portal.sso.{region}.amazonaws.com", global = FALSE),
+      "cn-*" = list(endpoint = "portal.sso.{region}.amazonaws.com.cn", global = FALSE),
+      "eu-isoe-*" = list(endpoint = "portal.sso.{region}.cloud.adc-e.uk", global = FALSE),
+      "us-iso-*" = list(endpoint = "portal.sso.{region}.c2s.ic.gov", global = FALSE),
+      "us-isob-*" = list(endpoint = "portal.sso.{region}.sc2s.sgov.gov", global = FALSE),
+      "us-isof-*" = list(endpoint = "portal.sso.{region}.csp.hci.ic.gov", global = FALSE)
     )
   )
 }
@@ -86,11 +68,7 @@
     list(
       roleName = structure(
         logical(0),
-        tags = list(
-          location = "querystring",
-          locationName = "role_name",
-          type = "string"
-        )
+        tags = list(location = "querystring", locationName = "role_name", type = "string")
       ),
       accountId = structure(
         logical(0),

--- a/paws.common/R/credential_sts.R
+++ b/paws.common/R/credential_sts.R
@@ -68,24 +68,12 @@ sts <- function(config = list()) {
     ),
     "js" = list(
       "*" = list(endpoint = "https://sts.amazonaws.com", global = TRUE),
-      "us-gov-*" = list(
-        endpoint = "sts.{region}.amazonaws.com",
-        global = FALSE
-      ),
+      "us-gov-*" = list(endpoint = "sts.{region}.amazonaws.com", global = FALSE),
       "cn-*" = list(endpoint = "sts.{region}.amazonaws.com.cn", global = FALSE),
-      "eu-isoe-*" = list(
-        endpoint = "sts.{region}.cloud.adc-e.uk",
-        global = FALSE
-      ),
+      "eu-isoe-*" = list(endpoint = "sts.{region}.cloud.adc-e.uk", global = FALSE),
       "us-iso-*" = list(endpoint = "sts.{region}.c2s.ic.gov", global = FALSE),
-      "us-isob-*" = list(
-        endpoint = "sts.{region}.sc2s.sgov.gov",
-        global = FALSE
-      ),
-      "us-isof-*" = list(
-        endpoint = "sts.{region}.csp.hci.ic.gov",
-        global = FALSE
-      )
+      "us-isob-*" = list(endpoint = "sts.{region}.sc2s.sgov.gov", global = FALSE),
+      "us-isof-*" = list(endpoint = "sts.{region}.csp.hci.ic.gov", global = FALSE)
     )
   )
 }
@@ -252,10 +240,7 @@ sts_assume_role <- function(
         ),
         tags = list(type = "structure")
       ),
-      SubjectFromWebIdentityToken = structure(
-        logical(0),
-        tags = list(type = "string")
-      ),
+      SubjectFromWebIdentityToken = structure(logical(0), tags = list(type = "string")),
       AssumedRoleUser = structure(
         list(
           AssumedRoleId = structure(logical(0), tags = list(type = "string")),
@@ -268,10 +253,7 @@ sts_assume_role <- function(
       Audience = structure(logical(0), tags = list(type = "string")),
       SourceIdentity = structure(logical(0), tags = list(type = "string"))
     ),
-    tags = list(
-      type = "structure",
-      resultWrapper = "AssumeRoleWithWebIdentityResult"
-    )
+    tags = list(type = "structure", resultWrapper = "AssumeRoleWithWebIdentityResult")
   )
   return(populate(args, shape))
 }

--- a/paws.common/R/custom_rds.R
+++ b/paws.common/R/custom_rds.R
@@ -1,6 +1,5 @@
 rds_build_auth_token <- function(endpoint, user, creds = NULL, region = NULL) {
-  if (!startsWith(endpoint, "https://"))
-    endpoint <- paste0("https://", endpoint)
+  if (!startsWith(endpoint, "https://")) endpoint <- paste0("https://", endpoint)
   req <- new_http_request("GET", endpoint)
   auth_token_params <- list(Action = "connect", DBUser = user)
   req$url$raw_query <- update_query_string(req$url$raw_query, auth_token_params)
@@ -21,12 +20,7 @@ rds_build_auth_token <- function(endpoint, user, creds = NULL, region = NULL) {
   return(substr(url, 9, nchar(url)))
 }
 
-rds_build_auth_token_v2 <- function(
-  DBHostname,
-  Port,
-  DBUsername,
-  Region = NULL
-) {
+rds_build_auth_token_v2 <- function(DBHostname, Port, DBUsername, Region = NULL) {
   op <- new_operation(
     name = "connect",
     http_method = "GET",
@@ -43,8 +37,7 @@ rds_build_auth_token_v2 <- function(
     config$region <- Region
   }
 
-  if (!startsWith(DBHostname, "https://"))
-    DBHostname <- paste0("https://", DBHostname)
+  if (!startsWith(DBHostname, "https://")) DBHostname <- paste0("https://", DBHostname)
   config$endpoint <- paste(DBHostname, Port, sep = ":")
 
   metadata <- list(

--- a/paws.common/R/custom_s3.R
+++ b/paws.common/R/custom_s3.R
@@ -97,12 +97,7 @@ get_access_point_endpoint <- function(access_point) {
   region <- part[4]
   account <- part[5]
   name <- part[7]
-  endpoint <- sprintf(
-    "%s-%s.s3-accesspoint.%s.amazonaws.com",
-    name,
-    account,
-    region
-  )
+  endpoint <- sprintf("%s-%s.s3-accesspoint.%s.amazonaws.com", name, account, region)
   return(endpoint)
 }
 
@@ -138,10 +133,7 @@ update_endpoint_for_s3_config <- function(request) {
   }
 
   if (use_virtual_host_style) {
-    request$http_request$url <- move_bucket_to_host(
-      request$http_request$url,
-      bucket_name
-    )
+    request$http_request$url <- move_bucket_to_host(request$http_request$url, bucket_name)
   }
 
   return(request)
@@ -274,10 +266,7 @@ s3_unmarshal_error <- function(request) {
     request$http_response$body,
     request$operation$stream_api
   )
-  data <- tryCatch(
-    decode_xml(request$http_response$body),
-    error = function(e) NULL
-  )
+  data <- tryCatch(decode_xml(request$http_response$body), error = function(e) NULL)
   # Bucket exists in a different region, and request needs
   # to be made to the correct region.
   if (request$http_response$status_code == 301) {
@@ -287,9 +276,7 @@ s3_unmarshal_error <- function(request) {
       request$config$region,
       request$config$endpoint
     )
-    if (
-      nzchar(v <- request$http_response$header[["x-amz-bucket-region"]] %||% "")
-    ) {
+    if (nzchar(v <- request$http_response$header[["x-amz-bucket-region"]] %||% "")) {
       error_msg[[2]] <- sprintf(", bucket is in '%s' region", v)
     }
     request$error <- Error(
@@ -314,12 +301,7 @@ s3_unmarshal_error <- function(request) {
     return(request)
   }
 
-  request$error <- Error(
-    code,
-    message,
-    request$http_response$status_code,
-    error_response
-  )
+  request$error <- Error(code, message, request$http_response$status_code, error_response)
   return(request)
 }
 
@@ -461,11 +443,7 @@ s3_get_bucket_region <- function(request, error, bucket) {
 # Splice a new endpoint into an existing URL. Note that some endpoints
 # from the endpoint provider have a path component which will be
 # discarded by this function.
-set_request_url <- function(
-  original_endpoint,
-  new_endpoint,
-  use_new_scheme = TRUE
-) {
+set_request_url <- function(original_endpoint, new_endpoint, use_new_scheme = TRUE) {
   new_endpoint_components <- parse_url(new_endpoint)
   final_endpoint_components <- parse_url(original_endpoint)
   scheme <- final_endpoint_components$scheme
@@ -536,14 +514,8 @@ quote_source_header_from_list <- function(source, tags) {
 ################################################################################
 
 customizations$s3 <- function(handlers) {
-  handlers$build <- handlers_add_front(
-    handlers$build,
-    update_endpoint_for_s3_config
-  )
-  handlers$build <- handlers_add_front(
-    handlers$build,
-    populate_location_constraint
-  )
+  handlers$build <- handlers_add_front(handlers$build, update_endpoint_for_s3_config)
+  handlers$build <- handlers_add_front(handlers$build, populate_location_constraint)
   handlers$build <- handlers_add_front(handlers$build, convert_file_to_raw)
   handlers$build <- handlers_add_front(handlers$build, handle_copy_source_param)
   handlers$build <- handlers_add_front(handlers$build, sse_md5_build)

--- a/paws.common/R/dateutil.R
+++ b/paws.common/R/dateutil.R
@@ -12,10 +12,7 @@ as_timestamp <- function(x, format, tz = "GMT") {
     attr(result, "tzone") <- tz
     return(result)
   }
-  lookup <- c(
-    "iso8601" = "%Y-%m-%dT%H:%M:%S",
-    "rfc822" = "%a, %d %b %Y %H:%M:%S"
-  )
+  lookup <- c("iso8601" = "%Y-%m-%dT%H:%M:%S", "rfc822" = "%a, %d %b %Y %H:%M:%S")
   result <- as.POSIXct(x, tz = tz, format = lookup[format])
   return(result)
 }

--- a/paws.common/R/error.R
+++ b/paws.common/R/error.R
@@ -11,9 +11,7 @@ Error <- struct(
 ERROR_MSG_TEMPLATE <- "An error occurred when calling the %s operation%s: %s"
 
 serialization_error <- function(request) {
-  error_message <- http_statuses[[
-    as.character(request$http_response$status_code)
-  ]]
+  error_message <- http_statuses[[as.character(request$http_response$status_code)]]
   Error(
     "SerializationError",
     sprintf(
@@ -69,10 +67,7 @@ aws_error <- function(e, call = sys.call(-1), use_call = FALSE) {
     # If the http_error is still NA (default), don't set specific classes.
     http_class <- c("http_error")
   } else {
-    http_class <- paste0(
-      "http_",
-      unique(c(e$status_code, status_type, "error"))
-    )
+    http_class <- paste0("http_", unique(c(e$status_code, status_type, "error")))
   }
   if (!use_call) {
     call <- NULL

--- a/paws.common/R/handlers_ec2query.R
+++ b/paws.common/R/handlers_ec2query.R
@@ -1,9 +1,6 @@
 # Build the request for the EC2 protocol.
 ec2query_build <- function(request) {
-  body <- list(
-    Action = request$operation$name,
-    Version = request$client_info$api_version
-  )
+  body <- list(Action = request$operation$name, Version = request$client_info$api_version)
 
   body <- query_parse(body, request$params, TRUE)
 
@@ -42,11 +39,6 @@ ec2query_unmarshal_error <- function(request) {
   error_response <- lapply(body$Response$Errors[[1]], unlist)
   code <- error_response$Code
   message <- error_response$Message
-  request$error <- Error(
-    code,
-    message,
-    request$http_response$status_code,
-    error_response
-  )
+  request$error <- Error(code, message, request$http_response$status_code, error_response)
   return(request)
 }

--- a/paws.common/R/handlers_jsonrpc.R
+++ b/paws.common/R/handlers_jsonrpc.R
@@ -8,18 +8,11 @@ jsonrpc_build <- function(request) {
     body <- EMPTY_JSON
   }
 
-  if (
-    !is_empty(request$client_info$target_prefix) ||
-      (!is.null(body) && body != "{}")
-  ) {
+  if (!is_empty(request$client_info$target_prefix) || (!is.null(body) && body != "{}")) {
     request <- set_body(request, body)
   }
   if (!is_empty(request$client_info$target_prefix)) {
-    target <- paste0(
-      request$client_info$target_prefix,
-      ".",
-      request$operation$name
-    )
+    target <- paste0(request$client_info$target_prefix, ".", request$operation$name)
     request$http_request$header["X-Amz-Target"] <- target
   }
 
@@ -71,12 +64,7 @@ jsonrpc_unmarshal_error <- function(request) {
   }
   code <- strsplit(error[["__type"]], "#")[[1]][1]
   message <- ""
-  message_name <- grep(
-    "message",
-    names(error),
-    ignore.case = TRUE,
-    value = TRUE
-  )
+  message_name <- grep("message", names(error), ignore.case = TRUE, value = TRUE)
   if (length(message_name) > 0) {
     message <- error[[message_name]]
   }

--- a/paws.common/R/handlers_query.R
+++ b/paws.common/R/handlers_query.R
@@ -2,10 +2,7 @@
 
 # Build the request for the Query protocol.
 query_build <- function(request) {
-  body <- list(
-    Action = request$operation$name,
-    Version = request$client_info$api_version
-  )
+  body <- list(Action = request$operation$name, Version = request$client_info$api_version)
 
   body <- query_parse(body, request$params, FALSE)
 
@@ -43,10 +40,7 @@ query_unmarshal_meta <- function(request) {
 
 # Unmarshal errors from a Query protocol response.
 query_unmarshal_error <- function(request) {
-  data <- tryCatch(
-    decode_xml(request$http_response$body),
-    error = function(e) NULL
-  )
+  data <- tryCatch(decode_xml(request$http_response$body), error = function(e) NULL)
 
   if (is.null(data)) {
     request$error <- serialization_error(request)

--- a/paws.common/R/handlers_rest.R
+++ b/paws.common/R/handlers_rest.R
@@ -40,11 +40,7 @@ rest_build_location_elements <- function(request, values, build_get_query) {
         name
       )
     } else if (location == "uri") {
-      request$http_request$url <- rest_build_uri(
-        request$http_request$url,
-        field,
-        name
-      )
+      request$http_request$url <- rest_build_uri(request$http_request$url, field, name)
     } else if (location == "querystring") {
       query <- rest_build_query_string(query, field, name)
     } else if (build_get_query) {
@@ -64,10 +60,7 @@ rest_build_header_map <- function(header, values) {
   prefix <- tag_get(values, "locationName")
   for (key in names(values)) {
     value <- values[[key]]
-    header[[paste0(prefix, key)]] <- convert_type(
-      value,
-      timestamp_format = "unix"
-    )
+    header[[paste0(prefix, key)]] <- convert_type(value, timestamp_format = "unix")
   }
   return(header)
 }

--- a/paws.common/R/handlers_restjson.R
+++ b/paws.common/R/handlers_restjson.R
@@ -10,9 +10,7 @@ restjson_build <- function(request) {
   if (has_streaming_payload(request, t)) {
     headers <- request[["http_request"]][["header"]]
     if (is.null(headers[["Content-Type"]])) {
-      request[["http_request"]][["header"]][[
-        "Content-Type"
-      ]] <- "application/json"
+      request[["http_request"]][["header"]][["Content-Type"]] <- "application/json"
     }
     if (is.null(headers[["Accept"]])) {
       request[["http_request"]][["header"]][["Accept"]] <- "application/json"

--- a/paws.common/R/handlers_stream.R
+++ b/paws.common/R/handlers_stream.R
@@ -267,10 +267,7 @@ parse_aws_event <- function(bytes) {
   payload_raw <- read_bytes(total_length - i - 4 + 1)
 
   # validate the message checksum
-  validate_checksum(
-    bytes[1:(total_length - 4)],
-    paste(read_bytes(4), collapse = "")
-  )
+  validate_checksum(bytes[1:(total_length - 4)], paste(read_bytes(4), collapse = ""))
 
   list(
     total_length = total_length,
@@ -346,10 +343,6 @@ crc32 <- function(raw) {
 validate_checksum <- function(data, crc) {
   computed_checksum <- crc32(data)
   if (computed_checksum != crc) {
-    stopf(
-      "Checksum mismatch: expected %s, calculated %s",
-      crc,
-      computed_checksum
-    )
+    stopf("Checksum mismatch: expected %s, calculated %s", crc, computed_checksum)
   }
 }

--- a/paws.common/R/head_bucket.R
+++ b/paws.common/R/head_bucket.R
@@ -48,54 +48,21 @@
       )
     ),
     "js" = list(
-      "us-gov-west-1" = list(
-        endpoint = "s3.{region}.amazonaws.com",
-        global = FALSE
-      ),
-      "us-west-1" = list(
-        endpoint = "s3.{region}.amazonaws.com",
-        global = FALSE
-      ),
-      "us-west-2" = list(
-        endpoint = "s3.{region}.amazonaws.com",
-        global = FALSE
-      ),
-      "eu-west-1" = list(
-        endpoint = "s3.{region}.amazonaws.com",
-        global = FALSE
-      ),
-      "ap-southeast-1" = list(
-        endpoint = "s3.{region}.amazonaws.com",
-        global = FALSE
-      ),
-      "ap-southeast-2" = list(
-        endpoint = "s3.{region}.amazonaws.com",
-        global = FALSE
-      ),
-      "ap-northeast-1" = list(
-        endpoint = "s3.{region}.amazonaws.com",
-        global = FALSE
-      ),
-      "sa-east-1" = list(
-        endpoint = "s3.{region}.amazonaws.com",
-        global = FALSE
-      ),
+      "us-gov-west-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+      "us-west-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+      "us-west-2" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+      "eu-west-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+      "ap-southeast-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+      "ap-southeast-2" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+      "ap-northeast-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+      "sa-east-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
       "us-east-1" = list(endpoint = "s3.amazonaws.com", global = FALSE),
       "*" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
       "cn-*" = list(endpoint = "s3.{region}.amazonaws.com.cn", global = FALSE),
-      "eu-isoe-*" = list(
-        endpoint = "s3.{region}.cloud.adc-e.uk",
-        global = FALSE
-      ),
+      "eu-isoe-*" = list(endpoint = "s3.{region}.cloud.adc-e.uk", global = FALSE),
       "us-iso-*" = list(endpoint = "s3.{region}.c2s.ic.gov", global = FALSE),
-      "us-isob-*" = list(
-        endpoint = "s3.{region}.sc2s.sgov.gov",
-        global = FALSE
-      ),
-      "us-isof-*" = list(
-        endpoint = "s3.{region}.csp.hci.ic.gov",
-        global = FALSE
-      )
+      "us-isob-*" = list(endpoint = "s3.{region}.sc2s.sgov.gov", global = FALSE),
+      "us-isof-*" = list(endpoint = "s3.{region}.csp.hci.ic.gov", global = FALSE)
     )
   )
 }

--- a/paws.common/R/iniutil.R
+++ b/paws.common/R/iniutil.R
@@ -45,9 +45,7 @@ read_ini <- function(file_name) {
         which(sub_grps[items])
       )
     } else {
-      profiles[[i]] <- extract_ini_parameter(
-        split_content[items, , drop = FALSE]
-      )
+      profiles[[i]] <- extract_ini_parameter(split_content[items, , drop = FALSE])
     }
   }
   ini_cache[[file_name]] <- profiles

--- a/paws.common/R/logging.R
+++ b/paws.common/R/logging.R
@@ -105,11 +105,7 @@ log_error <- function(...) {
 log_msg <- function(lvl, msg) {
   log_file <- getOption("paws.log_file")
   now <- strftime(now(), "%Y-%m-%d %H:%M:%OS3")
-  cat(
-    sprintf("%s [%s]: %s\n", log_color(lvl), now, msg),
-    file = log_file,
-    append = TRUE
-  )
+  cat(sprintf("%s [%s]: %s\n", log_color(lvl), now, msg), file = log_file, append = TRUE)
   on.exit(flush.console())
 }
 
@@ -158,10 +154,7 @@ init_log_config <- function() {
   # check R options for log settings
   r_options <- lapply(log_opt_name, getOption)
   names(r_options) <- log_opt_name
-  paws_logging_opt <- modifyList(
-    paws_logging_opt,
-    Filter(Negate(is.null), r_options)
-  )
+  paws_logging_opt <- modifyList(paws_logging_opt, Filter(Negate(is.null), r_options))
 
   # check environment variables for log settings
   env_options <- lapply(
@@ -170,10 +163,7 @@ init_log_config <- function() {
     unset = NA
   )
   names(env_options) <- c(log_opt_name)
-  paws_logging_opt <- modifyList(
-    paws_logging_opt,
-    Filter(Negate(is.na), env_options)
-  )
+  paws_logging_opt <- modifyList(paws_logging_opt, Filter(Negate(is.na), env_options))
   # ensure log level is an integer
   paws_logging_opt$paws.log_level <- as.integer(paws_logging_opt$paws.log_level)
 

--- a/paws.common/R/net.R
+++ b/paws.common/R/net.R
@@ -101,16 +101,7 @@ new_http_request <- function(
 }
 
 valid_method <- function(method) {
-  methods <- c(
-    "OPTIONS",
-    "GET",
-    "HEAD",
-    "POST",
-    "PUT",
-    "DELETE",
-    "TRACE",
-    "CONNECT"
-  )
+  methods <- c("OPTIONS", "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "CONNECT")
   ok <- method %in% methods
   return(ok)
 }

--- a/paws.common/R/populate.R
+++ b/paws.common/R/populate.R
@@ -30,10 +30,7 @@ populate_structure <- function(input, interface) {
       if (!check_location) {
         stopf("invalid name: %s", name)
       }
-      interface[[check_location]] <- populate(
-        input[[name]],
-        interface[[check_location]]
-      )
+      interface[[check_location]] <- populate(input[[name]], interface[[check_location]])
     } else {
       interface[[name]] <- populate(input[[name]], interface[[name]])
     }

--- a/paws.common/R/populateutil.R
+++ b/paws.common/R/populateutil.R
@@ -28,8 +28,7 @@ Map <- function(..., .tags = NULL) {
 }
 
 Scalar <- function(value = NULL, .tags = NULL, type = "scalar") {
-  if (length(value) > 1 || !is_atomic(value))
-    stop("a scalar must be length <= 1")
+  if (length(value) > 1 || !is_atomic(value)) stop("a scalar must be length <= 1")
   if (is.null(value)) value <- logical(0)
   tags <- c(list(type = type), .tags)
   value <- tag_add(value, tags)

--- a/paws.common/R/queryutil.R
+++ b/paws.common/R/queryutil.R
@@ -43,10 +43,7 @@ query_parse_structure <- function(values, value, prefix, tag, is_ec2 = FALSE) {
       name <- tag_get(field, "queryName")
     }
     if (name == "") {
-      if (
-        tag_get(field, "flattened") != "" &&
-          tag_get(field, "locationNameList") != ""
-      ) {
+      if (tag_get(field, "flattened") != "" && tag_get(field, "locationNameList") != "") {
         name <- tag_get(field, "locationNameList")
       } else if (tag_get(field, "locationName") != "") {
         name <- tag_get(field, "locationName")

--- a/paws.common/R/request.R
+++ b/paws.common/R/request.R
@@ -126,9 +126,7 @@ new_request <- function(client, operation, params, data, dest = NULL) {
     stream_api = operation$stream_api
   )
 
-  http_req$url <- parse_url(
-    paste0(client$client_info$endpoint, operation$http_path)
-  )
+  http_req$url <- parse_url(paste0(client$client_info$endpoint, operation$http_path))
 
   http_req <- sanitize_host_for_header(http_req)
 

--- a/paws.common/R/service.R
+++ b/paws.common/R/service.R
@@ -18,14 +18,8 @@ new_handlers <- function(protocol, signer) {
     get(paste0(protocol, "_", type))
   }
   handlers <- Handlers(
-    validate = HandlerList(
-      validate_endpoint_handler,
-      validate_parameters_handler
-    ),
-    build = HandlerList(
-      add_host_exec_env_user_agent_handler,
-      handler(protocol, "build")
-    ),
+    validate = HandlerList(validate_endpoint_handler, validate_parameters_handler),
+    build = HandlerList(add_host_exec_env_user_agent_handler, handler(protocol, "build")),
     sign = HandlerList(
       build_content_length_handler,
       handler(signer, "sign_request_handler")
@@ -103,12 +97,7 @@ new_handlers <- function(protocol, signer) {
 #' @seealso [new_operation()]
 #'
 #' @export
-new_service <- function(
-  metadata,
-  handlers,
-  cfgs = NULL,
-  operation = Operation()
-) {
+new_service <- function(metadata, handlers, cfgs = NULL, operation = Operation()) {
   cfg <- client_config(
     service_name = metadata$service_name,
     endpoints = metadata$endpoints,
@@ -134,11 +123,7 @@ new_service <- function(
 
   handlers <- customize(handlers, metadata$service_name)
 
-  svc <- Client(
-    config = cfg$config,
-    client_info = client_info,
-    handlers = handlers
-  )
+  svc <- Client(config = cfg$config, client_info = client_info, handlers = handlers)
   return(svc)
 }
 

--- a/paws.common/R/signer_v1.R
+++ b/paws.common/R/signer_v1.R
@@ -210,12 +210,7 @@ canonical_custom_headers <- function(ctx, headers) {
   sorted_header_keys <- sort_list(as.list(custom_headers))
   canonical_headers <- c(
     ctx$canonical_headers,
-    paste(
-      names(sorted_header_keys),
-      sorted_header_keys,
-      sep = ":",
-      collapse = "\n"
-    )
+    paste(names(sorted_header_keys), sorted_header_keys, sep = ":", collapse = "\n")
   )
   return(canonical_headers[nzchar(canonical_headers)])
 }

--- a/paws.common/R/signer_v4.R
+++ b/paws.common/R/signer_v4.R
@@ -99,11 +99,7 @@ v4_sign_request_handler <- function(request) {
   return(sign_sdk_request_with_curr_time(request))
 }
 
-sign_sdk_request_with_curr_time <- function(
-  request,
-  curr_time_fn = now,
-  opts = NULL
-) {
+sign_sdk_request_with_curr_time <- function(request, curr_time_fn = now, opts = NULL) {
   region <- request$client_info$signing_region
   if (region == "") {
     region <- request$config$region
@@ -299,11 +295,7 @@ build_context <- function(ctx, disable_header_hoisting) {
   # log_debug("Signature:\n%s", ctx$signature)
   if (ctx$is_presigned) {
     query <- ctx$request$url$raw_query
-    ctx$request$url$raw_query <- sprintf(
-      "%s&X-Amz-Signature=%s",
-      query,
-      ctx$signature
-    )
+    ctx$request$url$raw_query <- sprintf("%s&X-Amz-Signature=%s", query, ctx$signature)
   } else {
     authorization <- paste(
       paste0(
@@ -325,11 +317,7 @@ build_context <- function(ctx, disable_header_hoisting) {
 
 build_time <- function(ctx) {
   ctx$formatted_time <- format(ctx$time, tz = "UTC", format = TIME_FORMAT)
-  ctx$formatted_short_time <- format(
-    ctx$time,
-    tz = "UTC",
-    format = SHORT_TIME_FORMAT
-  )
+  ctx$formatted_short_time <- format(ctx$time, tz = "UTC", format = SHORT_TIME_FORMAT)
   if (ctx$is_presigned) {
     ctx$query[["X-Amz-Date"]] <- ctx$formatted_time
     ctx$query[["X-Amz-Expires"]] <- as.character(as.integer(ctx$expire_time))
@@ -368,12 +356,9 @@ build_body_digest <- function(ctx) {
   hash <- get_element(ctx$request$header, "X-Amz-Content-Sha256")
   if (hash == "") {
     include_sha256_header <- (
-      ctx$unsigned_payload ||
-        ctx$service_name %in% c("s3", "s3-object-lambda", "glacier")
+      ctx$unsigned_payload || ctx$service_name %in% c("s3", "s3-object-lambda", "glacier")
     )
-    s3_presign <- (
-      ctx$is_presigned && ctx$service_name %in% c("s3", "s3-object-lambda")
-    )
+    s3_presign <- (ctx$is_presigned && ctx$service_name %in% c("s3", "s3-object-lambda"))
     if (ctx$unsigned_payload || s3_presign) {
       hash <- "UNSIGNED-PAYLOAD"
       include_sha256_header <- !s3_presign

--- a/paws.common/R/tags.R
+++ b/paws.common/R/tags.R
@@ -115,13 +115,7 @@ tag_del <- function(object, tags = NULL) {
 type <- function(object) {
   type_tag <- tag_get(object, "type")
   if (type_tag != "") {
-    t <- switch(
-      type_tag,
-      structure = "structure",
-      list = "list",
-      map = "map",
-      "scalar"
-    )
+    t <- switch(type_tag, structure = "structure", list = "list", map = "map", "scalar")
   } else {
     t <- guess_type(object)
   }

--- a/paws.common/R/url.R
+++ b/paws.common/R/url.R
@@ -39,12 +39,7 @@ build_query_string <- function(params) {
   params[found_multi] <- vapply(
     param_names[found_multi],
     function(nm) {
-      paste(
-        nm,
-        paws_url_encoder(as.character(params[[nm]])),
-        sep = "=",
-        collapse = "&"
-      )
+      paste(nm, paws_url_encoder(as.character(params[[nm]])), sep = "=", collapse = "&")
     },
     FUN.VALUE = ""
   )

--- a/paws.common/R/util.R
+++ b/paws.common/R/util.R
@@ -241,8 +241,7 @@ parse_in_half <- function(x, char = "=") {
 }
 
 set_user_agent <- function(pkgname) {
-  paws_version <- .__NAMESPACE__.[["spec"]]["version"] %||%
-    packageVersion(pkgname)
+  paws_version <- .__NAMESPACE__.[["spec"]]["version"] %||% packageVersion(pkgname)
   user_agent <- sprintf(
     "paws/%s (R%s; %s; %s)",
     paws_version,

--- a/paws.common/air.toml
+++ b/paws.common/air.toml
@@ -1,5 +1,5 @@
 [format]
-line-width = 80
+line-width = 90
 indent-width = 2
 indent-style = "space"
 line-ending = "auto"

--- a/paws.common/tests/testthat/helper.R
+++ b/paws.common/tests/testthat/helper.R
@@ -18,12 +18,7 @@
 #
 # $z
 # [1] "bye"
-mock2 <- function(
-  ...,
-  cycle = FALSE,
-  side_effect = NULL,
-  envir = parent.frame()
-) {
+mock2 <- function(..., cycle = FALSE, side_effect = NULL, envir = parent.frame()) {
   return_values <- eval(substitute(alist(...)))
   return_values_env <- envir
   call_no <- 0
@@ -35,10 +30,7 @@ mock2 <- function(
     args[[call_no]] <<- list(...)
     if (length(return_values)) {
       if (call_no > length(return_values) && !cycle) {
-        stop(
-          "too many calls to mock object and cycle set to FALSE",
-          call. = FALSE
-        )
+        stop("too many calls to mock object and cycle set to FALSE", call. = FALSE)
       }
       value <- return_values[[(call_no - 1) %% length(return_values) + 1]]
       return(eval(value, envir = return_values_env))

--- a/paws.common/tests/testthat/test_client.R
+++ b/paws.common/tests/testthat/test_client.R
@@ -88,10 +88,7 @@ test_that("client_config uses custom endpoint", {
     ),
     cfgs = cfgs
   )
-  expect_equal(
-    "https://test.us-west-2.amazonaws.com",
-    client_cfg$config$endpoint
-  )
+  expect_equal("https://test.us-west-2.amazonaws.com", client_cfg$config$endpoint)
 })
 
 test_that("client_config uses custom region", {
@@ -131,9 +128,6 @@ test_that("client_config uses custom credentials", {
     service_id = "foo"
   )
   expect_equal("test_key", client_cfg$config$credentials$creds$access_key_id)
-  expect_equal(
-    "test_secret",
-    client_cfg$config$credentials$creds$secret_access_key
-  )
+  expect_equal("test_secret", client_cfg$config$credentials$creds$secret_access_key)
   expect_equal("test_profile", client_cfg$config$credentials$profile)
 })

--- a/paws.common/tests/testthat/test_config.R
+++ b/paws.common/tests/testthat/test_config.R
@@ -8,11 +8,7 @@ test_that("get_config", {
   expect_equal(actual$region, 123, ignore_attr = TRUE)
 
   # Check if config is returned when executed in a `do.call`.
-  expect_equal(
-    do.call(svc$operation, list()),
-    svc$operation(),
-    ignore_attr = TRUE
-  )
+  expect_equal(do.call(svc$operation, list()), svc$operation(), ignore_attr = TRUE)
 
   f <- function() {
     svc$operation()
@@ -42,11 +38,7 @@ test_that("get_config optional parameter update", {
 })
 
 test_that("set_config", {
-  svc <- list(
-    f = function() "foo",
-    g = function() 123,
-    h = function() get_config()
-  )
+  svc <- list(f = function() "foo", g = function() 123, h = function() get_config())
   a <- set_config(svc, list(region = "foo", endpoint = "bar"))
   expect_equal(a$f(), "foo")
   expect_equal(a$g(), 123)
@@ -90,10 +82,7 @@ test_that("get_role_session_name", {
 })
 
 test_that("get_web_identity_token_file", {
-  expect_error(
-    get_web_identity_token_file(),
-    "No WebIdentityToken file available"
-  )
+  expect_error(get_web_identity_token_file(), "No WebIdentityToken file available")
 
   withr::with_envvar(list(AWS_WEB_IDENTITY_TOKEN_FILE = "bar"), {
     expect_equal(get_web_identity_token_file(), "bar")
@@ -233,11 +222,7 @@ services/"
         http_request$method == "PUT" &&
         http_request$url$path == "/latest/api/token" &&
         !is.na(http_request$header[["X-aws-ec2-metadata-token-ttl-seconds"]]) &&
-        !is.na(
-          as.numeric(
-            http_request$header[["X-aws-ec2-metadata-token-ttl-seconds"]]
-          )
-        )
+        !is.na(as.numeric(http_request$header[["X-aws-ec2-metadata-token-ttl-seconds"]]))
     ) {
       # provide a valid IMDSv2 metadata service token
       mock_imdsv2_token_response <- HttpResponse(
@@ -301,11 +286,7 @@ services/"
 test_that("get sso legacy credentials", {
   mock_get_config_file_path <- mock2("data_sso_ini")
   mock_sso_credential_process <- mock2(invisible(TRUE))
-  mockery::stub(
-    config_file_provider,
-    "get_config_file_path",
-    mock_get_config_file_path
-  )
+  mockery::stub(config_file_provider, "get_config_file_path", mock_get_config_file_path)
   mockery::stub(
     config_file_provider,
     "sso_credential_process",
@@ -329,11 +310,7 @@ test_that("get sso legacy credentials", {
 test_that("get sso credentials", {
   mock_get_config_file_path <- mock2("data_sso_ini")
   mock_sso_credential_process <- mock2(invisible(TRUE))
-  mockery::stub(
-    config_file_provider,
-    "get_config_file_path",
-    mock_get_config_file_path
-  )
+  mockery::stub(config_file_provider, "get_config_file_path", mock_get_config_file_path)
   mockery::stub(
     config_file_provider,
     "sso_credential_process",
@@ -394,10 +371,7 @@ test_that("sso_credential_process legacy", {
 
   # check for correct sso_cache
   expect_true(
-    grepl(
-      "c7aaaf71fcc8777ae2475525ed049d39fe16c484",
-      mock_arg(mock_fromJSON)[[1]]
-    )
+    grepl("c7aaaf71fcc8777ae2475525ed049d39fe16c484", mock_arg(mock_fromJSON)[[1]])
   )
   expect_equal(
     mock_arg(mock_Creds),
@@ -450,10 +424,7 @@ test_that("sso_credential_process", {
 
   # check for correct sso_cache
   expect_true(
-    grepl(
-      "0ad374308c5a4e22f723adf10145eafad7c4031c",
-      mock_arg(mock_fromJSON)[[1]]
-    )
+    grepl("0ad374308c5a4e22f723adf10145eafad7c4031c", mock_arg(mock_fromJSON)[[1]])
   )
   expect_equal(
     mock_arg(mock_Creds),
@@ -597,10 +568,7 @@ test_that("merge_config default param config", {
   )
 
   # Check if cfg is not affected by credentials list()
-  actual2 <- merge_config(
-    cfg,
-    list(credentials = list(), endpoint = NULL, region = NULL)
-  )
+  actual2 <- merge_config(cfg, list(credentials = list(), endpoint = NULL, region = NULL))
 
   # Check if default config is not affected by default credentials()
   actual3 <- merge_config(
@@ -623,11 +591,7 @@ test_that("merge_config modify default config with param config", {
   # check if list config is modified by credentials()
   actual1 <- merge_config(
     list(),
-    list(
-      credentials = credentials(profile = "dummy"),
-      endpoint = NULL,
-      region = NULL
-    )
+    list(credentials = credentials(profile = "dummy"), endpoint = NULL, region = NULL)
   )
 
   # check if list config is modified by credentials
@@ -639,11 +603,7 @@ test_that("merge_config modify default config with param config", {
   # check if config() is modified by all param config
   actual3 <- merge_config(
     config(),
-    list(
-      credentials = credentials(profile = "dummy"),
-      endpoint = "bar",
-      region = "zoo"
-    )
+    list(credentials = credentials(profile = "dummy"), endpoint = "bar", region = "zoo")
   )
 
   expect_credentials <- as.list(credentials(profile = "dummy"))
@@ -668,11 +628,7 @@ test_that("merge_config config and param config", {
 
   # check if list config is modified by credentials
   actual2 <- merge_config(
-    config(
-      credentials(profile = "dummy"),
-      endpoint = "endpoint1",
-      region = "eu-west-1"
-    ),
+    config(credentials(profile = "dummy"), endpoint = "endpoint1", region = "eu-west-1"),
     list(
       credentials = list(profile = "edited"),
       endpoint = "my-endpoint",
@@ -694,9 +650,7 @@ test_that("merge_config config and param config", {
     )
   )
   actual4 <- merge_config(
-    config(
-      credentials(creds(access_key_id = "dummy", secret_access_key = "secret"))
-    ),
+    config(credentials(creds(access_key_id = "dummy", secret_access_key = "secret"))),
     list(endpoint = "my-endpoint", region = "us-east-1")
   )
 
@@ -717,9 +671,7 @@ test_that("merge_config config and param config", {
   )
 
   expect4 <- config(
-    credentials(
-      creds = creds(access_key_id = "dummy", secret_access_key = "secret")
-    ),
+    credentials(creds = creds(access_key_id = "dummy", secret_access_key = "secret")),
     endpoint = "my-endpoint",
     region = "us-east-1"
   )

--- a/paws.common/tests/testthat/test_convert.R
+++ b/paws.common/tests/testthat/test_convert.R
@@ -27,10 +27,7 @@ test_that("raw_to_utf", {
 test_that("convert_type", {
   value <- as.POSIXct("2010-01-01", tz = "UTC")
   value <- tag_add(value, tags = list(type = "timestamp"))
-  expect_equal(
-    "2010-01-01T00:00:00Z",
-    convert_type(value, timestamp_format = "iso8601")
-  )
+  expect_equal("2010-01-01T00:00:00Z", convert_type(value, timestamp_format = "iso8601"))
   expect_equal(
     "Fri, 01 Jan 2010 00:00:00 UTC",
     convert_type(value, timestamp_format = "rfc822")

--- a/paws.common/tests/testthat/test_credential_providers.R
+++ b/paws.common/tests/testthat/test_credential_providers.R
@@ -27,11 +27,7 @@ test_that("get_creds_from_sts_resp()", {
   test_access_key_id <- "AccessKeyId"
   test_secret_access_key <- "SecretAccessKey"
   test_session_token <- "SessionToken"
-  test_expiration <- structure(
-    1136214245,
-    class = c("POSIXct", "POSIXt"),
-    tzone = "GMT"
-  )
+  test_expiration <- structure(1136214245, class = c("POSIXct", "POSIXt"), tzone = "GMT")
 
   test_response <- list(
     Credentials = list(
@@ -84,9 +80,7 @@ test_that("config_file_provider", {
 
     # Test profile using environment credential_source
     mock_get_assumed_role_creds <- mock2(creds$p1)
-    local_mocked_bindings(
-      get_assumed_role_creds = mock_get_assumed_role_creds,
-    )
+    local_mocked_bindings(get_assumed_role_creds = mock_get_assumed_role_creds, )
     expect_equal(config_file_provider("p1"), creds$p1)
     expect_equal(
       mock_arg(mock_get_assumed_role_creds)[1:3],

--- a/paws.common/tests/testthat/test_credentials.R
+++ b/paws.common/tests/testthat/test_credentials.R
@@ -23,11 +23,7 @@ test_that("credentials not provided", {
 })
 
 test_that("credentials expired", {
-  creds <- Creds(
-    access_key_id = "foo",
-    secret_access_key = "bar",
-    expiration = 1000
-  )
+  creds <- Creds(access_key_id = "foo", secret_access_key = "bar", expiration = 1000)
 
   expect_false(is_credentials_provided(creds))
 
@@ -47,19 +43,11 @@ test_that("credentials expired", {
 
   expect_true(is_credentials_provided(creds))
 
-  creds <- Creds(
-    access_key_id = "foo",
-    secret_access_key = "bar",
-    expiration = Inf
-  )
+  creds <- Creds(access_key_id = "foo", secret_access_key = "bar", expiration = Inf)
 
   expect_true(is_credentials_provided(creds))
 
-  creds <- Creds(
-    access_key_id = "foo",
-    secret_access_key = "bar",
-    expiration = NA
-  )
+  creds <- Creds(access_key_id = "foo", secret_access_key = "bar", expiration = NA)
 
   expect_true(is_credentials_provided(creds))
 })
@@ -126,16 +114,8 @@ test_that("credentials are cached", {
   foo <- svc$get_credentials() # get the credentials
   actual <- svc$dont_get_credentials() # access the credentials found above
 
-  expect_equal(
-    actual$credentials$creds$access_key_id,
-    "AKID",
-    ignore_attr = TRUE
-  )
-  expect_equal(
-    actual$credentials$creds$secret_access_key,
-    "SECRET",
-    ignore_attr = TRUE
-  )
+  expect_equal(actual$credentials$creds$access_key_id, "AKID", ignore_attr = TRUE)
+  expect_equal(actual$credentials$creds$secret_access_key, "SECRET", ignore_attr = TRUE)
 })
 
 test_that("credentials refresh when expired", {

--- a/paws.common/tests/testthat/test_custom_s3.R
+++ b/paws.common/tests/testthat/test_custom_s3.R
@@ -74,10 +74,7 @@ test_that("content_md5 works with an empty body", {
   op_input <- function(Body, Bucket, Key) {
     args <- list(Body = Body, Bucket = Bucket, Key = Key)
     interface <- Structure(
-      Body = structure(
-        logical(0),
-        tags = list(streaming = TRUE, type = "blob")
-      ),
+      Body = structure(logical(0), tags = list(streaming = TRUE, type = "blob")),
       Bucket = structure(
         logical(0),
         tags = list(location = "uri", locationName = "Bucket", type = "string")
@@ -284,10 +281,7 @@ test_that("redirect request from http response error", {
   sign_args <- mockery::mock_args(pass)[[1]]
   expect_true(sign_args[[1]]$context$s3_redirect)
   expect_false(sign_args[[1]]$built)
-  expect_equal(
-    actual$client_info$endpoint,
-    "https://s3.eu-east-2.amazonaws.com"
-  )
+  expect_equal(actual$client_info$endpoint, "https://s3.eu-east-2.amazonaws.com")
   expect_equal(actual$http_request$url$host, "s3.eu-east-2.amazonaws.com")
 })
 
@@ -308,9 +302,7 @@ test_that("redirect error with region", {
   error <- s3_unmarshal_error(req)$error
 
   expect_equal(error$code, "BucketRegionError")
-  expect_true(
-    grepl("incorrect region.*bucket is in 'eu-east-2' region", error$message)
-  )
+  expect_true(grepl("incorrect region.*bucket is in 'eu-east-2' region", error$message))
   expect_equal(error$status_code, 301)
 })
 
@@ -400,10 +392,7 @@ test_that("check CopySource character versionId encoded", {
   )
 
   req <- handle_copy_source_param(req)
-  expect_equal(
-    req$params$CopySource,
-    "/foo/%2501file%25/output.txt?versionId=123"
-  )
+  expect_equal(req$params$CopySource, "/foo/%2501file%25/output.txt?versionId=123")
 })
 
 test_that("check CopySource with multiple questions", {
@@ -413,10 +402,7 @@ test_that("check CopySource with multiple questions", {
     copy_source = "/foo/bar+baz?a=baz+?versionId=a+"
   )
   req <- handle_copy_source_param(req)
-  expect_equal(
-    req$params$CopySource,
-    "/foo/bar%2Bbaz%3Fa%3Dbaz%2B?versionId=a+"
-  )
+  expect_equal(req$params$CopySource, "/foo/bar%2Bbaz%3Fa%3Dbaz%2B?versionId=a+")
 })
 
 test_that("check CopySource list encoded", {
@@ -434,18 +420,11 @@ test_that("check CopySource list versionId encoded", {
   req <- build_copy_object_request(
     bucket = "foo",
     key = "file.txt",
-    copy_source = list(
-      Bucket = "foo",
-      Key = "%01file%/output.txt",
-      VersionId = "123"
-    )
+    copy_source = list(Bucket = "foo", Key = "%01file%/output.txt", VersionId = "123")
   )
 
   req <- handle_copy_source_param(req)
-  expect_equal(
-    req$params$CopySource,
-    "foo/%2501file%25/output.txt?versionId=123"
-  )
+  expect_equal(req$params$CopySource, "foo/%2501file%25/output.txt?versionId=123")
 })
 
 test_that("check CopySource list bucket s3 access point", {

--- a/paws.common/tests/testthat/test_endpoint_vendor.R
+++ b/paws.common/tests/testthat/test_endpoint_vendor.R
@@ -76,25 +76,13 @@ test_that("resolver_endpoint boto", {
 test_that("resolver_endpoint js", {
   on.exit(vendor_cache$vendor <- "boto")
   s3_endpoints_js <- list(
-    "us-gov-west-1" = list(
-      endpoint = "s3.{region}.amazonaws.com",
-      global = FALSE
-    ),
+    "us-gov-west-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
     "us-west-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
     "us-west-2" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
     "eu-west-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
-    "ap-southeast-1" = list(
-      endpoint = "s3.{region}.amazonaws.com",
-      global = FALSE
-    ),
-    "ap-southeast-2" = list(
-      endpoint = "s3.{region}.amazonaws.com",
-      global = FALSE
-    ),
-    "ap-northeast-1" = list(
-      endpoint = "s3.{region}.amazonaws.com",
-      global = FALSE
-    ),
+    "ap-southeast-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+    "ap-southeast-2" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
+    "ap-northeast-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
     "sa-east-1" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),
     "us-east-1" = list(endpoint = "s3.amazonaws.com", global = FALSE),
     "*" = list(endpoint = "s3.{region}.amazonaws.com", global = FALSE),

--- a/paws.common/tests/testthat/test_escape.R
+++ b/paws.common/tests/testthat/test_escape.R
@@ -34,10 +34,7 @@ test_that("check if non-ascci characters are correctly encoded", {
 test_that("check if encoded url is correctly decoded", {
   string <- "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~`!@#$%^&*()=+[{]}\\|;:'\",<>/? "
 
-  url <- paste0(
-    sample(strsplit(string, "")[[1]], 1e4, replace = TRUE),
-    collapse = ""
-  )
+  url <- paste0(sample(strsplit(string, "")[[1]], 1e4, replace = TRUE), collapse = "")
   url_encode <- paws_url_encoder(url)
   actual <- unescape(url_encode)
 
@@ -48,10 +45,7 @@ test_that("check if encoded url is correctly decoded", {
 test_that("check if non-encoded url is correctly decoded", {
   string <- "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~"
 
-  url <- paste(
-    sample(strsplit(string, "")[[1]], 1e4, replace = TRUE),
-    collapse = ""
-  )
+  url <- paste(sample(strsplit(string, "")[[1]], 1e4, replace = TRUE), collapse = "")
   url_encode <- paws_url_encoder(url)
   actual <- unescape(url_encode)
 

--- a/paws.common/tests/testthat/test_handlers_core.R
+++ b/paws.common/tests/testthat/test_handlers_core.R
@@ -67,13 +67,7 @@ expect_user_agent <- function(request) {
   r_version <- getRversion()
   r_os <- R.Version()$os
   r_arch <- R.Version()$arch
-  user_agent <- sprintf(
-    "paws/%s (R%s; %s; %s)",
-    paws_version,
-    r_version,
-    r_os,
-    r_arch
-  )
+  user_agent <- sprintf("paws/%s (R%s; %s; %s)", paws_version, r_version, r_os, r_arch)
   return(user_agent)
 }
 

--- a/paws.common/tests/testthat/test_handlers_ec2query.R
+++ b/paws.common/tests/testthat/test_handlers_ec2query.R
@@ -22,10 +22,7 @@ test_that("build scalar members", {
   input <- op_input1(Bar = "val2", Foo = "val1")
   req <- new_request(svc, op, input, NULL)
   req <- build(req)
-  expect_equal(
-    req$body,
-    "Action=OperationName&Bar=val2&Foo=val1&Version=2014-01-01"
-  )
+  expect_equal(req$body, "Action=OperationName&Bar=val2&Foo=val1&Version=2014-01-01")
 })
 
 op_input2 <- function(Foo = NULL, Bar = NULL, Yuck = NULL) {
@@ -34,10 +31,7 @@ op_input2 <- function(Foo = NULL, Bar = NULL, Yuck = NULL) {
     Foo = Scalar(),
     Bar = Scalar(.tags = list(locationName = "barLocationName")),
     Yuck = Scalar(
-      .tags = list(
-        locationName = "yuckLocationName",
-        queryName = "yuckQueryName"
-      )
+      .tags = list(locationName = "yuckLocationName", queryName = "yuckQueryName")
     )
   )
   return(populate(args, interface))
@@ -63,10 +57,7 @@ test_that("build nested structure members", {
   input <- op_input3(Struct = list(Scalar = "foo"))
   req <- new_request(svc, op, input, NULL)
   req <- build(req)
-  expect_equal(
-    req$body,
-    "Action=OperationName&Struct.Scalar=foo&Version=2014-01-01"
-  )
+  expect_equal(req$body, "Action=OperationName&Struct.Scalar=foo&Version=2014-01-01")
 })
 
 op_input4 <- function(ListBools, ListFloats, ListIntegers, ListStrings) {
@@ -194,10 +185,7 @@ test_that("build idempotency token", {
   req <- build(req)
   expect_true(
     grepl(
-      sprintf(
-        "Action=OperationName&Token=%s&Version=2014-01-01",
-        UUID_V4_PATTERN
-      ),
+      sprintf("Action=OperationName&Token=%s&Version=2014-01-01", UUID_V4_PATTERN),
       req$body
     )
   )
@@ -206,9 +194,7 @@ test_that("build idempotency token", {
 op_input10 <- function(ListEnums = NULL) {
   args <- list(ListEnums = ListEnums)
   interface <- Structure(
-    ListEnums = List(
-      Scalar(.tags = list(enum = "InputService10TestShapeEnumType"))
-    )
+    ListEnums = List(Scalar(.tags = list(enum = "InputService10TestShapeEnumType")))
   )
   return(populate(args, interface))
 }
@@ -372,11 +358,7 @@ test_that("unmarshal flattened map", {
 op_output8 <- Structure(
   Map = Map(
     Scalar(),
-    .tags = list(
-      locationNameKey = "foo",
-      locationNameValue = "bar",
-      flattened = TRUE
-    )
+    .tags = list(locationNameKey = "foo", locationNameValue = "bar", flattened = TRUE)
   )
 )
 

--- a/paws.common/tests/testthat/test_handlers_jsonrpc.R
+++ b/paws.common/tests/testthat/test_handlers_jsonrpc.R
@@ -4,10 +4,7 @@
 
 op <- Operation(name = "OperationName")
 svc <- Client(
-  client_info = ClientInfo(
-    json_version = "1.1",
-    target_prefix = "com.amazonaws.foo"
-  )
+  client_info = ClientInfo(json_version = "1.1", target_prefix = "com.amazonaws.foo")
 )
 svc$handlers$build <- HandlerList(jsonrpc_build)
 UUID_V4_PATTERN <- "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
@@ -58,9 +55,7 @@ test_that("build blob value", {
 })
 
 test_that("build blob map", {
-  input <- op_input3(
-    BlobMap = list(key1 = charToRaw("foo"), key2 = charToRaw("bar"))
-  )
+  input <- op_input3(BlobMap = list(key1 = charToRaw("foo"), key2 = charToRaw("bar")))
   req <- new_request(svc, op, input, NULL)
   req <- build(req)
   expect_equal(req$body, '{"BlobMap":{"key1":"Zm9v","key2":"YmFy"}}')
@@ -81,9 +76,7 @@ test_that("build blob list", {
 
 op_input5 <- function(RecursiveStruct) {
   args <- list(RecursiveStruct = RecursiveStruct)
-  interface <- Structure(
-    RecursiveStruct = Structure(NoRecurse = Scalar(type = "string"))
-  )
+  interface <- Structure(RecursiveStruct = Structure(NoRecurse = Scalar(type = "string")))
   return(populate(args, interface))
 }
 
@@ -105,15 +98,10 @@ op_input6 <- function(RecursiveStruct) {
 }
 
 test_that("build nested structure", {
-  input <- op_input6(
-    RecursiveStruct = list(RecursiveStruct = list(NoRecurse = "foo"))
-  )
+  input <- op_input6(RecursiveStruct = list(RecursiveStruct = list(NoRecurse = "foo")))
   req <- new_request(svc, op, input, NULL)
   req <- build(req)
-  expect_equal(
-    req$body,
-    '{"RecursiveStruct":{"RecursiveStruct":{"NoRecurse":"foo"}}}'
-  )
+  expect_equal(req$body, '{"RecursiveStruct":{"RecursiveStruct":{"NoRecurse":"foo"}}}')
 })
 
 op_input7 <- function(RecursiveStruct) {
@@ -215,10 +203,7 @@ op_input10 <- function(RecursiveStruct) {
 test_that("build nested structure", {
   input <- op_input10(
     RecursiveStruct = list(
-      RecursiveMap = list(
-        bar = list(NoRecurse = "bar"),
-        foo = list(NoRecurse = "foo")
-      )
+      RecursiveMap = list(bar = list(NoRecurse = "bar"), foo = list(NoRecurse = "foo"))
     )
   )
   req <- new_request(svc, op, input, NULL)
@@ -273,10 +258,7 @@ op_input13 <- function(FooEnum, ListEnums) {
       .tags = list(enum = "InputService8TestShapeEnumType")
     ),
     ListEnums = List(
-      Scalar(
-        type = "string",
-        .tags = list(enum = "InputService8TestShapeEnumType")
-      )
+      Scalar(type = "string", .tags = list(enum = "InputService8TestShapeEnumType"))
     )
   )
   return(populate(args, interface))
@@ -358,9 +340,7 @@ test_that("build nested structure with incomplete input shape", {
 # Build with no target prefix
 
 op <- Operation(name = "OperationName")
-svc <- Client(
-  client_info = ClientInfo(json_version = "1.1", target_prefix = NULL)
-)
+svc <- Client(client_info = ClientInfo(json_version = "1.1", target_prefix = NULL))
 svc$handlers$build <- HandlerList(jsonrpc_build)
 
 op_input1 <- function(Name) {
@@ -536,10 +516,7 @@ op_output7 <- Structure(
     .tags = list(enum = "OutputService7TestShapeJSONEnumType")
   ),
   ListEnums = List(
-    Scalar(
-      type = "string",
-      .tags = list(enum = "OutputService7TestShapeJSONEnumType")
-    )
+    Scalar(type = "string", .tags = list(enum = "OutputService7TestShapeJSONEnumType"))
   )
 )
 
@@ -547,9 +524,7 @@ test_that("unmarshal enums", {
   req <- new_request(svc, op, NULL, op_output7)
   req$http_response <- HttpResponse(
     status_code = 200,
-    body = charToRaw(
-      "{\"FooEnum\": \"foo\", \"ListEnums\": [\"foo\", \"bar\"]}"
-    )
+    body = charToRaw("{\"FooEnum\": \"foo\", \"ListEnums\": [\"foo\", \"bar\"]}")
   )
   req <- unmarshal(req)
   out <- req$data
@@ -607,14 +582,8 @@ test_that("unmarshal nested structure with incomplete output shape", {
   out <- req$data
   expect_length(out$Items, 1)
   expect_equal(out$Items[[1]]$Bar$NS, c("3", "2", "1"))
-  expect_equal(
-    out$Items[[1]]$Foo$L[[1]],
-    list(M = list(FooBar = list(N = "1")))
-  )
-  expect_equal(
-    out$Items[[1]]$Foo$L[[2]],
-    list(M = list(FooBar = list(N = "2")))
-  )
+  expect_equal(out$Items[[1]]$Foo$L[[1]], list(M = list(FooBar = list(N = "1"))))
+  expect_equal(out$Items[[1]]$Foo$L[[2]], list(M = list(FooBar = list(N = "2"))))
 })
 
 test_that("unmarshal UTF-8 text", {

--- a/paws.common/tests/testthat/test_handlers_query.R
+++ b/paws.common/tests/testthat/test_handlers_query.R
@@ -22,10 +22,7 @@ test_that("build scalar members", {
   input <- op_input1(Bar = "val2", Foo = "val1")
   req <- new_request(svc, op, input, NULL)
   req <- build(req)
-  expect_equal(
-    req$body,
-    "Action=OperationName&Bar=val2&Foo=val1&Version=2014-01-01"
-  )
+  expect_equal(req$body, "Action=OperationName&Bar=val2&Foo=val1&Version=2014-01-01")
 })
 
 test_that("build scalar members", {
@@ -44,9 +41,7 @@ test_that("build scalar members", {
 
 op_input2 <- function(StructArg) {
   args <- list(StructArg = StructArg)
-  interface <- Structure(
-    StructArg = Structure(ScalarArg = Scalar(type = "string"))
-  )
+  interface <- Structure(StructArg = Structure(ScalarArg = Scalar(type = "string")))
   return(populate(args, interface))
 }
 
@@ -86,11 +81,7 @@ test_that("build empty list", {
 })
 
 op_input4 <- function(ListArg = NULL, NamedListArg = NULL, ScalarArg = NULL) {
-  args <- list(
-    ListArg = ListArg,
-    NamedListArg = NamedListArg,
-    ScalarArg = ScalarArg
-  )
+  args <- list(ListArg = ListArg, NamedListArg = NamedListArg, ScalarArg = ScalarArg)
   interface <- Structure(
     ListArg = List(Scalar(type = "string"), .tags = list(flattened = TRUE)),
     NamedListArg = List(
@@ -140,10 +131,7 @@ test_that("build flattened map", {
 op_input6 <- function(ListArg) {
   args <- list(ListArg = ListArg)
   interface <- Structure(
-    ListArg = List(
-      Scalar(type = "string"),
-      .tags = list(locationNameList = "item")
-    )
+    ListArg = List(Scalar(type = "string"), .tags = list(locationNameList = "item"))
   )
   return(populate(args, interface))
 }
@@ -242,10 +230,7 @@ test_that("build blob argument", {
   input <- op_input11(BlobArgs = list(charToRaw("foo")))
   req <- new_request(svc, op, input, NULL)
   req <- build(req)
-  expect_equal(
-    req$body,
-    "Action=OperationName&BlobArgs.1=Zm9v&Version=2014-01-01"
-  )
+  expect_equal(req$body, "Action=OperationName&BlobArgs.1=Zm9v&Version=2014-01-01")
 })
 
 op_input12 <- function(TimeArg) {
@@ -301,10 +286,7 @@ test_that("build nested shapes", {
 test_that("build nested shapes", {
   input <- op_input13(
     RecursiveStruct = list(
-      RecursiveMap = list(
-        bar = list(NoRecurse = "bar"),
-        foo = list(NoRecurse = "foo")
-      )
+      RecursiveMap = list(bar = list(NoRecurse = "bar"), foo = list(NoRecurse = "foo"))
     )
   )
   req <- new_request(svc, op, input, NULL)
@@ -336,10 +318,7 @@ test_that("build idempotency token auto-fill", {
   req <- build(req)
   expect_true(
     grepl(
-      sprintf(
-        "Action=OperationName&Token=%s&Version=2014-01-01",
-        UUID_V4_PATTERN
-      ),
+      sprintf("Action=OperationName&Token=%s&Version=2014-01-01", UUID_V4_PATTERN),
       req$body
     )
   )
@@ -471,10 +450,7 @@ test_that("unmarshal list", {
 })
 
 op_output4 <- Structure(
-  ListMember = List(
-    Scalar(type = "string"),
-    .tags = list(locationNameList = "item")
-  )
+  ListMember = List(Scalar(type = "string"), .tags = list(locationNameList = "item"))
 )
 
 test_that("unmarshal list with custom member name", {
@@ -606,9 +582,7 @@ test_that("unmarshal flattened list with location name", {
 })
 
 op_output9 <- Structure(
-  Map = Map(
-    Structure(Foo = Scalar(type = "string", .tags = list(locationName = "foo")))
-  )
+  Map = Map(Structure(Foo = Scalar(type = "string", .tags = list(locationName = "foo"))))
 )
 
 test_that("unmarshal map", {
@@ -671,11 +645,7 @@ test_that("unmarshal flattened map", {
 op_output12 <- Structure(
   Map = Map(
     Scalar(type = "string"),
-    .tags = list(
-      locationNameKey = "foo",
-      locationNameValue = "bar",
-      flattened = TRUE
-    )
+    .tags = list(locationNameKey = "foo", locationNameValue = "bar", flattened = TRUE)
   )
 )
 
@@ -742,14 +712,8 @@ test_that("unmarshal empty output shape", {
 })
 
 op_output16 <- Structure(
-  FooStr = Structure(
-    Foo = Scalar(type = "string"),
-    Bar = Scalar(type = "double")
-  ),
-  ChoStr = Structure(
-    Cho = Scalar(type = "string"),
-    Zar = Scalar(type = "double")
-  ),
+  FooStr = Structure(Foo = Scalar(type = "string"), Bar = Scalar(type = "double")),
+  ChoStr = Structure(Cho = Scalar(type = "string"), Zar = Scalar(type = "double")),
   Zoo = Scalar(type = "string")
 )
 

--- a/paws.common/tests/testthat/test_handlers_rest.R
+++ b/paws.common/tests/testthat/test_handlers_rest.R
@@ -31,17 +31,11 @@ test_that("build request with URL requiring escaping", {
         type = "string",
         .tags = list(location = "uri", locationName = "bucket")
       ),
-      Key = Scalar(
-        type = "string",
-        .tags = list(location = "uri", locationName = "key")
-      )
+      Key = Scalar(type = "string", .tags = list(location = "uri", locationName = "key"))
     )
     return(populate(args, interface))
   }
-  input <- op_input1(
-    Bucket = "mybucket",
-    Key = "my/cool+thing space/object世界"
-  )
+  input <- op_input1(Bucket = "mybucket", Key = "my/cool+thing space/object世界")
   req <- new_request(svc, op1, input, NULL)
   req <- build(req)
   r <- req$http_request
@@ -53,16 +47,10 @@ test_that("build request with URL requiring escaping", {
 })
 
 test_that("build request with URL", {
-  op1 <- Operation(
-    name = "OperationName",
-    http_method = "GET",
-    http_path = "/{foo}"
-  )
+  op1 <- Operation(name = "OperationName", http_method = "GET", http_path = "/{foo}")
   op_input1 <- function(foo) {
     args <- list(foo = foo)
-    interface <- Structure(
-      foo = Scalar(type = "string", .tags = list(location = "uri"))
-    )
+    interface <- Structure(foo = Scalar(type = "string", .tags = list(location = "uri")))
     return(populate(args, interface))
   }
   input <- op_input1(foo = "bar")

--- a/paws.common/tests/testthat/test_handlers_restjson.R
+++ b/paws.common/tests/testthat/test_handlers_restjson.R
@@ -62,11 +62,7 @@ test_that("URI parameter with location name", {
 })
 
 test_that("query string list of strings", {
-  op4 <- Operation(
-    name = "OperationName",
-    http_method = "GET",
-    http_path = "/path"
-  )
+  op4 <- Operation(name = "OperationName", http_method = "GET", http_path = "/path")
   op_input4 <- function(Items) {
     args <- list(Items = Items)
     interface <- Structure(
@@ -94,17 +90,11 @@ test_that("query string map of strings", {
     args <- list(PipelineId = PipelineId, QueryDoc = QueryDoc)
     interface <- Structure(
       PipelineId = Scalar(type = "string", .tags = list(location = "uri")),
-      QueryDoc = Map(
-        Scalar(type = "string"),
-        .tags = list(location = "querystring")
-      )
+      QueryDoc = Map(Scalar(type = "string"), .tags = list(location = "querystring"))
     )
     return(populate(args, interface))
   }
-  input <- op_input5(
-    PipelineId = "foo",
-    QueryDoc = list(bar = "baz", fizz = "buzz")
-  )
+  input <- op_input5(PipelineId = "foo", QueryDoc = list(bar = "baz", fizz = "buzz"))
   req <- new_request(svc, op5, input, NULL)
   req <- build(req)
   r <- req$http_request
@@ -145,11 +135,7 @@ test_that("query string map of lists of strings", {
 })
 
 test_that("query string with bool (true)", {
-  op7 <- Operation(
-    name = "OperationName",
-    http_method = "GET",
-    http_path = "/path"
-  )
+  op7 <- Operation(name = "OperationName", http_method = "GET", http_path = "/path")
   op_input7 <- function(BoolQuery) {
     args <- list(BoolQuery = BoolQuery)
     interface <- Structure(
@@ -168,11 +154,7 @@ test_that("query string with bool (true)", {
 })
 
 test_that("query string with bool (false)", {
-  op8 <- Operation(
-    name = "OperationName",
-    http_method = "GET",
-    http_path = "/path"
-  )
+  op8 <- Operation(name = "OperationName", http_method = "GET", http_path = "/path")
   op_input8 <- function(BoolQuery) {
     args <- list(BoolQuery = BoolQuery)
     interface <- Structure(
@@ -197,11 +179,7 @@ test_that("URI and query string parameters", {
     http_path = "/2014-01-01/jobsByPipeline/{PipelineId}"
   )
   op_input9 <- function(Ascending, PageToken, PipelineId) {
-    args <- list(
-      Ascending = Ascending,
-      PageToken = PageToken,
-      PipelineId = PipelineId
-    )
+    args <- list(Ascending = Ascending, PageToken = PageToken, PipelineId = PipelineId)
     interface <- Structure(
       Ascending = Scalar(
         type = "string",
@@ -246,10 +224,7 @@ test_that("URI, query string, and JSON body", {
         type = "string",
         .tags = list(location = "querystring", locationName = "Ascending")
       ),
-      Config = Structure(
-        A = Scalar(type = "string"),
-        B = Scalar(type = "string")
-      ),
+      Config = Structure(A = Scalar(type = "string"), B = Scalar(type = "string")),
       PageToken = Scalar(
         type = "string",
         .tags = list(location = "querystring", locationName = "PageToken")
@@ -300,10 +275,7 @@ test_that("URI, query string, JSON body, and header", {
         type = "string",
         .tags = list(location = "header", locationName = "x-amz-checksum")
       ),
-      Config = Structure(
-        A = Scalar(type = "string"),
-        B = Scalar(type = "string")
-      ),
+      Config = Structure(A = Scalar(type = "string"), B = Scalar(type = "string")),
       PageToken = Scalar(
         type = "string",
         .tags = list(location = "querystring", locationName = "PageToken")
@@ -345,28 +317,17 @@ test_that("streaming payload", {
       Body = Scalar(type = "blob", .tags = list(locationName = "body")),
       Checksum = Scalar(
         type = "string",
-        .tags = list(
-          location = "header",
-          locationName = "x-amz-sha256-tree-hash"
-        )
+        .tags = list(location = "header", locationName = "x-amz-sha256-tree-hash")
       ),
       VaultName = Scalar(
         type = "string",
-        .tags = list(
-          location = "uri",
-          locationName = "vaultName",
-          required = TRUE
-        )
+        .tags = list(location = "uri", locationName = "vaultName", required = TRUE)
       ),
       .tags = list(payload = "Body")
     )
     return(populate(args, interface))
   }
-  input <- op_input12(
-    Body = charToRaw("contents"),
-    Checksum = "foo",
-    VaultName = "name"
-  )
+  input <- op_input12(Body = charToRaw("contents"), Checksum = "foo", VaultName = "name")
   req <- new_request(svc, op12, input, NULL)
   req <- build(req)
   r <- req$http_request
@@ -460,11 +421,7 @@ test_that("empty structure payload", {
 })
 
 test_that("omit null query string parameters", {
-  op16 <- Operation(
-    name = "OperationName",
-    http_method = "POST",
-    http_path = "/path"
-  )
+  op16 <- Operation(name = "OperationName", http_method = "POST", http_path = "/path")
   op_input16 <- function(Foo = NULL) {
     args <- list(Foo = Foo)
     interface <- Structure(
@@ -510,11 +467,7 @@ test_that("serialize empty string query string parameters", {
 # TODO: RecursiveStructs.
 
 test_that("timestamp value", {
-  op18 <- Operation(
-    name = "OperationName",
-    http_method = "POST",
-    http_path = "/path"
-  )
+  op18 <- Operation(name = "OperationName", http_method = "POST", http_path = "/path")
   op_input18 <- function(TimeArg) {
     args <- list(TimeArg = TimeArg)
     interface <- Structure(TimeArg = Scalar(type = "timestamp"))
@@ -529,11 +482,7 @@ test_that("timestamp value", {
 })
 
 test_that("timestamp value in header", {
-  op19 <- Operation(
-    name = "OperationName",
-    http_method = "POST",
-    http_path = "/path"
-  )
+  op19 <- Operation(name = "OperationName", http_method = "POST", http_path = "/path")
   op_input19 <- function(TimeArgInHeader) {
     args <- list(TimeArgInHeader = TimeArgInHeader)
     interface <- Structure(
@@ -553,11 +502,7 @@ test_that("timestamp value in header", {
 })
 
 test_that("timestamp value in JSON body", {
-  op20 <- Operation(
-    name = "OperationName",
-    http_method = "POST",
-    http_path = "/path"
-  )
+  op20 <- Operation(name = "OperationName", http_method = "POST", http_path = "/path")
   op_input20 <- function(TimeArg) {
     args <- list(TimeArg = TimeArg)
     interface <- Structure(
@@ -577,11 +522,7 @@ test_that("timestamp value in JSON body", {
 })
 
 test_that("string payload", {
-  op21 <- Operation(
-    name = "OperationName",
-    http_method = "POST",
-    http_path = "/path"
-  )
+  op21 <- Operation(name = "OperationName", http_method = "POST", http_path = "/path")
   op_input21 <- function(Foo) {
     args <- list(Foo = Foo)
     interface <- Structure(
@@ -598,11 +539,7 @@ test_that("string payload", {
   expect_equal(r$body, "bar")
 })
 
-op22 <- Operation(
-  name = "OperationName",
-  http_method = "POST",
-  http_path = "/path"
-)
+op22 <- Operation(name = "OperationName", http_method = "POST", http_path = "/path")
 op_input22 <- function(Token = NULL) {
   args <- list(Token = Token)
   interface <- Structure(
@@ -655,10 +592,7 @@ test_that("unmarshal scalar members", {
     ),
     Long = Scalar(type = "long"),
     Num = Scalar(type = "integer"),
-    StatusCode = Scalar(
-      type = "integer",
-      .tags = list(location = "statusCode")
-    ),
+    StatusCode = Scalar(type = "integer", .tags = list(location = "statusCode")),
     Str = Scalar(type = "string"),
     TrueBool = Scalar(type = "boolean")
   )
@@ -710,10 +644,7 @@ test_that("unmarshal blob member", {
 
 test_that("unmarshal timestamp member", {
   op_output3 <- Structure(
-    TimeMember = Scalar(
-      type = "timestamp",
-      .tags = list(timestampFormat = "unix")
-    ),
+    TimeMember = Scalar(type = "timestamp", .tags = list(timestampFormat = "unix")),
     StructMember = Structure(
       Foo = Scalar(
         type = "timestamp",
@@ -732,11 +663,7 @@ test_that("unmarshal timestamp member", {
   req <- unmarshal(req)
   out <- req$data
   expect_equal(out$TimeMember, unix_time(1.398796238e+09), ignore_attr = TRUE)
-  expect_equal(
-    out$StructMember$Foo,
-    unix_time(1.398796238e+09),
-    ignore_attr = TRUE
-  )
+  expect_equal(out$StructMember$Foo, unix_time(1.398796238e+09), ignore_attr = TRUE)
 })
 
 test_that("unmarshal list", {
@@ -754,9 +681,7 @@ test_that("unmarshal list", {
 })
 
 test_that("unmarshal list with structure member", {
-  op_output5 <- Structure(
-    ListMember = List(Structure(Foo = Scalar(type = "string")))
-  )
+  op_output5 <- Structure(ListMember = List(Structure(Foo = Scalar(type = "string"))))
   req <- new_request(svc, op, NULL, op_output5)
   req$http_response <- HttpResponse(
     status_code = 200,
@@ -795,16 +720,8 @@ test_that("unmarshal map with timestamps", {
   req <- unmarshal_meta(req)
   req <- unmarshal(req)
   out <- req$data
-  expect_equal(
-    out$MapMember[["a"]],
-    unix_time(1.398796238e+09),
-    ignore_attr = TRUE
-  )
-  expect_equal(
-    out$MapMember[["b"]],
-    unix_time(1.398796238e+09),
-    ignore_attr = TRUE
-  )
+  expect_equal(out$MapMember[["a"]], unix_time(1.398796238e+09), ignore_attr = TRUE)
+  expect_equal(out$MapMember[["b"]], unix_time(1.398796238e+09), ignore_attr = TRUE)
 })
 
 test_that("unmarshal ignores extra data", {
@@ -823,10 +740,7 @@ test_that("unmarshal ignores extra data", {
 
 test_that("unmarshal header map", {
   op_output9 <- Structure(
-    AllHeaders = Map(
-      Scalar(type = "string"),
-      .tags = list(location = "headers")
-    ),
+    AllHeaders = Map(Scalar(type = "string"), .tags = list(location = "headers")),
     PrefixedHeaders = Map(
       Scalar(type = "string"),
       .tags = list(location = "headers", locationName = "X-")

--- a/paws.common/tests/testthat/test_handlers_restxml.R
+++ b/paws.common/tests/testthat/test_handlers_restxml.R
@@ -65,11 +65,7 @@ test_that("URI parameter with location name", {
 })
 
 test_that("query string list of strings", {
-  op4 <- Operation(
-    name = "OperationName",
-    http_method = "GET",
-    http_path = "/path"
-  )
+  op4 <- Operation(name = "OperationName", http_method = "GET", http_path = "/path")
   op_input4 <- function(Items) {
     args <- list(Items = Items)
     interface <- Structure(
@@ -97,17 +93,11 @@ test_that("query string map of strings", {
     args <- list(PipelineId = PipelineId, QueryDoc = QueryDoc)
     interface <- Structure(
       PipelineId = Scalar(type = "string", .tags = list(location = "uri")),
-      QueryDoc = Map(
-        Scalar(type = "string"),
-        .tags = list(location = "querystring")
-      )
+      QueryDoc = Map(Scalar(type = "string"), .tags = list(location = "querystring"))
     )
     return(populate(args, interface))
   }
-  input <- op_input5(
-    PipelineId = "foo",
-    QueryDoc = list(bar = "baz", fizz = "buzz")
-  )
+  input <- op_input5(PipelineId = "foo", QueryDoc = list(bar = "baz", fizz = "buzz"))
   req <- new_request(svc, op5, input, NULL)
   req <- build(req)
   r <- req$http_request
@@ -148,11 +138,7 @@ test_that("query string map of lists of strings", {
 })
 
 test_that("query string with bool (true)", {
-  op7 <- Operation(
-    name = "OperationName",
-    http_method = "GET",
-    http_path = "/path"
-  )
+  op7 <- Operation(name = "OperationName", http_method = "GET", http_path = "/path")
   op_input7 <- function(BoolQuery) {
     args <- list(BoolQuery = BoolQuery)
     interface <- Structure(
@@ -171,11 +157,7 @@ test_that("query string with bool (true)", {
 })
 
 test_that("query string with bool (false)", {
-  op8 <- Operation(
-    name = "OperationName",
-    http_method = "GET",
-    http_path = "/path"
-  )
+  op8 <- Operation(name = "OperationName", http_method = "GET", http_path = "/path")
   op_input8 <- function(BoolQuery) {
     args <- list(BoolQuery = BoolQuery)
     interface <- Structure(
@@ -200,11 +182,7 @@ test_that("URI and query string parameters", {
     http_path = "/2014-01-01/jobsByPipeline/{PipelineId}"
   )
   op_input9 <- function(Ascending, PageToken, PipelineId) {
-    args <- list(
-      Ascending = Ascending,
-      PageToken = PageToken,
-      PipelineId = PipelineId
-    )
+    args <- list(Ascending = Ascending, PageToken = PageToken, PipelineId = PipelineId)
     interface <- Structure(
       Ascending = Scalar(
         type = "string",
@@ -296,10 +274,7 @@ test_that("Nested Structure Case1", {
     return(populate(args, interface))
   }
 
-  input <- op_input_test(
-    Description = "baz",
-    SubStructure = list(Bar = "b", Foo = "a")
-  )
+  input <- op_input_test(Description = "baz", SubStructure = list(Bar = "b", Foo = "a"))
   req <- new_request(svc, op_test, input, NULL)
   req <- build(req)
   r <- req$body
@@ -337,10 +312,7 @@ test_that("NonFlattened List With LocationName Case1", {
     interface <- Structure(
       ListParam = List(
         Scalar(type = "string"),
-        .tags = list(
-          locationName = "AlternateName",
-          locationNameList = "NotMember"
-        )
+        .tags = list(locationName = "AlternateName", locationNameList = "NotMember")
       ),
       .tags = list(locationName = "OperationRequest", xmlURI = "https://foo/")
     )
@@ -362,10 +334,7 @@ test_that("Flattened List Case1", {
   op_input_test <- function(ListParam) {
     args <- list(ListParam = ListParam)
     interface <- Structure(
-      ListParam = List(
-        Scalar(type = "string"),
-        .tags = list(flattened = "true")
-      ),
+      ListParam = List(Scalar(type = "string"), .tags = list(flattened = "true")),
       .tags = list(locationName = "OperationRequest", xmlURI = "https://foo/")
     )
     return(populate(args, interface))
@@ -412,10 +381,7 @@ test_that("List of Structures Case1", {
     interface <- Structure(
       ListParam = List(
         Structure(
-          Element = Scalar(
-            type = "string",
-            .tags = list(locationName = "value")
-          )
+          Element = Scalar(type = "string", .tags = list(locationName = "value"))
         ),
         .tags = list(flattened = "true", locationName = "item")
       ),
@@ -674,11 +640,7 @@ test_that("unmarshal flattened map", {
 op_output8 <- Structure(
   Map = Map(
     Scalar(),
-    .tags = list(
-      locationNameKey = "foo",
-      locationNameValue = "bar",
-      flattened = TRUE
-    )
+    .tags = list(locationNameKey = "foo", locationNameValue = "bar", flattened = TRUE)
   )
 )
 
@@ -831,10 +793,7 @@ op_output14 <- Structure(
   Contents = List(
     Structure(
       Size = Scalar(type = "integer"),
-      Owner = list(
-        DisplayName = Scalar(type = "string"),
-        ID = Scalar(type = "string")
-      )
+      Owner = list(DisplayName = Scalar(type = "string"), ID = Scalar(type = "string"))
     ),
     .tags = list(flattened = TRUE)
   )
@@ -895,10 +854,7 @@ op_output15 <- Structure(
   Version = List(
     Structure(
       Size = Scalar(type = "integer"),
-      Owner = list(
-        DisplayName = Scalar(type = "string"),
-        ID = Scalar(type = "string")
-      )
+      Owner = list(DisplayName = Scalar(type = "string"), ID = Scalar(type = "string"))
     ),
     .tags = list(flattened = TRUE)
   )

--- a/paws.common/tests/testthat/test_handlers_sse.R
+++ b/paws.common/tests/testthat/test_handlers_sse.R
@@ -8,10 +8,7 @@ svc$client_info$api_version <- "2014-01-01"
 svc$handlers$build <- HandlerList(sse_md5_build)
 
 op_input1 <- function(SSECustomerKey = NULL, SSECustomerKeyMD5 = NULL) {
-  args <- list(
-    SSECustomerKey = SSECustomerKey,
-    SSECustomerKeyMD5 = SSECustomerKeyMD5
-  )
+  args <- list(SSECustomerKey = SSECustomerKey, SSECustomerKeyMD5 = SSECustomerKeyMD5)
   interface <- Structure(
     SSECustomerKey = Scalar(type = "blob"),
     SSECustomerKeyMD5 = Scalar(type = "string")
@@ -38,10 +35,7 @@ test_that("build SSECustomer md5", {
 })
 
 test_that("build skip SSECustomer md5", {
-  input <- op_input1(
-    SSECustomerKey = charToRaw("foobar"),
-    SSECustomerKeyMD5 = "made-up"
-  )
+  input <- op_input1(SSECustomerKey = charToRaw("foobar"), SSECustomerKeyMD5 = "made-up")
   req <- new_request(svc, op, input, NULL)
   req <- build(req)
   expect_equal(req$params$SSECustomerKeyMD5, "made-up", ignore_attr = TRUE)
@@ -75,11 +69,7 @@ test_that("build empty CopySourceSSECustomer md5", {
   input <- op_input2()
   req <- new_request(svc, op, input, NULL)
   req <- build(req)
-  expect_equal(
-    req$params$CopySourceSSECustomerKeyMD5,
-    list(),
-    ignore_attr = TRUE
-  )
+  expect_equal(req$params$CopySourceSSECustomerKeyMD5, list(), ignore_attr = TRUE)
 })
 
 test_that("build CopySourceSSECustomer md5", {
@@ -100,11 +90,7 @@ test_that("build skip CopySourceSSECustomer md5", {
   )
   req <- new_request(svc, op, input, NULL)
   req <- build(req)
-  expect_equal(
-    req$params$CopySourceSSECustomerKeyMD5,
-    "made-up",
-    ignore_attr = TRUE
-  )
+  expect_equal(req$params$CopySourceSSECustomerKeyMD5, "made-up", ignore_attr = TRUE)
 })
 
 test_that("build skip CopySourceSSECustomer md5", {
@@ -112,9 +98,5 @@ test_that("build skip CopySourceSSECustomer md5", {
   req <- new_request(svc, op, input, NULL)
   req <- build(req)
   expect_equal(req$params$CopySourceSSECustomerKey, list(), ignore_attr = TRUE)
-  expect_equal(
-    req$params$CopySourceSSECustomerKeyMD5,
-    "made-up",
-    ignore_attr = TRUE
-  )
+  expect_equal(req$params$CopySourceSSECustomerKeyMD5, "made-up", ignore_attr = TRUE)
 })

--- a/paws.common/tests/testthat/test_handlers_stream.R
+++ b/paws.common/tests/testthat/test_handlers_stream.R
@@ -424,10 +424,7 @@ test_that("check xml paws_stream_parser", {
     list(
       Records = structure(
         list(
-          Payload = structure(
-            logical(0),
-            tags = list(eventpayload = TRUE, type = "blob")
-          )
+          Payload = structure(logical(0), tags = list(eventpayload = TRUE, type = "blob"))
         ),
         tags = list(type = "structure", event = TRUE)
       ),
@@ -496,9 +493,7 @@ test_that("check xml paws_stream_parser", {
   expect_equal(rawToChar(actual$Records$Payload), "1\n2\n3\n")
   expect_equal(
     actual$Stats,
-    list(
-      Details = list(BytesScanned = 10, BytesProcessed = 10, BytesReturned = 6)
-    )
+    list(Details = list(BytesScanned = 10, BytesProcessed = 10, BytesReturned = 6))
   )
 })
 
@@ -1651,9 +1646,7 @@ test_that("check json paws_stream_parser", {
             list(
               text = structure(logical(0), tags = list(type = "string")),
               toolUse = structure(
-                list(
-                  input = structure(logical(0), tags = list(type = "string"))
-                ),
+                list(input = structure(logical(0), tags = list(type = "string"))),
                 tags = list(type = "structure")
               )
             ),

--- a/paws.common/tests/testthat/test_iniutil.R
+++ b/paws.common/tests/testthat/test_iniutil.R
@@ -56,10 +56,7 @@ test_that("Reads in values with nested content", {
   paws_reset_cache()
   content <- read_ini("data_ini")
   profile <- "nested"
-  expect_equal(
-    content[[profile]][["nested1"]],
-    list(arg1 = "value1", arg2 = "value2")
-  )
+  expect_equal(content[[profile]][["nested1"]], list(arg1 = "value1", arg2 = "value2"))
   expect_equal(content[[profile]][["nested2"]], list(arg4 = "value4"))
   expect_equal(content[[profile]][["arg3"]], "value3")
 })

--- a/paws.common/tests/testthat/test_logging.R
+++ b/paws.common/tests/testthat/test_logging.R
@@ -13,11 +13,7 @@ test_that("check default logging settings", {
 
 test_that("check updating paws log config", {
   temp_file <- tempfile()
-  paws_config_log(
-    level = 3L,
-    file = temp_file,
-    timestamp_fmt = "%Y-%m-%d %H:%M"
-  )
+  paws_config_log(level = 3L, file = temp_file, timestamp_fmt = "%Y-%m-%d %H:%M")
 
   log_level <- getOption("paws.log_level")
   log_file <- getOption("paws.log_file")
@@ -75,11 +71,7 @@ test_that("check if http logs aren't being tracked", {
 })
 
 test_that("check reset log config", {
-  paws_config_log(
-    level = 3L,
-    file = "made-up",
-    timestamp_fmt = "%Y-%m-%d %H:%M"
-  )
+  paws_config_log(level = 3L, file = "made-up", timestamp_fmt = "%Y-%m-%d %H:%M")
   log_level <- getOption("paws.log_level")
   log_file <- getOption("paws.log_file")
   log_timestamp_fmt <- getOption("paws.log_timestamp_fmt")
@@ -99,11 +91,7 @@ test_that("check reset log config", {
 })
 
 test_that("ensure init_log_config doesn't modified already set log config", {
-  paws_config_log(
-    level = 3L,
-    file = "made-up",
-    timestamp_fmt = "%Y-%m-%d %H:%M"
-  )
+  paws_config_log(level = 3L, file = "made-up", timestamp_fmt = "%Y-%m-%d %H:%M")
 
   init_log_config()
 
@@ -130,10 +118,7 @@ test_that("update log config from environmental variables", {
   expect_equal(log_level, 4L)
   expect_equal(log_file, "dummy-file")
   expect_equal(log_timestamp_fmt, "made-up")
-  lapply(
-    c("PAWS_LOG_LEVEL", "PAWS_LOG_TIMESTAMP_FMT", "PAWS_LOG_FILE"),
-    Sys.unsetenv
-  )
+  lapply(c("PAWS_LOG_LEVEL", "PAWS_LOG_TIMESTAMP_FMT", "PAWS_LOG_FILE"), Sys.unsetenv)
 })
 
 test_that("check log messages", {

--- a/paws.common/tests/testthat/test_net.R
+++ b/paws.common/tests/testthat/test_net.R
@@ -2,10 +2,7 @@ test_that("issue", {
   # Avoid CRAN check errors due to unavailable network resources.
   skip_on_cran()
 
-  req <- HttpRequest(
-    method = "GET",
-    url = parse_url("https://httpbin.org/json")
-  )
+  req <- HttpRequest(method = "GET", url = parse_url("https://httpbin.org/json"))
   resp <- issue(req)
 
   # skip if network flaky
@@ -75,10 +72,7 @@ test_that("don't decompress the body when already decompressed", {
   # Avoid CRAN check errors due to unavailable network resources.
   skip_on_cran()
 
-  req <- HttpRequest(
-    method = "GET",
-    url = parse_url("https://httpbin.org/gzip")
-  )
+  req <- HttpRequest(method = "GET", url = parse_url("https://httpbin.org/gzip"))
 
   expect_error(resp <- issue(req), NA)
 
@@ -113,10 +107,7 @@ test_that("write content to disk", {
 })
 
 test_that("check issue", {
-  req <- HttpRequest(
-    method = "GET",
-    url = parse_url("https://httpbin.org/json")
-  )
+  req <- HttpRequest(method = "GET", url = parse_url("https://httpbin.org/json"))
 
   mock_request_aws <- mock2(httr2::response(body = charToRaw("dummy")))
   mockery::stub(issue, "request_aws", mock_request_aws)

--- a/paws.common/tests/testthat/test_request.R
+++ b/paws.common/tests/testthat/test_request.R
@@ -16,10 +16,7 @@ test_that("sanitize_host_for_header", {
       "https://estest.us-east-1.es.amazonaws.com:443",
       "estest.us-east-1.es.amazonaws.com"
     ),
-    c(
-      "https://estest.us-east-1.es.amazonaws.com",
-      "estest.us-east-1.es.amazonaws.com"
-    ),
+    c("https://estest.us-east-1.es.amazonaws.com", "estest.us-east-1.es.amazonaws.com"),
     c("https://localhost:9200", "localhost:9200"),
     c("http://localhost:80", "localhost"),
     c("http://localhost:8080", "localhost:8080")

--- a/paws.common/tests/testthat/test_retry.R
+++ b/paws.common/tests/testthat/test_retry.R
@@ -5,11 +5,7 @@
 aws_dummy_error <- function(msg, status_code, error_response) {
   http_class <- sprintf("http_%s", status_code)
   structure(
-    list(
-      message = msg,
-      status_code = status_code,
-      error_response = error_response
-    ),
+    list(message = msg, status_code = status_code, error_response = error_response),
     class = c("paws_error", http_class, "error", "condition"),
     status_code = status_code,
     error_response = error_response
@@ -108,16 +104,10 @@ test_that("default number of retries", {
   mockery::stub(standard_retry_handler, "sign", mock_sign)
   mockery::stub(standard_retry_handler, "send", mock_send)
   mockery::stub(standard_retry_handler, "unmarshal_meta", mock_unmarshal_meta)
-  mockery::stub(
-    standard_retry_handler,
-    "validate_response",
-    mock_validate_response
-  )
+  mockery::stub(standard_retry_handler, "validate_response", mock_validate_response)
   mockery::stub(standard_retry_handler, "exp_back_off", mock_exp_back_off)
 
-  standard_retry_handler(
-    dummy_req_error(req1, "ThrottledException", "foo", 400)
-  )
+  standard_retry_handler(dummy_req_error(req1, "ThrottledException", "foo", 400))
 
   last_args <- mock_arg(mock_exp_back_off)
   expect_equal(mock_call_no(mock_exp_back_off), 4)
@@ -141,16 +131,10 @@ test_that("default number of retries", {
   mockery::stub(standard_retry_handler, "sign", mock_sign)
   mockery::stub(standard_retry_handler, "send", mock_send)
   mockery::stub(standard_retry_handler, "unmarshal_meta", mock_unmarshal_meta)
-  mockery::stub(
-    standard_retry_handler,
-    "validate_response",
-    mock_validate_response
-  )
+  mockery::stub(standard_retry_handler, "validate_response", mock_validate_response)
   mockery::stub(standard_retry_handler, "exp_back_off", mock_exp_back_off)
 
-  standard_retry_handler(
-    dummy_req_error(req1, "ThrottledException", "foo", 400)
-  )
+  standard_retry_handler(dummy_req_error(req1, "ThrottledException", "foo", 400))
 
   last_args <- mock_arg(mock_exp_back_off)
   expect_equal(mock_call_no(mock_exp_back_off), 4)
@@ -174,17 +158,11 @@ test_that("non retryable error", {
   mockery::stub(standard_retry_handler, "sign", mock_sign)
   mockery::stub(standard_retry_handler, "send", mock_send)
   mockery::stub(standard_retry_handler, "unmarshal_meta", mock_unmarshal_meta)
-  mockery::stub(
-    standard_retry_handler,
-    "validate_response",
-    mock_validate_response
-  )
+  mockery::stub(standard_retry_handler, "validate_response", mock_validate_response)
   mockery::stub(standard_retry_handler, "exp_back_off", mock_exp_back_off)
 
   expect_error(
-    standard_retry_handler(
-      dummy_req_error(req1, "ThrottledException", "foo", 400)
-    ),
+    standard_retry_handler(dummy_req_error(req1, "ThrottledException", "foo", 400)),
     "non retryable error"
   )
   last_args <- mock_arg(mock_exp_back_off)
@@ -209,16 +187,10 @@ test_that("succesful retry", {
   mockery::stub(standard_retry_handler, "sign", mock_sign)
   mockery::stub(standard_retry_handler, "send", mock_send)
   mockery::stub(standard_retry_handler, "unmarshal_meta", mock_unmarshal_meta)
-  mockery::stub(
-    standard_retry_handler,
-    "validate_response",
-    mock_validate_response
-  )
+  mockery::stub(standard_retry_handler, "validate_response", mock_validate_response)
   mockery::stub(standard_retry_handler, "exp_back_off", mock_exp_back_off)
 
-  resp <- standard_retry_handler(
-    dummy_req_error(req1, "ThrottledException", "foo", 400)
-  )
+  resp <- standard_retry_handler(dummy_req_error(req1, "ThrottledException", "foo", 400))
   last_args <- mock_arg(mock_exp_back_off)
   expect_equal(mock_call_no(mock_exp_back_off), 3)
   expect_true(last_args[[2]] != last_args[[3]])
@@ -236,9 +208,7 @@ test_that("no retries", {
   mockery::stub(standard_retry_handler, "exp_back_off", mock_exp_back_off)
 
   expect_error(
-    standard_retry_handler(
-      dummy_req_error(req2, "ThrottledException", "foo", 400)
-    ),
+    standard_retry_handler(dummy_req_error(req2, "ThrottledException", "foo", 400)),
     "foo"
   )
 
@@ -256,9 +226,7 @@ test_that("no retries", {
   mockery::stub(standard_retry_handler, "exp_back_off", mock_exp_back_off)
 
   expect_error(
-    standard_retry_handler(
-      dummy_req_error(req2, "ThrottledException", "foo", 400)
-    ),
+    standard_retry_handler(dummy_req_error(req2, "ThrottledException", "foo", 400)),
     "foo"
   )
 
@@ -281,16 +249,10 @@ test_that("1 retries", {
   mockery::stub(standard_retry_handler, "sign", mock_sign)
   mockery::stub(standard_retry_handler, "send", mock_send)
   mockery::stub(standard_retry_handler, "unmarshal_meta", mock_unmarshal_meta)
-  mockery::stub(
-    standard_retry_handler,
-    "validate_response",
-    mock_validate_response
-  )
+  mockery::stub(standard_retry_handler, "validate_response", mock_validate_response)
   mockery::stub(standard_retry_handler, "exp_back_off", mock_exp_back_off)
 
-  standard_retry_handler(
-    dummy_req_error(req3, "ThrottledException", "foo", 400)
-  )
+  standard_retry_handler(dummy_req_error(req3, "ThrottledException", "foo", 400))
 
   last_args <- mock_arg(mock_exp_back_off)
   expect_equal(mock_call_no(mock_exp_back_off), 2)

--- a/paws.common/tests/testthat/test_service.R
+++ b/paws.common/tests/testthat/test_service.R
@@ -113,10 +113,7 @@ test_that("test custom config credentials take priority", {
 
   expect_equal(service$config$region, "cfgs_region")
   expect_equal(service$config$credentials$creds$access_key_id, "cfgs_key")
-  expect_equal(
-    service$config$credentials$creds$secret_access_key,
-    "cfgs_secret"
-  )
+  expect_equal(service$config$credentials$creds$secret_access_key, "cfgs_secret")
   expect_equal(service$config$credentials$profile, "cfgs_profile")
 })
 
@@ -163,7 +160,5 @@ test_that("test service endpoint environment variables", {
   expect_equal(endpoint2, "http://localhost:9090")
   expect_equal(endpoint3, "http://localhost:1234")
 
-  Sys.unsetenv(
-    c("AWS_ENDPOINT_URL_BAR", "AWS_ENDPOINT_URL_BAZ_CHO", "AWS_ENDPOINT_URL")
-  )
+  Sys.unsetenv(c("AWS_ENDPOINT_URL_BAR", "AWS_ENDPOINT_URL_BAZ_CHO", "AWS_ENDPOINT_URL"))
 })

--- a/paws.common/tests/testthat/test_signer_query.R
+++ b/paws.common/tests/testthat/test_signer_query.R
@@ -1,16 +1,8 @@
 mock_request <- function(bucket, key, http_path) {
-  list(
-    operation = list(http_path = http_path),
-    params = list(Bucket = bucket, Key = key)
-  )
+  list(operation = list(http_path = http_path), params = list(Bucket = bucket, Key = key))
 }
 
-http_paths <- c(
-  "/{Bucket}",
-  "/{Bucket}?foo",
-  "/{Bucket}/{Key+}",
-  "/{Bucket}/{Key+}?bar"
-)
+http_paths <- c("/{Bucket}", "/{Bucket}?foo", "/{Bucket}/{Key+}", "/{Bucket}/{Key+}?bar")
 
 test_that("get auth path for standard bucket and key", {
   bucket <- "made-up"
@@ -86,11 +78,7 @@ list_objects_v2_input_params <- function(...) {
       ),
       Delimiter = structure(
         logical(0),
-        tags = list(
-          location = "querystring",
-          locationName = "delimiter",
-          type = "string"
-        )
+        tags = list(location = "querystring", locationName = "delimiter", type = "string")
       ),
       EncodingType = structure(
         logical(0),
@@ -102,19 +90,11 @@ list_objects_v2_input_params <- function(...) {
       ),
       MaxKeys = structure(
         logical(0),
-        tags = list(
-          location = "querystring",
-          locationName = "max-keys",
-          type = "integer"
-        )
+        tags = list(location = "querystring", locationName = "max-keys", type = "integer")
       ),
       Prefix = structure(
         logical(0),
-        tags = list(
-          location = "querystring",
-          locationName = "prefix",
-          type = "string"
-        )
+        tags = list(location = "querystring", locationName = "prefix", type = "string")
       ),
       ContinuationToken = structure(
         logical(0),
@@ -170,10 +150,7 @@ list_objects_v2_output_params <- structure(
         structure(
           list(
             Key = structure(logical(0), tags = list(type = "string")),
-            LastModified = structure(
-              logical(0),
-              tags = list(type = "timestamp")
-            ),
+            LastModified = structure(logical(0), tags = list(type = "timestamp")),
             ETag = structure(logical(0), tags = list(type = "string")),
             ChecksumAlgorithm = structure(
               list(structure(logical(0), tags = list(type = "string"))),
@@ -183,10 +160,7 @@ list_objects_v2_output_params <- structure(
             StorageClass = structure(logical(0), tags = list(type = "string")),
             Owner = structure(
               list(
-                DisplayName = structure(
-                  logical(0),
-                  tags = list(type = "string")
-                ),
+                DisplayName = structure(logical(0), tags = list(type = "string")),
                 ID = structure(logical(0), tags = list(type = "string"))
               ),
               tags = list(type = "structure")
@@ -358,11 +332,7 @@ get_object_input_params <- function(...) {
       ),
       IfMatch = structure(
         logical(0),
-        tags = list(
-          location = "header",
-          locationName = "If-Match",
-          type = "string"
-        )
+        tags = list(location = "header", locationName = "If-Match", type = "string")
       ),
       IfModifiedSince = structure(
         logical(0),
@@ -374,11 +344,7 @@ get_object_input_params <- function(...) {
       ),
       IfNoneMatch = structure(
         logical(0),
-        tags = list(
-          location = "header",
-          locationName = "If-None-Match",
-          type = "string"
-        )
+        tags = list(location = "header", locationName = "If-None-Match", type = "string")
       ),
       IfUnmodifiedSince = structure(
         logical(0),
@@ -394,11 +360,7 @@ get_object_input_params <- function(...) {
       ),
       Range = structure(
         logical(0),
-        tags = list(
-          location = "header",
-          locationName = "Range",
-          type = "string"
-        )
+        tags = list(location = "header", locationName = "Range", type = "string")
       ),
       ResponseCacheControl = structure(
         logical(0),
@@ -451,11 +413,7 @@ get_object_input_params <- function(...) {
       ),
       VersionId = structure(
         logical(0),
-        tags = list(
-          location = "querystring",
-          locationName = "versionId",
-          type = "string"
-        )
+        tags = list(location = "querystring", locationName = "versionId", type = "string")
       ),
       SSECustomerAlgorithm = structure(
         logical(0),
@@ -533,43 +491,23 @@ get_object_output_params <- structure(
     ),
     AcceptRanges = structure(
       logical(0),
-      tags = list(
-        location = "header",
-        locationName = "accept-ranges",
-        type = "string"
-      )
+      tags = list(location = "header", locationName = "accept-ranges", type = "string")
     ),
     Expiration = structure(
       logical(0),
-      tags = list(
-        ocation = "header",
-        locationName = "x-amz-expiration",
-        type = "string"
-      )
+      tags = list(ocation = "header", locationName = "x-amz-expiration", type = "string")
     ),
     Restore = structure(
       logical(0),
-      tags = list(
-        location = "header",
-        locationName = "x-amz-restore",
-        type = "string"
-      )
+      tags = list(location = "header", locationName = "x-amz-restore", type = "string")
     ),
     LastModified = structure(
       logical(0),
-      tags = list(
-        location = "header",
-        locationName = "Last-Modified",
-        type = "timestamp"
-      )
+      tags = list(location = "header", locationName = "Last-Modified", type = "timestamp")
     ),
     ContentLength = structure(
       logical(0),
-      tags = list(
-        location = "header",
-        locationName = "Content-Length",
-        type = "long"
-      )
+      tags = list(location = "header", locationName = "Content-Length", type = "long")
     ),
     ETag = structure(
       logical(0),
@@ -617,19 +555,11 @@ get_object_output_params <- structure(
     ),
     VersionId = structure(
       logical(0),
-      tags = list(
-        location = "header",
-        locationName = "x-amz-version-id",
-        type = "string"
-      )
+      tags = list(location = "header", locationName = "x-amz-version-id", type = "string")
     ),
     CacheControl = structure(
       logical(0),
-      tags = list(
-        location = "header",
-        locationName = "Cache-Control",
-        type = "string"
-      )
+      tags = list(location = "header", locationName = "Cache-Control", type = "string")
     ),
     ContentDisposition = structure(
       logical(0),
@@ -641,43 +571,23 @@ get_object_output_params <- structure(
     ),
     ContentEncoding = structure(
       logical(0),
-      tags = list(
-        location = "header",
-        locationName = "Content-Encoding",
-        type = "string"
-      )
+      tags = list(location = "header", locationName = "Content-Encoding", type = "string")
     ),
     ContentLanguage = structure(
       logical(0),
-      tags = list(
-        location = "header",
-        locationName = "Content-Language",
-        type = "string"
-      )
+      tags = list(location = "header", locationName = "Content-Language", type = "string")
     ),
     ContentRange = structure(
       logical(0),
-      tags = list(
-        location = "header",
-        locationName = "Content-Range",
-        type = "string"
-      )
+      tags = list(location = "header", locationName = "Content-Range", type = "string")
     ),
     ContentType = structure(
       logical(0),
-      tags = list(
-        location = "header",
-        locationName = "Content-Type",
-        type = "string"
-      )
+      tags = list(location = "header", locationName = "Content-Type", type = "string")
     ),
     Expires = structure(
       logical(0),
-      tags = list(
-        location = "header",
-        locationName = "Expires",
-        type = "timestamp"
-      )
+      tags = list(location = "header", locationName = "Expires", type = "timestamp")
     ),
     WebsiteRedirectLocation = structure(
       logical(0),
@@ -697,11 +607,7 @@ get_object_output_params <- structure(
     ),
     Metadata = structure(
       list(structure(logical(0), tags = list(type = "string"))),
-      tags = list(
-        location = "headers",
-        locationName = "x-amz-meta-",
-        type = "map"
-      )
+      tags = list(location = "headers", locationName = "x-amz-meta-", type = "map")
     ),
     SSECustomerAlgorithm = structure(
       logical(0),

--- a/paws.common/tests/testthat/test_signer_v4.R
+++ b/paws.common/tests/testthat/test_signer_v4.R
@@ -47,16 +47,7 @@ test_that("sign with custom URI escape", {
   req$url$path <- "/log-*/_search"
   req$url$opaque <- "//subdomain.us-east-1.es.amazonaws.com/log-%2A/_search"
 
-  req <- sign_with_body(
-    signer,
-    req,
-    NULL,
-    "es",
-    "us-east-1",
-    0,
-    FALSE,
-    unix_time(0, 0)
-  )
+  req <- sign_with_body(signer, req, NULL, "es", "us-east-1", 0, FALSE, unix_time(0, 0))
   actual <- req$header[["Authorization"]]
 
   expect_equal(actual, expected)
@@ -88,16 +79,7 @@ test_that("standalone sign with port", {
   for (case in cases) {
     signer <- Signer(test_creds)
     req <- new_http_request("GET", case$url, NULL)
-    req <- sign_with_body(
-      signer,
-      req,
-      NULL,
-      "es",
-      "us-east-1",
-      0,
-      FALSE,
-      unix_time(0, 0)
-    )
+    req <- sign_with_body(signer, req, NULL, "es", "us-east-1", 0, FALSE, unix_time(0, 0))
     actual <- req$header[["Authorization"]]
     expect_equal(actual, case$expected)
   }
@@ -147,11 +129,7 @@ test_that("standalone presign with port", {
 
 test_that("presign", {
   signer <- Signer(test_creds)
-  req <- new_http_request(
-    "POST",
-    "https://dynamodb.us-east-1.amazonaws.com",
-    "{}"
-  )
+  req <- new_http_request("POST", "https://dynamodb.us-east-1.amazonaws.com", "{}")
   req$url$opaque <- "//example.org/bucket/key-._~,!@#$%^&*()"
   req$header["X-Amz-Target"] <- "prefix.Operation"
   req$header["Content-Type"] <- "application/x-amz-json-1.0"
@@ -178,10 +156,7 @@ test_that("presign", {
     q[["X-Amz-Signature"]],
     "122f0b9e091e4ba84286097e2b3404a1f1f4c4aad479adda95b7dff0ccbe5581"
   )
-  expect_equal(
-    q[["X-Amz-Credential"]],
-    "AKID/19700101/us-east-1/dynamodb/aws4_request"
-  )
+  expect_equal(q[["X-Amz-Credential"]], "AKID/19700101/us-east-1/dynamodb/aws4_request")
   expect_equal(
     q[["X-Amz-SignedHeaders"]],
     "content-length;content-type;host;x-amz-meta-other-header;x-amz-meta-other-header_with_underscore"

--- a/paws.common/tests/testthat/test_util.R
+++ b/paws.common/tests/testthat/test_util.R
@@ -51,8 +51,5 @@ test_that("call_with_args", {
     a + b
   }
   args <- list(a = 1, b = 2)
-  expect_error(
-    call_with_args(foo, args),
-    "A parameter has no corresponding element in.*"
-  )
+  expect_error(call_with_args(foo, args), "A parameter has no corresponding element in.*")
 })

--- a/paws.common/tests/testthat/test_xmlutil.R
+++ b/paws.common/tests/testthat/test_xmlutil.R
@@ -1,7 +1,5 @@
 test_that("add XML namespace", {
-  object <- list(
-    Foo = list(Bar = list(list(Baz = list(Qux = 123, Quux = 456))))
-  )
+  object <- list(Foo = list(Bar = list(list(Baz = list(Qux = 123, Quux = 456)))))
   result <- add_xmlns(object, "https://foo/")
   expect_equal(attr(result, "xmlns"), "https://foo/")
   expect_equal(attr(result$Foo, "xmlns"), "https://foo/")
@@ -64,23 +62,13 @@ test_that("check nested xml build with nested default parameters", {
 })
 
 test_that("check if list is transposed correctly", {
-  obj1 <- list(
-    var1 = c(1, 2, 3),
-    var2 = letters[1:3],
-    var3 = list(),
-    var4 = list()
-  )
+  obj1 <- list(var1 = c(1, 2, 3), var2 = letters[1:3], var3 = list(), var4 = list())
   expected1 <- list(
     list(var1 = 1, var2 = "a", var3 = NULL, var4 = NULL),
     list(var1 = 2, var2 = "b", var3 = NULL, var4 = NULL),
     list(var1 = 3, var2 = "c", var3 = NULL, var4 = NULL)
   )
-  obj2 <- list(
-    var1 = list(),
-    var2 = letters[1:3],
-    var3 = list(),
-    var4 = c(1, 2, 3)
-  )
+  obj2 <- list(var1 = list(), var2 = letters[1:3], var3 = list(), var4 = c(1, 2, 3))
   expected2 <- list(
     list(var1 = NULL, var2 = "a", var3 = NULL, var4 = 1),
     list(var1 = NULL, var2 = "b", var3 = NULL, var4 = 2),


### PR DESCRIPTION
Set line length to 90 just to follow the quote: 
> In general, [90-ish seems like the wise choice](https://youtu.be/wf-BqAjZb8M?t=260)

Which is close to what python formatter `black` and `ruff` default settings [black: Line Length](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length)

> Line length
You probably noticed the peculiar default line length. Black defaults to 88 characters per line, which happens to be 10% over 80. This number was found to produce significantly shorter files than sticking with 80 (the most popular), or even 79 (used by the standard library). In general, [90-ish seems like the wise choice](https://youtu.be/wf-BqAjZb8M?t=260).