### PR TITLE
don't sign empty-body DELETE requests either

### DIFF
--- a/paws.common/R/signer_v4.R
+++ b/paws.common/R/signer_v4.R
@@ -392,8 +392,8 @@ build_canonical_headers <- function(ctx, header, ignored_headers) {
 
   method <- toupper(ctx$request$method %||% "GET")
 
-  # Do not sign content-length for empty-body GET/HEAD
-  if (method %in% c("GET", "HEAD")) {
+  # Do not sign content-length for empty-body GET/HEAD/DELETE
+  if (method %in% c("GET", "HEAD", "DELETE")) {
     cl <- header[["Content-Length"]] %||% header[["content-length"]]
     if (!is.null(cl) && as.numeric(cl) == 0) {
       header[["Content-Length"]] <- NULL


### PR DESCRIPTION
Fix for #995.  I've tested this out with a Cloudflare R2 bucket and deleting objects now works.