### PR TITLE
fix: improve documentation generation and markdown formatting

### DIFF
--- a/make.paws/DESCRIPTION
+++ b/make.paws/DESCRIPTION
@@ -12,6 +12,7 @@ Description: make.paws generates the Paws AWS SDKs for R.
 License: Apache License (>= 2.0)
 URL: https://github.com/paws-r/paws
 Encoding: UTF-8
+Depends: R (>= 4.1.0)
 Imports:
     cachem,
     desc,

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -114,14 +114,18 @@ make_doc_params <- function(operation, api) {
     shapes <- api$shapes
     shape <- shapes[[operation$input$shape]]
     inputs <- get_inputs(shape)
+    pkg_name <- package_name(api)
+    links <- get_links(api)
     params <- lapply(inputs, function(input) {
       param <- input$member_name
       required <- input$required
-      documentation <- convert(
-        input$documentation,
-        package_name(api),
-        links = get_links(api)
-      )
+      # First attempt, get documentation from input parameters
+      # Second attempt, get documentation from global parameters
+      # Finally attempt, get documentation from generic parameters
+      decs <- (input$documentation %||%
+        shapes[[param]]$documentation %||%
+        shapes[[input$shape]]$documentation)
+      documentation <- convert(decs, pkg_name, links)
       documentation <- convert_headings_to_bold(documentation)
       documentation <- glue::glue_collapse(documentation, sep = "\n")
       if (required) {
@@ -599,6 +603,12 @@ clean_markdown <- function(markdown) {
   result <- gsub("\\\\{2,}", "\\\\\\\\", result, perl = TRUE)
 
   result <- fix_internal_links(result)
+
+  # remove tailing whitespace
+  result <- sub("[ \t\r\n]+$", "", result, perl = TRUE)
+
+  # remove horizontal rules:
+  result <- result[!grepl("^\\#+$", result, perl = TRUE)]
 
   return(result)
 }

--- a/make.paws/R/docs.R
+++ b/make.paws/R/docs.R
@@ -122,10 +122,10 @@ make_doc_params <- function(operation, api) {
       # First attempt, get documentation from input parameters
       # Second attempt, get documentation from global parameters
       # Finally attempt, get documentation from generic parameters
-      decs <- (input$documentation %||%
+      docs <- (input$documentation %||%
         shapes[[param]]$documentation %||%
         shapes[[input$shape]]$documentation)
-      documentation <- convert(decs, pkg_name, links)
+      documentation <- convert(docs, pkg_name, links)
       documentation <- convert_headings_to_bold(documentation)
       documentation <- glue::glue_collapse(documentation, sep = "\n")
       if (required) {

--- a/make.paws/R/text.R
+++ b/make.paws/R/text.R
@@ -12,7 +12,7 @@ read_utf8 <- function(file) {
 }
 
 # Convert HTML to other formats using Pandoc.
-html_to <- function(html, to) {
+html_to <- function(html, to, options = NULL) {
   if (is.null(html)) {
     return("")
   }
@@ -21,7 +21,13 @@ html_to <- function(html, to) {
     temp_in <- tempfile()
     write_utf8(html, temp_in)
     temp_out <- tempfile()
-    rmarkdown::pandoc_convert(temp_in, output = temp_out, from = "html", to = to)
+    rmarkdown::pandoc_convert(
+      temp_in,
+      output = temp_out,
+      from = "html",
+      to = to,
+      options = options
+    )
     result <- read_utf8(temp_out)
     # Pandoc inappropriately escapes "%" and "*"; undo this escaping.
     result <- gsub("\\\\(\\%|\\*)", "\\1", result)
@@ -31,7 +37,7 @@ html_to <- function(html, to) {
 
 # Convert HTML to markdown
 html_to_markdown <- function(html) {
-  html_to(html, "commonmark")
+  html_to(html, "commonmark", options = "--wrap=preserve")
 }
 
 html_to_text <- function(html) {


### PR DESCRIPTION
**Summary**

A significant amount of parameter documentation is missing from the latest build ([action run](https://github.com/paws-r/paws/actions/runs/25728447578/job/75547204450)).

**Root Causes**

After investigating the AWS JSON definitions in botocore, three issues were identified:

1. **Missing documentation sources** — Parameter documentation is found in multiple locations within the botocore JSON files, and not all of these were being captured.

2. **Pandoc truncating hrefs** — Pandoc's default line width of 72 characters was splitting URLs across lines, breaking href attributes. See [Pandoc manual](https://pandoc.org/MANUAL.html). The fix preserves the original HTML formatting to avoid this.

3. **Unsupported horizontal rules** — Html to markdown converter was generating horizontal rules (`****`) which cause roxygen2 to fail, as they aren't supported in R documentation.