### PR TITLE
feat: add S3 on Outposts support (signing_name + content-sha256)

### DIFF
--- a/paws.common/R/client.R
+++ b/paws.common/R/client.R
@@ -30,7 +30,8 @@ Config <- struct(
   disable_rest_protocol_uri_cleaning = FALSE,
   sts_regional_endpoint = "",
   signature_version = "",
-  partition_name = ""
+  partition_name = "",
+  signing_name = ""
 )
 
 # A Session object stores configuration and request handlers for a service.

--- a/paws.common/R/service.R
+++ b/paws.common/R/service.R
@@ -110,6 +110,11 @@ new_service <- function(metadata, handlers, cfgs = NULL, operation = Operation()
   if (is.null(signing_name)) {
     signing_name <- cfg$signing_name
   }
+  # Allow user to override signing_name via config
+  config_signing_name <- cfg$config$signing_name
+  if (!is.null(config_signing_name) && nzchar(config_signing_name)) {
+    signing_name <- config_signing_name
+  }
   custom_endpoint <- cfg$config$endpoint != "" || cfg$custom_endpoint
   client_info <- ClientInfo(
     service_name = metadata$service_name,

--- a/paws.common/R/signer_v4.R
+++ b/paws.common/R/signer_v4.R
@@ -125,11 +125,6 @@ sign_sdk_request_with_curr_time <- function(request, curr_time_fn = now, opts = 
     name <- request$config$service_name
   }
 
-  # Auto-detect S3 on Outposts from endpoint URL
-  if (name == "s3" && grepl("s3-outposts", request$config$endpoint %||% "")) {
-    name <- "s3-outposts"
-  }
-
   v4 <- Signer(
     credentials = request$config$credentials,
     disable_header_hoisting = request$not_hoist,
@@ -137,7 +132,7 @@ sign_sdk_request_with_curr_time <- function(request, curr_time_fn = now, opts = 
     disable_request_body_overwrite = TRUE
   )
 
-  if (name %in% c("s3", "s3-outposts")) {
+  if (name == "s3") {
     v4$disable_uri_path_escaping <- TRUE
   }
 
@@ -374,8 +369,8 @@ build_body_digest <- function(ctx) {
   hash <- get_element(ctx$request$header, "X-Amz-Content-Sha256")
   if (hash == "") {
     include_sha256_header <- (ctx$unsigned_payload ||
-      ctx$service_name %in% c("s3", "s3-object-lambda", "glacier", "s3-outposts"))
-    s3_presign <- (ctx$is_presigned && ctx$service_name %in% c("s3", "s3-object-lambda", "s3-outposts"))
+      ctx$service_name %in% c("s3", "s3-object-lambda", "glacier"))
+    s3_presign <- (ctx$is_presigned && ctx$service_name %in% c("s3", "s3-object-lambda"))
     if (ctx$unsigned_payload || s3_presign) {
       hash <- "UNSIGNED-PAYLOAD"
       include_sha256_header <- !s3_presign

--- a/paws.common/R/signer_v4.R
+++ b/paws.common/R/signer_v4.R
@@ -132,7 +132,7 @@ sign_sdk_request_with_curr_time <- function(request, curr_time_fn = now, opts = 
     disable_request_body_overwrite = TRUE
   )
 
-  if (name == "s3") {
+  if (name %in% c("s3", "s3-outposts")) {
     v4$disable_uri_path_escaping <- TRUE
   }
 
@@ -369,8 +369,8 @@ build_body_digest <- function(ctx) {
   hash <- get_element(ctx$request$header, "X-Amz-Content-Sha256")
   if (hash == "") {
     include_sha256_header <- (ctx$unsigned_payload ||
-      ctx$service_name %in% c("s3", "s3-object-lambda", "glacier"))
-    s3_presign <- (ctx$is_presigned && ctx$service_name %in% c("s3", "s3-object-lambda"))
+      ctx$service_name %in% c("s3", "s3-object-lambda", "glacier", "s3-outposts"))
+    s3_presign <- (ctx$is_presigned && ctx$service_name %in% c("s3", "s3-object-lambda", "s3-outposts"))
     if (ctx$unsigned_payload || s3_presign) {
       hash <- "UNSIGNED-PAYLOAD"
       include_sha256_header <- !s3_presign

--- a/paws.common/R/signer_v4.R
+++ b/paws.common/R/signer_v4.R
@@ -125,6 +125,11 @@ sign_sdk_request_with_curr_time <- function(request, curr_time_fn = now, opts = 
     name <- request$config$service_name
   }
 
+  # Auto-detect S3 on Outposts from endpoint URL
+  if (name == "s3" && grepl("s3-outposts", request$config$endpoint %||% "")) {
+    name <- "s3-outposts"
+  }
+
   v4 <- Signer(
     credentials = request$config$credentials,
     disable_header_hoisting = request$not_hoist,


### PR DESCRIPTION
Problem: paws doesn't support S3 on Outposts Access Points. Requests fail with AuthorizationHeaderMalformed (signing service mismatch) and Missing x-amz-content-sha256 header.

Solution: Add "s3-outposts" to the service name checks in the SigV4 signer and body digest handler, so Outposts endpoints receive the correct credential scope and required headers.