### PR TITLE
No content-length for empty-body GET/HEAD

### DIFF
--- a/paws.common/R/signer_v4.R
+++ b/paws.common/R/signer_v4.R
@@ -390,6 +390,18 @@ build_body_digest <- function(ctx) {
 build_canonical_headers <- function(ctx, header, ignored_headers) {
   headers <- c("host")
   header_names <- names(header)
+
+  method <- toupper(ctx$request$method %||% "GET")
+
+# Do not sign content-length for empty-body GET/HEAD
+  if (method %in% c("GET", "HEAD")) {
+    cl <- header[["Content-Length"]] %||% header[["content-length"]]
+  if (!is.null(cl) && as.numeric(cl) == 0) {
+      header[["Content-Length"]] <- NULL
+      header[["content-length"]] <- NULL
+    }
+  }
+  
   for (key in header_names[!(header_names %in% ignored_headers)]) {
     lower_case_key <- tolower(key)
     ctx$signed_header_vals[[lower_case_key]] <- header[[key]]


### PR DESCRIPTION
This PR makes a small change to the V4 signing method to make it compatible with services that implement it strictly, in my case Cloudflare R2.  For requests with empty bodies, the signature fails if the body is empty with the default "empty SHA". If instead, we remove the content-length header, this succeeds.